### PR TITLE
Replace main guard with direct register call

### DIFF
--- a/blender_auto_track.py
+++ b/blender_auto_track.py
@@ -254,5 +254,4 @@ def unregister() -> None:
     del bpy.types.Scene.min_track_length
 
 
-if __name__ == "__main__":
-    register()
+register()


### PR DESCRIPTION
## Summary
- call `register()` unconditionally at the end of `blender_auto_track.py`

## Testing
- `python -m py_compile blender_auto_track.py`

------
https://chatgpt.com/codex/tasks/task_e_685db3d140dc832dbb70abafe2952a25