### PR TITLE
Improve short track removal

### DIFF
--- a/autoTrack.py
+++ b/autoTrack.py
@@ -46,13 +46,21 @@ class WM_OT_auto_track(bpy.types.Operator):
         return {'FINISHED'}
 
 
+def track_length(track):
+    """Return the tracked frame span of a track."""
+    frames = [m.frame for m in track.markers if not m.mute]
+    if not frames:
+        return 0
+    return max(frames) - min(frames) + 1
+
+
 def delete_short_tracks(ctx, clip):
     """Remove tracks shorter than the minimum length."""
     tracks = clip.tracking.tracks
     removed = 0
     with bpy.context.temp_override(**ctx):
         for track in list(tracks):
-            if len(track.markers) < MIN_TRACK_LENGTH:
+            if track_length(track) < MIN_TRACK_LENGTH:
                 tracks.remove(track)
                 removed += 1
     if removed:
@@ -66,7 +74,8 @@ def print_track_lengths(clip):
     """Gibt die Länge aller Tracks aus."""
     print("📊 Track-Längen:", flush=True)
     for track in clip.tracking.tracks:
-        print(f"    {track.name}: {len(track.markers)} Frames", flush=True)
+        length = track_length(track)
+        print(f"    {track.name}: {length} Frames", flush=True)
 
 
 def get_clip_context():


### PR DESCRIPTION
## Summary
- compute track lengths using first and last marker frames
- delete short tracks based on the computed length
- show each track's frame-span in the console

## Testing
- `python -m py_compile autoTrack.py`


------
https://chatgpt.com/codex/tasks/task_e_685c2a47e8e8832daacf9973c7b1903a