### PR TITLE
Set Blender detection threshold property

### DIFF
--- a/blender_auto_track.py
+++ b/blender_auto_track.py
@@ -122,6 +122,8 @@ def run_tracking_cycle(
     while True:
         existing = {t.name for t in clip.tracking.tracks}
         bpy.ops.clip.select_all(action='DESELECT')
+        # Set the detection threshold used by detect_features()
+        clip.tracking.settings.correlation_min = config.threshold
         print(f"Threshold vor detect_features: {config.threshold}")
         bpy.ops.clip.detect_features()
         print(f"Anzahl Tracks nach detect_features: {len(clip.tracking.tracks)}")


### PR DESCRIPTION
## Summary
- set `clip.tracking.settings.correlation_min` before running `detect_features`

## Testing
- `python -m py_compile blender_auto_track.py`

------
https://chatgpt.com/codex/tasks/task_e_685dd1464e1c832d9c12d5b7992b1625