### PR TITLE
Implement proxy post-detection cycle

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -10,15 +10,24 @@ bl_info = {
 from . import combined_cycle
 from . import sparse_marker_check
 from . import motion_outlier_cleanup
+from . import marker_count_property
+from . import adjust_marker_count_plus
+from . import proxy_marker_cycle
 
 
 def register():
     combined_cycle.register()
     sparse_marker_check.register()
     motion_outlier_cleanup.register()
+    marker_count_property.register()
+    adjust_marker_count_plus.register()
+    proxy_marker_cycle.register()
 
 
 def unregister():
+    proxy_marker_cycle.unregister()
+    adjust_marker_count_plus.unregister()
+    marker_count_property.unregister()
     motion_outlier_cleanup.unregister()
     sparse_marker_check.unregister()
     combined_cycle.unregister()

--- a/adjust_marker_count_plus.py
+++ b/adjust_marker_count_plus.py
@@ -1,0 +1,27 @@
+import bpy
+from .combined_cycle import adjust_marker_count_plus as _adjust
+
+
+class CLIP_OT_adjust_marker_count_plus(bpy.types.Operator):
+    """Adjust ``scene.min_marker_count_plus`` by ``delta``."""
+
+    bl_idname = "clip.adjust_marker_count_plus"
+    bl_label = "Adjust Marker Count Plus"
+
+    delta: bpy.props.IntProperty(default=10)
+
+    def execute(self, context):
+        _adjust(context.scene, self.delta)
+        return {'FINISHED'}
+
+
+def register():
+    bpy.utils.register_class(CLIP_OT_adjust_marker_count_plus)
+
+
+def unregister():
+    bpy.utils.unregister_class(CLIP_OT_adjust_marker_count_plus)
+
+
+if __name__ == "__main__":
+    register()

--- a/combined_cycle.py
+++ b/combined_cycle.py
@@ -282,7 +282,7 @@ class CLIP_OT_auto_start(bpy.types.Operator):
                 context.scene.proxy_built = True
                 self.report({'INFO'}, "✅ Proxy-Erstellung abgeschlossen")
                 print("[Proxy] build finished")
-                bpy.ops.clip.tracking_cycle('INVOKE_DEFAULT')
+                bpy.ops.clip.proxy_marker_cycle('INVOKE_DEFAULT')
                 return {'FINISHED'}
             if self._checks > 300:
                 context.window_manager.event_timer_remove(self._timer)

--- a/ensure_margin_distance.py
+++ b/ensure_margin_distance.py
@@ -1,0 +1,3 @@
+from .combined_cycle import ensure_margin_distance
+
+__all__ = ["ensure_margin_distance"]

--- a/marker_count_property.py
+++ b/marker_count_property.py
@@ -1,0 +1,37 @@
+import bpy
+
+
+def count_new_markers(context):
+    """Return number of tracks starting with ``NEU_`` on the active clip."""
+    clip = context.space_data.clip
+    if not clip:
+        return 0
+    return sum(1 for t in clip.tracking.tracks if t.name.startswith("NEU_"))
+
+
+class CLIP_OT_marker_count_property(bpy.types.Operator):
+    """Update ``scene.new_marker_count`` with current NEU_ marker count."""
+
+    bl_idname = "clip.marker_count_property"
+    bl_label = "Count New Markers"
+
+    def execute(self, context):
+        context.scene.new_marker_count = count_new_markers(context)
+        return {'FINISHED'}
+
+
+def register():
+    bpy.utils.register_class(CLIP_OT_marker_count_property)
+    bpy.types.Scene.new_marker_count = bpy.props.IntProperty(
+        name="New Marker Count",
+        default=0,
+    )
+
+
+def unregister():
+    del bpy.types.Scene.new_marker_count
+    bpy.utils.unregister_class(CLIP_OT_marker_count_property)
+
+
+if __name__ == "__main__":
+    register()

--- a/proxy_marker_cycle.py
+++ b/proxy_marker_cycle.py
@@ -1,0 +1,74 @@
+import bpy
+from .marker_count_property import count_new_markers
+from .combined_cycle import adjust_marker_count_plus, ensure_margin_distance
+
+
+class CLIP_OT_proxy_marker_cycle(bpy.types.Operator):
+    """Detect markers after proxy generation until enough are found."""
+
+    bl_idname = "clip.proxy_marker_cycle"
+    bl_label = "Proxy Marker Detect Cycle"
+
+    def execute(self, context):
+        clip = context.space_data.clip
+        if not clip:
+            self.report({'WARNING'}, "Kein Clip gefunden")
+            return {'CANCELLED'}
+
+        threshold = 0.1
+
+        while True:
+            margin, distance, _ = ensure_margin_distance(clip, threshold)
+            initial = {t.name for t in clip.tracking.tracks}
+            bpy.ops.clip.detect_features(
+                threshold=threshold,
+                margin=margin,
+                min_distance=distance,
+                placement='FRAME',
+            )
+            new_tracks = [t for t in clip.tracking.tracks if t.name not in initial]
+            for t in new_tracks:
+                t.name = f"NEU_{t.name}"
+
+            new_marker = count_new_markers(context)
+            if new_marker >= context.scene.min_marker_count_plus:
+                break
+
+            adjust_marker_count_plus(context.scene, 10)
+            base_plus = context.scene.min_marker_count_plus
+            factor = (new_marker + 0.1) / base_plus
+            threshold = max(threshold * factor, 0.0001)
+            self._delete_new_tracks(context)
+
+        # Cleanup and rename markers
+        for track in clip.tracking.tracks:
+            if track.name.startswith("NEU_"):
+                track.name = f"TRACK_{track.name[4:]}"
+        return {'FINISHED'}
+
+    def _delete_new_tracks(self, context):
+        clip = context.space_data.clip
+        if not clip:
+            return
+        for t in clip.tracking.tracks:
+            t.select = t.name.startswith("NEU_")
+        for area in context.screen.areas:
+            if area.type == 'CLIP_EDITOR':
+                region = next((r for r in area.regions if r.type == 'WINDOW'), None)
+                space = area.spaces.active
+                if region and space:
+                    with context.temp_override(area=area, region=region, space_data=space):
+                        bpy.ops.clip.delete_track()
+                    break
+
+
+def register():
+    bpy.utils.register_class(CLIP_OT_proxy_marker_cycle)
+
+
+def unregister():
+    bpy.utils.unregister_class(CLIP_OT_proxy_marker_cycle)
+
+
+if __name__ == "__main__":
+    register()


### PR DESCRIPTION
## Summary
- add marker count operator and property
- add operator to tweak min_marker_count_plus
- expose ensure_margin_distance helper
- implement `CLIP_OT_proxy_marker_cycle` for iterative detection after proxies
- register new operators in addon init
- trigger the new cycle when proxy building finishes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68705a275ce0832db7741317a7b920b7