### PR TITLE
Update TrackingConfig default threshold

### DIFF
--- a/blender_auto_track.py
+++ b/blender_auto_track.py
@@ -26,7 +26,7 @@ class TrackingConfig:
             "LocRot",
         ]
     )
-    threshold: float = 0.1
+    threshold: float = 1.0
     feature_detection: bool = True
     placed_markers: int = 0
     trigger_tracker: bool = False


### PR DESCRIPTION
## Summary
- set `TrackingConfig.threshold` default to `1.0`

## Testing
- `python -m py_compile blender_auto_track.py`

------
https://chatgpt.com/codex/tasks/task_e_685dbbc63cf0832d92f921b62d6b133e