### PR TITLE
Fix marker assignment format

### DIFF
--- a/blender_auto_track.py
+++ b/blender_auto_track.py
@@ -130,10 +130,7 @@ def run_tracking_cycle(
                 placed_tracks.append(track)
                 placed_markers.append(track.markers[0])
 
-        good,
-        bad,
-        good_tracks,
-        bad_tracks = _validate_markers(
+        good, bad, good_tracks, bad_tracks = _validate_markers(
             list(zip(placed_markers, placed_tracks)),
             active_markers,
             frame_width,


### PR DESCRIPTION
## Summary
- streamline `_validate_markers` assignment onto a single line

## Testing
- `python -m py_compile blender_auto_track.py`


------
https://chatgpt.com/codex/tasks/task_e_685dcb6f4f60832daed8d3a702c550f6