### PR TITLE
Add detect_until_count_matches note

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ the helper scripts sit directly in the archive root before installing.
    disables the proxy timeline, detects features and filters them
    automatically.
 
+The main operator now relies on `detect_until_count_matches`. This helper
+repeatedly runs feature detection and adapts the settings until the number of
+markers falls within the expected range. Once a satisfactory count is achieved,
+all newly created tracks are renamed with the ``TRACK_`` prefix.
+
 ### Properties
 
 The panel exposes several options:


### PR DESCRIPTION
## Summary
- explain that the main operator relies on `detect_until_count_matches`
- note how it iteratively adjusts detection and renames tracks with `TRACK_`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68721fa6ee70832dab2dc13af8e1a1a3