### PR TITLE
Start auto tracking at clip's first frame

### DIFF
--- a/autoTrack.py
+++ b/autoTrack.py
@@ -75,6 +75,9 @@ class WM_OT_auto_track(bpy.types.Operator):
         result = {'FINISHED'}
         ctx = autotracker.ctx
         clip = autotracker.clip
+        # Always start tracking from the first frame of the clip
+        bpy.context.scene.frame_set(clip.frame_start)
+        print(f"⏮ Starte Tracking bei Frame {clip.frame_start}", flush=True)
         prev_frame = bpy.context.scene.frame_current
         model_index = original_model_index
         marker_boost = 0


### PR DESCRIPTION
## Summary
- ensure auto tracking always begins at the clip's first frame

## Testing
- `python -m py_compile autoTrack.py`

------
https://chatgpt.com/codex/tasks/task_e_685d90d14c30832d92b464967f77f624