### PR TITLE
Fix indentation error in autoTrack.py

### DIFF
--- a/autoTrack.py
+++ b/autoTrack.py
@@ -182,7 +182,7 @@ def detect_features_until_enough():
         if escape_pressed():
             print("❌ Abgebrochen mit Escape", flush=True)
             break
-    distance = int(int(width / 20) / (((log10(threshold)/-1)+1)/2))
+        distance = int(int(width / 20) / (((log10(threshold)/-1)+1)/2))
         before = len(tracks)
         with bpy.context.temp_override(**ctx):
             bpy.ops.clip.detect_features(


### PR DESCRIPTION
## Summary
- fix indentation level in the feature detection loop to prevent `IndentationError`

## Testing
- `python -m py_compile autoTrack.py`


------
https://chatgpt.com/codex/tasks/task_e_685c5500393c832da9a487464f3591ec