### PR TITLE
Track deleted markers

### DIFF
--- a/autoTrack.py
+++ b/autoTrack.py
@@ -108,7 +108,7 @@ class WM_OT_auto_track(bpy.types.Operator):
                 result = {'CANCELLED'}
                 break
 
-            delete_short_tracks(ctx, clip, autotracker.min_track_length)
+            delete_short_tracks(ctx, clip, autotracker.min_track_length, autotracker)
             move_playhead_to_min_tracks(ctx, clip, initial_min_markers)
             bpy.context.view_layer.update()
 
@@ -234,8 +234,12 @@ def delete_new_tracks(tracks):
             print(f"🗑 Entferne neuen Marker: {track.name}", flush=True)
 
 
-def delete_short_tracks(ctx, clip, min_track_length):
-    """Remove short tracks and lock long living ones."""
+def delete_short_tracks(ctx, clip, min_track_length, autotracker=None):
+    """Remove short tracks and lock long living ones.
+
+    If ``autotracker`` is given, the names of all removed tracks will be
+    appended to ``autotracker.bad_markers``.
+    """
     tracks = clip.tracking.tracks
     with bpy.context.temp_override(**ctx):
         for track in list(tracks):
@@ -250,7 +254,10 @@ def delete_short_tracks(ctx, clip, min_track_length):
                 track.select = False
 
         if any(track.select for track in tracks):
-            removed = sum(1 for track in tracks if track.select)
+            selected_names = [t.name for t in tracks if t.select]
+            removed = len(selected_names)
+            if autotracker is not None:
+                autotracker.bad_markers.extend(selected_names)
             bpy.ops.clip.delete_track()
             if removed:
                 print(
@@ -413,7 +420,7 @@ def detect_features_until_enough(
             # Tracking vorher ausführen
             bpy.ops.clip.track_markers(backwards=False, sequence=True)
         # Dann auswerten, ob die neuen Tracks lang genug waren
-        delete_short_tracks(ctx, clip, autotracker.min_track_length)
+        delete_short_tracks(ctx, clip, autotracker.min_track_length, autotracker)
         # Jetzt Marker-Anzahl prüfen
         new_markers = [t for t in tracks if t not in before_tracks]
         added = len(new_markers)


### PR DESCRIPTION
## Summary
- record removed track names during cleanup
- propagate `autotracker` when deleting short tracks

## Testing
- `python -m py_compile autoTrack.py`

------
https://chatgpt.com/codex/tasks/task_e_685d90d961e4832d901c1182ae330e5a