### PR TITLE
Integrate error cleanup into tracking cycle

### DIFF
--- a/combined_cycle.py
+++ b/combined_cycle.py
@@ -667,7 +667,7 @@ class TRACKING_PT_custom_panel(bpy.types.Panel):
 # ---- Playhead utilities (from playhead.py) ----
 DEFAULT_MINIMUM_MARKER_COUNT = 5
 # Maximum markers allowed during error cleanup
-DEFAULT_ERROR_LIMIT = 10
+DEFAULT_ERROR_LIMIT = 2
 # Seconds between timer events during the tracking cycle
 CYCLE_TIMER_INTERVAL = 1.0
 # Maximum number of attempts on the same frame before aborting


### PR DESCRIPTION
## Summary
- add `cleanup_marker_errors` helper for deleting bad tracks
- expose `error_cleanup_limit` setting in the panel
- invoke error cleanup after cycle completion

## Testing
- `python -m py_compile combined_cycle.py`

------
https://chatgpt.com/codex/tasks/task_e_686e56ab703c832db66ed629f68720d7