### PR TITLE
Update Proxy Wait default

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The panel exposes several options:
 - **min marker pro frame** – minimum marker count per frame (default 10)
 - **min tracking length** – minimum length for each track (default 20)
 - **Error Threshold** – maximum error allowed for trackers (default 0.04)
-- **Proxy Wait** – time in seconds to wait after proxies are generated.
+- **Proxy Wait** – wait time after proxies are generated (fixed at 300s).
   Proxy creation is performed as the final step of the operation
 
 ### Helper Scripts

--- a/__init__.py
+++ b/__init__.py
@@ -79,7 +79,6 @@ class CLIP_PT_kaiserlich_track(Panel):
         layout.prop(scene, "kt_min_marker_per_frame")
         layout.prop(scene, "kt_min_tracking_length")
         layout.prop(scene, "kt_error_threshold")
-        layout.prop(scene, "kt_proxy_wait")
         layout.operator(CLIP_OT_kaiserlich_track.bl_idname, text="Start")
 
 
@@ -101,7 +100,7 @@ def register():
     )
     bpy.types.Scene.kt_proxy_wait = FloatProperty(
         name="Proxy Wait",
-        default=2.0,
+        default=300.0,
         min=0.0,
     )
     bpy.types.Scene.min_marker_count = IntProperty(


### PR DESCRIPTION
## Summary
- increase proxy wait timeout to 300 seconds
- hide the proxy wait setting from the UI
- update README description

## Testing
- `python3 -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_687011de6604832d8e7271d760ecf63c