### PR TITLE
Remove Clip menu options

### DIFF
--- a/blender_auto_track.py
+++ b/blender_auto_track.py
@@ -85,7 +85,7 @@ class CLIP_OT_auto_track_start_head(bpy.types.Operator):
 
     def execute(self, context):
         try:
-            context.scene.tracking.settings.motion_model = 'LocRotScale'
+            context.scene.tracking.settings.motion_model = 'TRANSLATION_ROTATION_SCALE'
             bpy.ops.clip.track_markers(
                 'INVOKE_DEFAULT', backwards=False, sequence=True
             )


### PR DESCRIPTION
## Summary
- rename add-on to **Auto Track Tools** and update its description
- remove `draw_auto_track_menu` and Clip menu registration
- keep the Auto Track panel and operators

## Testing
- `python -m py_compile blender_auto_track.py`


------
https://chatgpt.com/codex/tasks/task_e_68617f13a108832db581343965ddaeb3