### PR TITLE
Set playhead before detecting features

### DIFF
--- a/autoTrack.py
+++ b/autoTrack.py
@@ -230,7 +230,7 @@ def detect_features_until_enough(motion_model="Perspective", playhead_min_marker
         current_frame = bpy.context.scene.frame_current
         with bpy.context.temp_override(**ctx):
             bpy.context.scene.frame_set(current_frame)
-            ctx["space_data"].clip_user.frame_number = current_frame
+            ctx["space_data"].clip_user.frame_current = current_frame
             bpy.ops.clip.detect_features(
                 threshold=threshold,
                 margin=margin,


### PR DESCRIPTION
## Summary
- keep the playhead on the scene's current frame before detecting features

## Testing
- `python -m py_compile autoTrack.py`


------
https://chatgpt.com/codex/tasks/task_e_685c705d2684832da612aee2aa54d052