### PR TITLE
Add marker count check

### DIFF
--- a/count_new_markers.py
+++ b/count_new_markers.py
@@ -1,0 +1,43 @@
+import bpy
+from delet import delete_track_by_name_index
+
+
+def check_new_marker_count(min_count_plus_min: int, min_count_plus_max: int) -> int:
+    """Check NEW_ marker count and remove them if out of range.
+
+    Parameters
+    ----------
+    min_count_plus_min: int
+        Lower bound for expected NEW_ marker count.
+    min_count_plus_max: int
+        Upper bound for expected NEW_ marker count.
+
+    Returns
+    -------
+    int
+        Number of NEW_ markers found before any deletion.
+    """
+    clip = bpy.context.space_data.clip
+    if not clip:
+        print("[count_new_markers] No active clip found.")
+        return 0
+
+    tracks = clip.tracking.tracks
+    new_tracks = [t for t in tracks if t.name.startswith("NEW_")]
+    new_count = len(new_tracks)
+    print(f"[count_new_markers] Found {new_count} NEW_ markers.")
+
+    if new_count <= min_count_plus_min or new_count >= min_count_plus_max:
+        print(
+            "[count_new_markers] Count outside expected range - deleting NEW_ markers."
+        )
+        for t in new_tracks:
+            idx = tracks.find(t.name)
+            delete_track_by_name_index(t.name, idx)
+    else:
+        print("[count_new_markers] Count within expected range.")
+
+    return new_count
+
+
+__all__ = ["check_new_marker_count"]

--- a/delet.py
+++ b/delet.py
@@ -1,0 +1,41 @@
+import bpy
+
+
+def delete_track_by_name_index(name: str, index: int) -> bool:
+    """Delete the tracking track with the given ``name`` at ``index``.
+
+    Parameters
+    ----------
+    name: str
+        Name of the track to remove.
+    index: int
+        Expected index of the track in the tracking list.
+
+    Returns
+    -------
+    bool
+        ``True`` if the track was removed, ``False`` otherwise.
+    """
+    clip = bpy.context.space_data.clip
+    if not clip:
+        print("[delet] No active clip found.")
+        return False
+
+    tracks = clip.tracking.tracks
+    track = tracks.get(name)
+    if not track:
+        print(f"[delet] Track '{name}' not found.")
+        return False
+
+    track_idx = tracks.find(track.name)
+    if track_idx != index:
+        print(
+            f"[delet] Track index mismatch: expected {index}, actual {track_idx}."
+        )
+
+    tracks.remove(track)
+    print(f"[delet] Removed track '{name}' at index {track_idx}.")
+    return True
+
+
+__all__ = ["delete_track_by_name_index"]


### PR DESCRIPTION
## Summary
- implement a helper `delete_track_by_name_index` in `delet.py`
- add `check_new_marker_count` utility to delete NEW_ tracks when count is out of bounds

## Testing
- `python -m py_compile delet.py count_new_markers.py`
- `python -m py_compile *.py` *(fails: SyntaxError in motion_outlier_cleanup.py)*

------
https://chatgpt.com/codex/tasks/task_e_68706e408398832da54f802cb4ee6422