### PR TITLE
Update playhead context after moving playhead

### DIFF
--- a/autoTrack.py
+++ b/autoTrack.py
@@ -80,6 +80,7 @@ class WM_OT_auto_track(bpy.types.Operator):
 
             delete_short_tracks(ctx, clip)
             move_playhead_to_min_tracks(ctx, clip, MIN_MARKERS)
+            bpy.context.view_layer.update()
 
             current_frame = bpy.context.scene.frame_current
             if current_frame == prev_frame:


### PR DESCRIPTION
## Summary
- ensure Blender scene updates after moving the playhead by calling `bpy.context.view_layer.update()`

## Testing
- `python -m py_compile autoTrack.py`

------
https://chatgpt.com/codex/tasks/task_e_685c984ebb54832d9e21f5278567936e