### PR TITLE
Add computed marker count properties

### DIFF
--- a/blender_auto_track.py
+++ b/blender_auto_track.py
@@ -38,12 +38,12 @@ class AutoTrackProperties(bpy.types.PropertyGroup):
     @property
     def min_marker_count_plus_small(self):
         """Minimum marker count increased by 80 percent"""
-        return int(self.min_marker_count * 1.8)
+        return int(self.min_marker_count * 0.8)
 
     @property
     def min_marker_count_plus_big(self):
         """Minimum marker count increased by 120 percent"""
-        return int(self.min_marker_count * 2.2)
+        return int(self.min_marker_count * 1.2)
 
 
 class CLIP_OT_auto_track_settings(bpy.types.Operator):


### PR DESCRIPTION
## Summary
- extend `AutoTrackProperties` with two new computed properties for marker counts

## Testing
- `python -m py_compile blender_auto_track.py`
- `flake8 blender_auto_track.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686174e3124c832dacab2b664abe78b9