### PR TITLE
Update max_attempts default value

### DIFF
--- a/autoTrack.py
+++ b/autoTrack.py
@@ -103,7 +103,7 @@ class WM_OT_auto_track(bpy.types.Operator):
                 autotracker,
                 motion_model,
                 initial_min_markers,
-                max_attempts=50,
+                max_attempts=10,
             ):
                 result = {'CANCELLED'}
                 break
@@ -340,7 +340,7 @@ def detect_features_until_enough(
     motion_model="Perspective",
     playhead_min_markers=None,
     *,
-    max_attempts=5,
+    max_attempts=10,
     min_threshold=0.0001,
 ):
     ctx = autotracker.ctx


### PR DESCRIPTION
## Summary
- adjust default `max_attempts` in `detect_features_until_enough` to 10
- match the call in `execute` to use `max_attempts=10`

## Testing
- `python -m py_compile autoTrack.py`


------
https://chatgpt.com/codex/tasks/task_e_685d90d73f9c832da136dcacf06b1c8a