### PR TITLE
Fix track deletion after final iteration

### DIFF
--- a/blender_auto_track.py
+++ b/blender_auto_track.py
@@ -179,7 +179,9 @@ def run_tracking_cycle(
         clip = get_movie_clip(bpy.context)
 
         # Nur löschen, wenn noch weiter iteriert wird
-        if clip:
+        if not (
+            config.min_marker_range <= config.placed_markers <= config.max_marker_range
+        ):
             for track in placed_tracks:
                 track.select = True
                 bpy.ops.clip.delete_track()


### PR DESCRIPTION
## Summary
- adjust deletion logic so tracks are only removed when another iteration will occur

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ddba8bc88832da0252e3e6124c0c9