### PR TITLE
Fix automatic run leaving markers

### DIFF
--- a/blender_auto_track.py
+++ b/blender_auto_track.py
@@ -320,7 +320,6 @@ class OT_RunAutoTracking(bpy.types.Operator):
 
         clip = get_movie_clip(context)
         if clip:
-            delete_short_tracks(clip, config.min_track_length)
             frame = find_first_insufficient_frame(clip, config.min_marker_count)
             if frame is not None:
                 self.report({'INFO'}, f"Insufficient markers at frame {frame}")
@@ -364,6 +363,19 @@ def unregister() -> None:
 
 
 register()
+
+if __name__ == "__main__":
+    scene = bpy.context.scene
+    scene.frame_current = scene.frame_start
+    scene.motion_model = MOTION_MODELS[0]
+    scene.threshold = 1.0
+    scene.min_marker_count = 8
+    scene.min_track_length = 6
+
+    if get_movie_clip(bpy.context):
+        bpy.ops.scene.run_auto_tracking()
+    else:
+        print("No active MovieClip found, skipping automatic run")
 
 
 


### PR DESCRIPTION
## Summary
- keep markers by avoiding deletion in `run_auto_tracking`
- only run auto tracking automatically if a clip is loaded

## Testing
- `python -m py_compile blender_auto_track.py`


------
https://chatgpt.com/codex/tasks/task_e_685de4e7d028832d896a68f4d1a02b49