### PR TITLE
Fix region selection for UI operator

### DIFF
--- a/blender_auto_track.py
+++ b/blender_auto_track.py
@@ -125,7 +125,10 @@ def run_tracking_cycle(
             if area.type == 'CLIP_EDITOR':
                 override = bpy.context.copy()
                 override['area'] = area
-                override['region'] = area.regions[-1]  # Wichtig: Region muss gesetzt sein
+                for region in area.regions:
+                    if region.type == 'WINDOW':
+                        override['region'] = region  # Wichtig: Region muss gesetzt sein
+                        break
                 with bpy.context.temp_override(**override):
                     bpy.ops.clip.select_all(action='DESELECT')
                     bpy.ops.clip.detect_features(threshold=config.threshold)


### PR DESCRIPTION
## Summary
- select the 'WINDOW' region instead of the last region when overriding for UI ops

## Testing
- `python -m py_compile blender_auto_track.py`


------
https://chatgpt.com/codex/tasks/task_e_685ddec27498832db543c6904398fff7