### PR TITLE
Remove unused marker helper imports

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -32,7 +32,6 @@ from margin_a_distanz import compute_margin_distance
 from playhead import (
     get_tracking_marker_counts,
 )
-from count_new_markers import check_marker_range, count_new_markers
 import proxy_wait
 importlib.reload(proxy_wait)
 from proxy_wait import create_proxy_and_wait, remove_existing_proxies
@@ -120,12 +119,8 @@ class CLIP_OT_kaiserlich_track(Operator):
                 start_idx = len(clip.tracking.tracks)
                 bpy.ops.clip.detect_features_custom()
                 rename_new_tracks(list(clip.tracking.tracks)[start_idx:])
-                # store marker count before cleanup
-                count_new_markers(context, clip)
-                print(f"NEW_ Marker vor Cleanup: {scene.new_marker_count}")
                 print("Bereinige Marker")
                 bpy.ops.clip.remove_close_new_markers()
-                check_marker_range(context, clip)
 
             if not run_in_clip_editor(clip, run_ops):
                 print("Kein Clip Editor zum Ausführen der Operatoren gefunden")

--- a/detect.py
+++ b/detect.py
@@ -3,7 +3,6 @@ from margin_a_distanz import compute_margin_distance
 # ``ensure_margin_distance`` is defined in ``margin_distance_adapt``
 from margin_distance_adapt import ensure_margin_distance
 from adjust_marker_count_plus import adjust_marker_count_plus
-from count_new_markers import count_new_markers
 
 # Operator-Klasse
 class DetectFeaturesCustomOperator(bpy.types.Operator):


### PR DESCRIPTION
## Summary
- clean up `__init__.py` by removing `count_new_markers` helper import
- drop related helper calls
- remove unused import from `detect.py`

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_68721f82aa30832d8998f883a79688e8