### PR TITLE
Avoid deleting markers when target count reached

### DIFF
--- a/blender_auto_track.py
+++ b/blender_auto_track.py
@@ -170,14 +170,12 @@ def run_tracking_cycle(
         print(f"✅ Gesamt-Platzierte Marker: {config.placed_markers}")
         print(f"🔍 Zielbereich: {config.min_marker_range} bis {config.max_marker_range}")
 
-        if (
-            config.min_marker_range <= config.placed_markers <= config.max_marker_range
-            or threshold_iter >= config.max_threshold_iteration
-        ):
-            if threshold_iter >= config.max_threshold_iteration:
-                print("⛔️ Abbruch: Maximale Anzahl an Threshold-Iterationen erreicht.")
-            else:
-                print("✅ Abbruch: Zielbereich für Markeranzahl erreicht.")
+        if config.min_marker_range <= config.placed_markers <= config.max_marker_range:
+            print("✅ Abbruch: Zielbereich für Markeranzahl erreicht.")
+            return
+
+        if threshold_iter >= config.max_threshold_iteration:
+            print("⛔️ Abbruch: Maximale Anzahl an Threshold-Iterationen erreicht.")
             break
 
         old_threshold = config.threshold


### PR DESCRIPTION
## Summary
- return immediately once the desired marker range is reached in `run_tracking_cycle`
- leave marker cleanup only for iterations that continue

## Testing
- `python -m py_compile blender_auto_track.py`

------
https://chatgpt.com/codex/tasks/task_e_685de16218e0832d8132997adafa69c1