### PR TITLE
Update marker count computation

### DIFF
--- a/update_min_marker_props.py
+++ b/update_min_marker_props.py
@@ -10,7 +10,8 @@ count.
 def update_min_marker_props(scene, _context):
     """Update derived marker count properties when the base count changes."""
     base = scene.min_marker_count
-    marker_count_plus = min(base * 4, base * 200)
+    # Compute the target marker count as four times the base value
+    marker_count_plus = base * 4
     scene.min_marker_count_plus = int(marker_count_plus)
     scene.marker_count_plus_min = int(marker_count_plus * 0.8)
     scene.marker_count_plus_max = int(marker_count_plus * 1.2)


### PR DESCRIPTION
## Summary
- update marker count plus calculation
- document the new computation

## Testing
- `python -m py_compile update_min_marker_props.py`
- `python - <<'PY'
import update_min_marker_props as mod
class Scene:
    def __init__(self):
        self.min_marker_count = 10
scene = Scene()
mod.update_min_marker_props(scene, None)
print(scene.min_marker_count_plus, scene.marker_count_plus_min, scene.marker_count_plus_max, scene.new_marker_count)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68724b6507e0832d8d3a7b2e449c3289