### PR TITLE
Remove unused remove_track_by_name function

### DIFF
--- a/blender_auto_track.py
+++ b/blender_auto_track.py
@@ -71,15 +71,6 @@ class AutoTrackProperties(bpy.types.PropertyGroup):
     )
 
 
-def remove_track_by_name(tracks, name):
-    """Remove track from collection if it exists."""
-    track = tracks.get(name)
-    if track:
-        try:
-            tracks.remove(track)
-        except Exception as e:
-            print(f"Failed to remove track '{name}': {e}")
-
 
 def disable_track(track):
     """Disable the track as a soft-delete workaround."""


### PR DESCRIPTION
## Summary
- delete the unused `remove_track_by_name()` helper

## Testing
- `python3 -m py_compile blender_auto_track.py`

------
https://chatgpt.com/codex/tasks/task_e_686353bd71b4832d8eeac6d5da84fd85