### PR TITLE
Add Blender auto tracking setup script

### DIFF
--- a/scene_setup.py
+++ b/scene_setup.py
@@ -1,0 +1,48 @@
+import bpy
+from bpy.props import IntProperty, StringProperty, FloatProperty
+
+MOTION_MODELS = [
+    "LocRotScale",
+    "Affine",
+    "Loc",
+    "Perspective",
+    "LocRot",
+]
+
+class OT_SetupAutoTracking(bpy.types.Operator):
+    """Set up scene for auto tracking."""
+    bl_idname = "scene.setup_auto_tracking"
+    bl_label = "Setup Auto Tracking"
+
+    min_marker_count: IntProperty(name="Min Marker Count", default=8)
+    min_track_length: IntProperty(name="Min Track Length", default=6)
+
+    def invoke(self, context, event):
+        return context.window_manager.invoke_props_dialog(self)
+
+    def execute(self, context):
+        scene = context.scene
+        scene.frame_current = scene.frame_start
+        scene.motion_model = MOTION_MODELS[0]
+        scene.threshold = 1.0
+        scene.min_marker_count = self.min_marker_count
+        scene.min_track_length = self.min_track_length
+        self.report({'INFO'}, "Auto tracking initialized")
+        return {'FINISHED'}
+
+def register():
+    bpy.types.Scene.motion_model = StringProperty()
+    bpy.types.Scene.threshold = FloatProperty()
+    bpy.types.Scene.min_marker_count = IntProperty()
+    bpy.types.Scene.min_track_length = IntProperty()
+    bpy.utils.register_class(OT_SetupAutoTracking)
+
+def unregister():
+    bpy.utils.unregister_class(OT_SetupAutoTracking)
+    del bpy.types.Scene.motion_model
+    del bpy.types.Scene.threshold
+    del bpy.types.Scene.min_marker_count
+    del bpy.types.Scene.min_track_length
+
+if __name__ == "__main__":
+    register()


### PR DESCRIPTION
## Summary
- implement a Blender operator that prepares a scene for auto tracking
- query minimum markers and track length via a dialog
- reset the playhead to the scene start frame
- set the motion model and threshold defaults

## Testing
- `python -m py_compile scene_setup.py`


------
https://chatgpt.com/codex/tasks/task_e_685da8603a40832d849f4ecab77b1c00