### PR TITLE
Simplify auto track setup

### DIFF
--- a/blender_auto_track.py
+++ b/blender_auto_track.py
@@ -74,7 +74,7 @@ class CLIP_OT_auto_track_start(bpy.types.Operator):
             if space and space.clip:
                 track = space.clip.tracking.tracks.active
                 if track:
-                    track.motion_model = 'LocRotScale'
+                    space.clip.tracking.settings.motion_model = 'LocRotScale'
                     for area in context.screen.areas:
                         if area.type == 'CLIP_EDITOR':
                             area.tag_redraw()


### PR DESCRIPTION
## Summary
- keep only one auto track operator
- operator now just sets the active track motion model to LocRotScale and doesn't start tracking

## Testing
- `python -m py_compile blender_auto_track.py`


------
https://chatgpt.com/codex/tasks/task_e_68618e4bcf5c832dbab6cb98536344a9