### PR TITLE
Ensure detect_features uses clip editor context

### DIFF
--- a/blender_auto_track.py
+++ b/blender_auto_track.py
@@ -121,9 +121,15 @@ def run_tracking_cycle(
     threshold_iter = 0
     while True:
         existing = {t.name for t in clip.tracking.tracks}
-        bpy.ops.clip.select_all(action='DESELECT')
-        # Set the detection threshold used by detect_features()
-        bpy.ops.clip.detect_features(threshold=config.threshold)
+        for area in bpy.context.window.screen.areas:
+            if area.type == 'CLIP_EDITOR':
+                override = bpy.context.copy()
+                override['area'] = area
+                override['region'] = area.regions[-1]  # Wichtig: Region muss gesetzt sein
+                with bpy.context.temp_override(**override):
+                    bpy.ops.clip.select_all(action='DESELECT')
+                    bpy.ops.clip.detect_features(threshold=config.threshold)
+                break
         print(f"Threshold vor detect_features: {config.threshold}")
         print(f"Anzahl Tracks nach detect_features: {len(clip.tracking.tracks)}")
         placed_tracks = []


### PR DESCRIPTION
## Summary
- use a temporary context override so `bpy.ops.clip.detect_features` runs in the Clip Editor

## Testing
- `python -m py_compile blender_auto_track.py`


------
https://chatgpt.com/codex/tasks/task_e_685ddde12920832db8bae0e7c7ce4dcc