### PR TITLE
Set perspective motion model

### DIFF
--- a/autoTrack.py
+++ b/autoTrack.py
@@ -164,6 +164,11 @@ def get_clip_context():
 def detect_features_until_enough():
     ctx = get_clip_context()
     clip = ctx["space_data"].clip
+    clip.tracking.settings.default_motion_model = "Perspective"
+    print(
+        f"📐 Nutze Motion Model {clip.tracking.settings.default_motion_model}",
+        flush=True,
+    )
     tracks = clip.tracking.tracks
     width = clip.size[0]
     # margin and min_distance scale with clip width


### PR DESCRIPTION
## Summary
- set the default motion model for feature detection to `Perspective`

## Testing
- `python -m py_compile autoTrack.py`


------
https://chatgpt.com/codex/tasks/task_e_685c5c208bac832da1e044f79d0a0ccc