### PR TITLE
Add cross platform escape key detection

### DIFF
--- a/autoTrack.py
+++ b/autoTrack.py
@@ -35,7 +35,18 @@ def escape_pressed() -> bool:
     try:
         return bool(ctypes.windll.user32.GetAsyncKeyState(0x1B) & 0x8000)
     except Exception:
-        return False
+        pass
+
+    # Fallback for non-Windows systems
+    try:
+        wm = bpy.context.window_manager
+        if hasattr(wm, "events"):
+            for evt in wm.events:
+                if evt.type == 'ESC' and evt.value == 'PRESS':
+                    return True
+    except Exception:
+        pass
+    return False
 
 
 


### PR DESCRIPTION
## Summary
- handle Escape key detection on non-Windows systems

## Testing
- `python3 -m py_compile autoTrack.py`

------
https://chatgpt.com/codex/tasks/task_e_685d9306eb3c832d950d5f9f29baf315