### PR TITLE
Add automatic run step

### DIFF
--- a/blender_auto_track.py
+++ b/blender_auto_track.py
@@ -365,6 +365,16 @@ def unregister() -> None:
 
 register()
 
+if __name__ == "__main__":
+    scene = bpy.context.scene
+    scene.frame_current = scene.frame_start
+    scene.motion_model = MOTION_MODELS[0]
+    scene.threshold = 1.0
+    scene.min_marker_count = 8
+    scene.min_track_length = 6
+
+    bpy.ops.scene.run_auto_tracking()
+
 
 
 


### PR DESCRIPTION
## Summary
- automatically run `run_auto_tracking` when executed as a script

## Testing
- `python -m py_compile blender_auto_track.py`

------
https://chatgpt.com/codex/tasks/task_e_685de4e7d028832d896a68f4d1a02b49