### PR TITLE
Fix detection threshold usage

### DIFF
--- a/blender_auto_track.py
+++ b/blender_auto_track.py
@@ -123,8 +123,7 @@ def run_tracking_cycle(
         existing = {t.name for t in clip.tracking.tracks}
         bpy.ops.clip.select_all(action='DESELECT')
         # Set the detection threshold used by detect_features()
-        clip.tracking.settings.use_default_threshold = True
-        clip.tracking.settings.default_correlation_min = config.threshold
+        clip.tracking.settings.detect_threshold = config.threshold
         print(f"Threshold vor detect_features: {config.threshold}")
         bpy.ops.clip.detect_features()
         print(f"Anzahl Tracks nach detect_features: {len(clip.tracking.tracks)}")


### PR DESCRIPTION
## Summary
- use `detect_threshold` instead of `default_correlation_min` for feature detection

## Testing
- `python3 -m py_compile blender_auto_track.py`

------
https://chatgpt.com/codex/tasks/task_e_685dd3d17718832dacbf849b5a9a3601