### PR TITLE
Ensure auto tracker runs exact cycle count

### DIFF
--- a/autoTrack.py
+++ b/autoTrack.py
@@ -88,7 +88,7 @@ class WM_OT_auto_track(bpy.types.Operator):
         while True:
             cycle_start = time.time()
             cycle_count += 1
-            if cycle_count >= max_cycles:
+            if cycle_count > max_cycles:
                 print(
                     f"❌ Maximalanzahl an Trackingzyklen ({max_cycles}) erreicht – Abbruch",
                     flush=True,


### PR DESCRIPTION
## Summary
- fix loop condition for auto-tracking cycles so MAX_CYCLES are executed

## Testing
- `python -m py_compile autoTrack.py`


------
https://chatgpt.com/codex/tasks/task_e_685d9303c454832dbb182e54a9ab24d1