### PR TITLE
Move playhead to scene start

### DIFF
--- a/autoTrack.py
+++ b/autoTrack.py
@@ -133,14 +133,6 @@ def move_playhead_to_min_tracks(ctx, clip):
     )
 
 
-def move_playhead_to_scene_start(ctx):
-    """Setze den Playhead auf den ersten Frame der Szene."""
-    with bpy.context.temp_override(**ctx):
-        start = bpy.context.scene.frame_start
-        bpy.context.scene.frame_set(start)
-    print(f"⏮ Setze Playhead auf Szene-Anfang (Frame {start})", flush=True)
-
-
 def get_clip_context():
     """Return a context with an active clip-editor and clip."""
     wm = bpy.context.window_manager
@@ -166,7 +158,6 @@ def get_clip_context():
 def detect_features_until_enough():
     ctx = get_clip_context()
     clip = ctx["space_data"].clip
-    move_playhead_to_scene_start(ctx)
     tracks = clip.tracking.tracks
     width = clip.size[0]
     # margin and min_distance scale with clip width
@@ -236,6 +227,9 @@ def unregister():
 
 
 if __name__ == "__main__":
+    start = bpy.context.scene.frame_start
+    bpy.context.scene.frame_set(start)
+    print(f"⏮ Setze Playhead auf Szene-Anfang (Frame {start})", flush=True)
     register()
     bpy.ops.wm.auto_track('INVOKE_DEFAULT')
 


### PR DESCRIPTION
## Summary
- jump to the start frame when tracking begins

## Testing
- `python3 -m py_compile autoTrack.py`

------
https://chatgpt.com/codex/tasks/task_e_685c3789da7c832da140e09a223d6fac