### PR TITLE
Reset settings for second tracking pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ updates to twice the current pattern size. Pattern sizes are capped at 150,
 allowing difficult frames to be tracked with progressively larger or smaller
 areas without exceeding this limit.
 
-If the search finds the same frame twenty times in a row, the playhead now skips ahead one frame and continues tracking instead of stopping. Each repeated attempt prints
-``[Cycle] Repeat attempt n/20 on frame x`` to the console so it's easy to see how close the loop is to moving on.
+If the search finds the same frame twenty times in a row, the playhead jumps back to the scene start. All detection values reset to their defaults and the cycle continues from the beginning. Each repeated attempt prints
+``[Cycle] Repeat attempt n/20 on frame x`` to the console so it's easy to see how close the loop is to restarting.
 
 ## Standalone Cleanup Script
 


### PR DESCRIPTION
## Summary
- document that tracking values reset before the automatic second pass
- reset pattern size, search size, motion model and marker counts when restarting the cycle

## Testing
- `python -m py_compile combined_cycle.py`
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_686d6a42d1a8832d957f56cf1c9915d8