### PR TITLE
Repeat auto tracking without resetting

### DIFF
--- a/autoTrack.py
+++ b/autoTrack.py
@@ -229,9 +229,6 @@ def unregister():
 
 
 if __name__ == "__main__":
-    start = bpy.context.scene.frame_start
-    bpy.context.scene.frame_set(start)
-    print(f"⏮ Setze Playhead auf Szene-Anfang (Frame {start})", flush=True)
     register()
     result = bpy.ops.wm.auto_track('INVOKE_DEFAULT')
     while result == {'FINISHED'}:


### PR DESCRIPTION
## Summary
- let detect function report success
- return 'CANCELLED' from operator when tracking was aborted
- loop auto tracking until it fails and avoid resetting playhead on repeats

## Testing
- `python -m py_compile autoTrack.py`

------
https://chatgpt.com/codex/tasks/task_e_685c3bd6a008832d98a7f0ecb8a5d7ea