### PR TITLE
Fix motion model initialization

### DIFF
--- a/blender_auto_track.py
+++ b/blender_auto_track.py
@@ -109,6 +109,11 @@ def run_tracking_cycle(
         print("No active MovieClip found")
         return
 
+    # Ensure the clip uses the current scene motion model for tracking
+    motion_model = getattr(bpy.context.scene, "motion_model", MOTION_MODELS[0])
+    clip.tracking.settings.default_motion_model = motion_model
+    print(f"\n🔧 Motion Model gesetzt auf: {motion_model}")
+
     print(
         f"🎬 Clip: {clip.name}, Frame-Bereich: {clip.frame_start}-{clip.frame_duration}"
     )


### PR DESCRIPTION
## Summary
- revert motion-model loop logic
- set default motion model on the clip before running detection

## Testing
- `python3 -m py_compile blender_auto_track.py`


------
https://chatgpt.com/codex/tasks/task_e_685ded1b8234832d9c38d70f3f4f8880