### PR TITLE
Add RAM cache clearing to tracking cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ prints diagnostic information in the console:
   markers, detects new features and tracks them forward.
 - **Delete Short Tracks with Prefix** – removes all tracking tracks starting
   with `TRACK_` that are shorter than 25 frames.
+- **Clear RAM Cache** – reloads the current clip to free memory.
 
 The minimum marker count used for detection and frame search can be configured
-in the panel before running the operator.
+in the panel before running the operator. During the tracking cycle the
+RAM cache is cleared automatically before jumping to the next frame.
 


### PR DESCRIPTION
## Summary
- add cache clearing operator and panel from `catch clean.py`
- clear clip RAM cache before each playhead jump
- register new operators and bump version
- document cache clearing in README

## Testing
- `python -m py_compile combined_cycle.py 'catch clean.py' playhead.py track.py detect.py 'Track Length.py'`


------
https://chatgpt.com/codex/tasks/task_e_68644e9603e0832da94fad35ed192fc2