### PR TITLE
Fix trailing space in print statement

### DIFF
--- a/count_new_markers.py
+++ b/count_new_markers.py
@@ -36,7 +36,7 @@ def check_marker_range(context, clip, prefix="NEW_"):
     adjust_marker_count_plus(scene, new_count)
     ensure_margin_distance(clip)
     print(
-        f"NEW_-Marker {new_count} außerhalb des Bereichs {min_count}-{max_count}" 
+        f"NEW_-Marker {new_count} außerhalb des Bereichs {min_count}-{max_count}"
         " → erneute Erkennung"
     )
     start_idx = len(clip.tracking.tracks)


### PR DESCRIPTION
## Summary
- trim trailing spaces from `count_new_markers.py`

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_68721f94b300832da04384089347e7da