### PR TITLE
Add helper modules and integrate into addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Kaiserlich Track Addon
+
+This repository contains a simple Blender addon located in the
+`kaiserlich_track` folder. The addon adds a panel to the Movie Clip
+Editor for custom tracking options.
+
+## Installation
+1. In Blender open **Edit > Preferences > Add-ons**.
+2. Click **Install...** and choose the zipped `kaiserlich_track` folder
+   (or select the folder itself).
+3. Enable the addon from the list under the *Movie Clip* category.
+
+## Usage
+1. Open the Movie Clip Editor and switch to **Tracking** context.
+2. Press **N** to reveal the sidebar and choose the **Kaiserlich** tab.
+3. Adjust the properties and click **Start** to run the operator.
+
+### Helper Scripts
+
+Several utility modules are included for experimentation:
+
+- `find_frame_with_few_tracking_markers.py` – locate frames with few markers.
+- `get_marker_count_plus.py` – compute additional marker thresholds.
+- `margin_a_distanz.py` – derive margin and distance values from the clip width.
+- `playhead.py` – utilities for repositioning the playhead.
+- `proxy_wait.py` – create proxies and wait for completion.
+- `update_min_marker_props.py` – sync derived marker properties.
+

--- a/kaiserlich_track/find_frame_with_few_tracking_markers.py
+++ b/kaiserlich_track/find_frame_with_few_tracking_markers.py
@@ -1,0 +1,13 @@
+"""Utility: locate first frame with few tracking markers."""
+
+import bpy
+
+
+def find_frame_with_few_tracking_markers(marker_counts, minimum_count):
+    """Return the first frame with fewer markers than ``minimum_count``."""
+    start = bpy.context.scene.frame_start
+    end = bpy.context.scene.frame_end
+    for frame in range(start, end + 1):
+        if marker_counts.get(frame, 0) < minimum_count:
+            return frame
+    return None

--- a/kaiserlich_track/get_marker_count_plus.py
+++ b/kaiserlich_track/get_marker_count_plus.py
@@ -1,0 +1,6 @@
+"""Utility: retrieve or calculate marker count plus."""
+
+
+def get_marker_count_plus(scene):
+    """Return stored value or the default derived from the base count."""
+    return scene.get("_marker_count_plus", scene.min_marker_count * 4)

--- a/kaiserlich_track/margin_a_distanz.py
+++ b/kaiserlich_track/margin_a_distanz.py
@@ -1,0 +1,25 @@
+"""Compute detection margin and distance values for the active clip."""
+
+import bpy
+
+
+def compute_margin_distance():
+    """Store margin and distance properties on the active clip."""
+    area = next((a for a in bpy.context.screen.areas if a.type == 'CLIP_EDITOR'), None)
+    if not area:
+        print("Movie Clip Editor nicht aktiv.")
+        return
+    space = next((s for s in area.spaces if s.type == 'CLIP_EDITOR'), None)
+    if not space or not space.clip:
+        print("Kein Clip im Movie Clip Editor geladen.")
+        return
+
+    clip = space.clip
+    width = clip.size[0]
+    margin = width / 200
+    distance = width / 20
+    clip["MARGIN"] = margin
+    clip["DISTANCE"] = distance
+    print(f"Breite: {width}")
+    print(f"MARGIN (Breite / 200): {margin}")
+    print(f"DISTANCE (Breite / 20): {distance}")

--- a/kaiserlich_track/playhead.py
+++ b/kaiserlich_track/playhead.py
@@ -1,0 +1,29 @@
+"""Utilities for adjusting the playhead position."""
+
+import bpy
+from collections import Counter
+
+from .find_frame_with_few_tracking_markers import (
+    find_frame_with_few_tracking_markers,
+)
+
+
+def get_tracking_marker_counts():
+    """Return a Counter of marker counts for each frame across all clips."""
+    marker_counts = Counter()
+    for clip in bpy.data.movieclips:
+        for track in clip.tracking.tracks:
+            for marker in track.markers:
+                marker_counts[marker.frame] += 1
+    return marker_counts
+
+
+def set_playhead_to_low_marker_frame(minimum_count):
+    """Move the playhead to the first frame with too few markers."""
+    counts = get_tracking_marker_counts()
+    frame = find_frame_with_few_tracking_markers(counts, minimum_count)
+    if frame is not None:
+        bpy.context.scene.frame_current = frame
+        print(f"Playhead auf Frame {frame} gesetzt.")
+    else:
+        print("Kein passender Frame gefunden.")

--- a/kaiserlich_track/proxy_wait.py
+++ b/kaiserlich_track/proxy_wait.py
@@ -1,0 +1,47 @@
+"""Create a 50% proxy and wait for its files to appear."""
+
+import bpy
+import os
+import threading
+import time
+
+
+def create_proxy_and_wait():
+    print("Starte Proxy-Erstellung (50%, custom Pfad)")
+    clip = bpy.context.space_data.clip
+    if not clip:
+        print("Kein aktiver Clip.")
+        return
+
+    clip_path = bpy.path.abspath(clip.filepath)
+    if not os.path.isfile(clip_path):
+        print("Clip-Datei existiert nicht.")
+        return
+
+    clip.use_proxy = True
+    clip.proxy.build_25 = False
+    clip.proxy.build_50 = True
+    clip.proxy.build_75 = False
+    clip.proxy.build_100 = False
+    clip.proxy.quality = 50
+    clip.use_proxy_custom_directory = True
+    proxy_dir = "//BL_proxy/"
+    clip.proxy.directory = proxy_dir
+    full_proxy = bpy.path.abspath(proxy_dir)
+    os.makedirs(full_proxy, exist_ok=True)
+    bpy.ops.clip.rebuild_proxy()
+    print("Warte auf erste Proxy-Datei…")
+
+    def wait_file():
+        proxy_filename = "proxy_50.avi"
+        direct_path = os.path.join(full_proxy, proxy_filename)
+        alt_folder = os.path.join(full_proxy, os.path.basename(clip.filepath))
+        alt_path = os.path.join(alt_folder, proxy_filename)
+        for _ in range(180):
+            time.sleep(0.5)
+            if os.path.exists(direct_path) or os.path.exists(alt_path):
+                print("Proxy-Datei gefunden")
+                return
+        print("Zeitüberschreitung beim Warten auf Proxy-Datei")
+
+    threading.Thread(target=wait_file).start()

--- a/kaiserlich_track/update_min_marker_props.py
+++ b/kaiserlich_track/update_min_marker_props.py
@@ -1,0 +1,7 @@
+"""Keep derived marker properties in sync."""
+
+
+def update_min_marker_props(scene, _context):
+    """Update derived marker count properties when the base count changes."""
+    base = scene.min_marker_count
+    scene.min_marker_count_plus = min(base * 4, base * 200)


### PR DESCRIPTION
## Summary
- add various helper scripts for Kaiserlich Track
- integrate helpers into `__init__.py`
- document helper modules in README

## Testing
- `python3 -m py_compile kaiserlich_track/__init__.py kaiserlich_track/find_frame_with_few_tracking_markers.py kaiserlich_track/get_marker_count_plus.py kaiserlich_track/margin_a_distanz.py kaiserlich_track/playhead.py kaiserlich_track/proxy_wait.py kaiserlich_track/update_min_marker_props.py`


------
https://chatgpt.com/codex/tasks/task_e_687000d4f05c832d902703bcf01b4714