### PR TITLE
Stop automatic tracking on script start

### DIFF
--- a/blender_auto_track.py
+++ b/blender_auto_track.py
@@ -545,7 +545,6 @@ def unregister() -> None:
     bpy.types.CLIP_MT_clip.remove(draw_func)
 
 
-register()
 
 if __name__ == "__main__":
     # Only register the operators and menu when running the script directly.


### PR DESCRIPTION
## Summary
- remove the automatic tracking run when the script is executed
- keep registration so the menu is available

## Testing
- `python -m py_compile blender_auto_track.py`

------
https://chatgpt.com/codex/tasks/task_e_685e9eb5f074832db8bd95d35e489bc4