### PR TITLE
Fix proxy order in addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# Kaiserlich Track Addon
+
+This repository contains a simple Blender addon. **Important:** the
+`__init__.py` file must reside at the root of the addon alongside all helper
+modules. When zipping the addon, select all files directly and **do not**
+include an extra parent folder. Blender extracts the archive into a new
+directory whose name matches the zip file, so the root must contain
+`__init__.py`. The addon adds a panel to the Movie Clip Editor for custom
+tracking options.
+If the addon is nested in another directory when the zip is created,
+Blender will fail to load the module. Double-check that `__init__.py` and
+the helper scripts sit directly in the archive root before installing.
+
+## Installation
+1. In Blender open **Edit > Preferences > Add-ons**.
+2. Click **Install...** and pick the zip archive that contains the addon files
+   (with `__init__.py` directly in the zip root).
+3. Enable the addon from the list under the *Movie Clip* category.
+
+## Usage
+1. Open the Movie Clip Editor and switch to **Tracking** context.
+2. Press **N** to reveal the sidebar and choose the **Kaiserlich** tab.
+3. Adjust the properties and click **Start** to run the operator.
+
+### Properties
+
+The panel exposes several options:
+
+- **min marker pro frame** – minimum marker count per frame (default 10)
+- **min tracking length** – minimum length for each track (default 20)
+- **Error Threshold** – maximum error allowed for trackers (default 0.04)
+- **Proxy Wait** – time in seconds to wait after proxies are generated.
+  Proxy creation is performed as the final step of the operation
+
+### Helper Scripts
+
+Several utility modules are included for experimentation:
+
+- `find_frame_with_few_tracking_markers.py` – locate frames with few markers.
+- `get_marker_count_plus.py` – compute additional marker thresholds.
+- `margin_a_distanz.py` – derive margin and distance values from the clip width.
+- `playhead.py` – utilities for repositioning the playhead.
+- `proxy_wait.py` – create proxies and wait for completion.
+- `update_min_marker_props.py` – sync derived marker properties.

--- a/__init__.py
+++ b/__init__.py
@@ -11,6 +11,28 @@ bl_info = {
 import bpy
 from bpy.types import Panel, Operator
 from bpy.props import IntProperty, FloatProperty
+import os
+import sys
+
+# Ensure helper modules in this directory can be imported when the addon is
+# installed as a single-file module. Blender does not automatically add the
+# addon folder to ``sys.path`` when ``__init__.py`` sits at the root of the
+# archive, so do it manually.
+addon_dir = os.path.dirname(__file__)
+if addon_dir not in sys.path:
+    sys.path.append(addon_dir)
+
+from find_frame_with_few_tracking_markers import (
+    find_frame_with_few_tracking_markers,
+)
+from get_marker_count_plus import get_marker_count_plus
+from margin_a_distanz import compute_margin_distance
+from playhead import (
+    set_playhead_to_low_marker_frame,
+    get_tracking_marker_counts,
+)
+from proxy_wait import create_proxy_and_wait
+from update_min_marker_props import update_min_marker_props
 
 
 class CLIP_OT_kaiserlich_track(Operator):
@@ -23,11 +45,24 @@ class CLIP_OT_kaiserlich_track(Operator):
         min_marker = scene.kt_min_marker_per_frame
         min_track_len = scene.kt_min_tracking_length
         error_threshold = scene.kt_error_threshold
-        self.report({'INFO'}, (
-            f"Start tracking with min markers {min_marker}, "
-            f"min length {min_track_len}, error threshold {error_threshold}"
-        ))
-        # TODO: Actual tracking implementation
+        proxy_wait = scene.kt_proxy_wait
+
+        update_min_marker_props(scene, context)
+        marker_counts = get_tracking_marker_counts()
+        frame = find_frame_with_few_tracking_markers(marker_counts, min_marker)
+        if frame is not None:
+            set_playhead_to_low_marker_frame(min_marker)
+
+        compute_margin_distance()
+        marker_plus = get_marker_count_plus(scene)
+        self.report(
+            {'INFO'},
+            (
+                f"Start with min markers {min_marker}, length {min_track_len}, "
+                f"error {error_threshold}, derived {marker_plus}"
+            ),
+        )
+        create_proxy_and_wait(proxy_wait)
         return {'FINISHED'}
 
 
@@ -44,24 +79,42 @@ class CLIP_PT_kaiserlich_track(Panel):
         layout.prop(scene, "kt_min_marker_per_frame")
         layout.prop(scene, "kt_min_tracking_length")
         layout.prop(scene, "kt_error_threshold")
+        layout.prop(scene, "kt_proxy_wait")
         layout.operator(CLIP_OT_kaiserlich_track.bl_idname, text="Start")
 
 
 def register():
     bpy.types.Scene.kt_min_marker_per_frame = IntProperty(
         name="min marker pro frame",
-        default=3,
+        default=10,
         min=0,
     )
     bpy.types.Scene.kt_min_tracking_length = IntProperty(
         name="min tracking length",
-        default=10,
+        default=20,
         min=0,
     )
     bpy.types.Scene.kt_error_threshold = FloatProperty(
         name="Error Threshold",
-        default=0.5,
+        default=0.04,
         min=0.0,
+    )
+    bpy.types.Scene.kt_proxy_wait = FloatProperty(
+        name="Proxy Wait",
+        default=2.0,
+        min=0.0,
+    )
+    bpy.types.Scene.min_marker_count = IntProperty(
+        name="Min Marker Count",
+        default=5,
+        min=5,
+        max=50,
+        update=update_min_marker_props,
+    )
+    bpy.types.Scene.min_marker_count_plus = IntProperty(
+        name="Marker Count Plus",
+        default=20,
+        min=0,
     )
     bpy.utils.register_class(CLIP_OT_kaiserlich_track)
     bpy.utils.register_class(CLIP_PT_kaiserlich_track)
@@ -73,6 +126,9 @@ def unregister():
     del bpy.types.Scene.kt_min_marker_per_frame
     del bpy.types.Scene.kt_min_tracking_length
     del bpy.types.Scene.kt_error_threshold
+    del bpy.types.Scene.kt_proxy_wait
+    del bpy.types.Scene.min_marker_count
+    del bpy.types.Scene.min_marker_count_plus
 
 
 if __name__ == "__main__":

--- a/find_frame_with_few_tracking_markers.py
+++ b/find_frame_with_few_tracking_markers.py
@@ -1,0 +1,13 @@
+"""Utility: locate first frame with few tracking markers."""
+
+import bpy
+
+
+def find_frame_with_few_tracking_markers(marker_counts, minimum_count):
+    """Return the first frame with fewer markers than ``minimum_count``."""
+    start = bpy.context.scene.frame_start
+    end = bpy.context.scene.frame_end
+    for frame in range(start, end + 1):
+        if marker_counts.get(frame, 0) < minimum_count:
+            return frame
+    return None

--- a/get_marker_count_plus.py
+++ b/get_marker_count_plus.py
@@ -1,0 +1,6 @@
+"""Utility: retrieve or calculate marker count plus."""
+
+
+def get_marker_count_plus(scene):
+    """Return stored value or the default derived from the base count."""
+    return scene.get("_marker_count_plus", scene.min_marker_count * 4)

--- a/margin_a_distanz.py
+++ b/margin_a_distanz.py
@@ -1,0 +1,25 @@
+"""Compute detection margin and distance values for the active clip."""
+
+import bpy
+
+
+def compute_margin_distance():
+    """Store margin and distance properties on the active clip."""
+    area = next((a for a in bpy.context.screen.areas if a.type == 'CLIP_EDITOR'), None)
+    if not area:
+        print("Movie Clip Editor nicht aktiv.")
+        return
+    space = next((s for s in area.spaces if s.type == 'CLIP_EDITOR'), None)
+    if not space or not space.clip:
+        print("Kein Clip im Movie Clip Editor geladen.")
+        return
+
+    clip = space.clip
+    width = clip.size[0]
+    margin = width / 200
+    distance = width / 20
+    clip["MARGIN"] = margin
+    clip["DISTANCE"] = distance
+    print(f"Breite: {width}")
+    print(f"MARGIN (Breite / 200): {margin}")
+    print(f"DISTANCE (Breite / 20): {distance}")

--- a/playhead.py
+++ b/playhead.py
@@ -1,0 +1,29 @@
+"""Utilities for adjusting the playhead position."""
+
+import bpy
+from collections import Counter
+
+from find_frame_with_few_tracking_markers import (
+    find_frame_with_few_tracking_markers,
+)
+
+
+def get_tracking_marker_counts():
+    """Return a Counter of marker counts for each frame across all clips."""
+    marker_counts = Counter()
+    for clip in bpy.data.movieclips:
+        for track in clip.tracking.tracks:
+            for marker in track.markers:
+                marker_counts[marker.frame] += 1
+    return marker_counts
+
+
+def set_playhead_to_low_marker_frame(minimum_count):
+    """Move the playhead to the first frame with too few markers."""
+    counts = get_tracking_marker_counts()
+    frame = find_frame_with_few_tracking_markers(counts, minimum_count)
+    if frame is not None:
+        bpy.context.scene.frame_current = frame
+        print(f"Playhead auf Frame {frame} gesetzt.")
+    else:
+        print("Kein passender Frame gefunden.")

--- a/proxy_wait.py
+++ b/proxy_wait.py
@@ -1,0 +1,50 @@
+"""Create a 50% proxy and wait for its files to appear."""
+
+import bpy
+import os
+import threading
+import time
+
+
+def create_proxy_and_wait(wait_time=0.0):
+    print("Starte Proxy-Erstellung (50%, custom Pfad)")
+    clip = bpy.context.space_data.clip
+    if not clip:
+        print("Kein aktiver Clip.")
+        return
+
+    clip_path = bpy.path.abspath(clip.filepath)
+    if not os.path.isfile(clip_path):
+        print("Clip-Datei existiert nicht.")
+        return
+
+    clip.use_proxy = True
+    clip.proxy.build_25 = False
+    clip.proxy.build_50 = True
+    clip.proxy.build_75 = False
+    clip.proxy.build_100 = False
+    clip.proxy.quality = 50
+    clip.use_proxy_custom_directory = True
+    proxy_dir = "//BL_proxy/"
+    clip.proxy.directory = proxy_dir
+    full_proxy = bpy.path.abspath(proxy_dir)
+    os.makedirs(full_proxy, exist_ok=True)
+    bpy.ops.clip.rebuild_proxy()
+    print("Warte auf erste Proxy-Datei…")
+
+    def wait_file():
+        proxy_filename = "proxy_50.avi"
+        direct_path = os.path.join(full_proxy, proxy_filename)
+        alt_folder = os.path.join(full_proxy, os.path.basename(clip.filepath))
+        alt_path = os.path.join(alt_folder, proxy_filename)
+        for _ in range(180):
+            time.sleep(0.5)
+            if os.path.exists(direct_path) or os.path.exists(alt_path):
+                print("Proxy-Datei gefunden")
+                return
+        print("Zeitüberschreitung beim Warten auf Proxy-Datei")
+
+    wait_thread = threading.Thread(target=wait_file)
+    wait_thread.start()
+    if wait_time > 0:
+        wait_thread.join(timeout=wait_time)

--- a/update_min_marker_props.py
+++ b/update_min_marker_props.py
@@ -1,0 +1,7 @@
+"""Keep derived marker properties in sync."""
+
+
+def update_min_marker_props(scene, _context):
+    """Update derived marker count properties when the base count changes."""
+    base = scene.min_marker_count
+    scene.min_marker_count_plus = min(base * 4, base * 200)


### PR DESCRIPTION
## Summary
- ensure proxy generation runs last in the start operator
- clarify README that proxies build at the end and wait for the configured time

## Testing
- `python3 -m py_compile __init__.py find_frame_with_few_tracking_markers.py get_marker_count_plus.py margin_a_distanz.py playhead.py proxy_wait.py update_min_marker_props.py`

------
https://chatgpt.com/codex/tasks/task_e_687000d4f05c832d902703bcf01b4714