### PR TITLE
Restart cycle after reaching final frame

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ After tracking forward and removing tracks that are too short, the remaining
 `TRACK_` markers are renamed to `GOOD_` so they are skipped in subsequent
 iterations.
 During the tracking cycle the RAM cache is cleared automatically before jumping
-to the next frame.
+to the next frame. When tracking hits the scene end, the proxy is rebuilt and
+the cycle restarts from the beginning.
 Each visited frame is remembered. If the playhead revisits one of these frames
 the value of **Marker Count Plus** increases by 10, widening the expected
 range for new markers. Landing on a new frame decreases the value by 10 again,

--- a/combined_cycle.py
+++ b/combined_cycle.py
@@ -561,6 +561,12 @@ class CLIP_OT_tracking_cycle(bpy.types.Operator):
             bpy.ops.clip.auto_track_forward()
             context.scene.tracking_cycle_status = "Cleaning tracks"
             bpy.ops.tracking.delete_short_tracks_with_prefix()
+            if context.scene.frame_current >= context.scene.frame_end:
+                self.report({'INFO'}, "End frame reached - restarting cycle")
+                self.cancel(context)
+                context.scene.frame_current = context.scene.frame_start
+                bpy.ops.clip.auto_start_tracking('INVOKE_DEFAULT')
+                return {'FINISHED'}
             self._last_frame = context.scene.frame_current
             context.scene.tracking_cycle_status = "Running"
             context.scene.current_cycle_frame = context.scene.frame_current


### PR DESCRIPTION
## Summary
- loop back to scene start and rebuild proxy when tracking hits the last frame
- document the automatic restart in the README

## Testing
- `python -m py_compile combined_cycle.py track.py`

------
https://chatgpt.com/codex/tasks/task_e_6865b1115860832d8afc3708f8557497