### PR TITLE
Remove old error handling

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -125,11 +125,8 @@ class CLIP_OT_kaiserlich_track(Operator):
         active_clip = context.space_data.clip
         remove_existing_proxies(active_clip)
         # 50% Proxy erstellen und warten, bis Dateien erscheinen
-        try:
-            print("✅ Aufruf: create_proxy_and_wait() wird gestartet")
-            create_proxy_and_wait(wait_time, on_finish=after_proxy, clip=active_clip)
-        except TypeError:
-            create_proxy_and_wait(on_finish=after_proxy, clip=active_clip)
+        print("✅ Aufruf: create_proxy_and_wait() wird gestartet")
+        create_proxy_and_wait(wait_time, on_finish=after_proxy, clip=active_clip)
 
         return {'FINISHED'}
 


### PR DESCRIPTION
## Summary
- clean up proxy creation call
- call `create_proxy_and_wait()` with `wait_time` directly

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68724b771548832db7497b6994797a41