### PR TITLE
Remove unused log10 import

### DIFF
--- a/autoTrack.py
+++ b/autoTrack.py
@@ -1,6 +1,5 @@
 import bpy
 import ctypes
-from math import log10
 import time
 import os
 import json


### PR DESCRIPTION
## Summary
- remove unused `log10` import from `autoTrack.py`

## Testing
- `python3 -m py_compile autoTrack.py`


------
https://chatgpt.com/codex/tasks/task_e_685d93046864832d9f63b4ad5f13fede