### PR TITLE
Refactor marker threshold logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,11 @@ The panel exposes several options:
 Several utility modules are included for experimentation:
 
 - `few_marker_frame.py` – locate frames with few markers and position the playhead.
-- `marker_count_plus.py` – compute additional marker thresholds.
+- `marker_count_plus.py` – compute marker thresholds and sync derived properties.
 - `margin_utils.py` – derive margin and distance values and scale them relative to the detection threshold.
 - `playhead.py` – utilities for repositioning the playhead.
 - `proxy_wait.py` – create proxies and timecode indices, show the proxy folder and a countdown until a file appears.
 - `remove_existing_proxies` – helper inside `proxy_wait.py` to delete old proxy files before new ones are generated.
-- `update_min_marker_props.py` – sync derived marker properties.
 - `proxy_switch.py` – disable proxies after generation.
 - `detect.py` – adaptive feature detection script that relies on `margin_utils.py` for margin and distance values.
 - `distance_remove.py` – filter NEW_ markers near GOOD_ markers.

--- a/marker_count_plus.py
+++ b/marker_count_plus.py
@@ -1,12 +1,15 @@
 """Calculate and store marker count thresholds."""
 
 
-def update_marker_count_plus(scene):
+def update_marker_count_plus(scene, _context=None):
     """Compute marker count limits from ``min_marker_count``.
 
     The main value ``min_marker_count_plus`` is four times the user input.
     Two additional properties ``marker_count_plus_min`` and
-    ``marker_count_plus_max`` are 80%% and 120%% of that value.
+    ``marker_count_plus_max`` are 80% and 120% of that value. The helper
+    also stores the base count in ``marker_count_plus_base`` so callers can
+    adjust the threshold relative to the original expectation.
+
     The computed count is returned for convenience.
     """
 
@@ -15,5 +18,6 @@ def update_marker_count_plus(scene):
     scene.min_marker_count_plus = marker_count_plus
     scene.marker_count_plus_min = int(marker_count_plus * 0.8)
     scene.marker_count_plus_max = int(marker_count_plus * 1.2)
+    scene.marker_count_plus_base = marker_count_plus
     scene.new_marker_count = marker_count_plus
     return marker_count_plus

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,8 @@
+"""Test package setup."""
+
+import sys
+import types
+
+# Ensure modules that expect Blender's ``bpy`` can be imported during tests
+sys.modules.setdefault("bpy", types.SimpleNamespace())
+

--- a/update_min_marker_props.py
+++ b/update_min_marker_props.py
@@ -7,14 +7,11 @@ count.
 """
 
 
-def update_min_marker_props(scene, _context):
-    """Update derived marker count properties when the base count changes."""
-    base = scene.min_marker_count
-    # Compute the target marker count as four times the base value
-    marker_count_plus = base * 4
-    scene.min_marker_count_plus = int(marker_count_plus)
-    scene.marker_count_plus_min = int(marker_count_plus * 0.8)
-    scene.marker_count_plus_max = int(marker_count_plus * 1.2)
-    scene.marker_count_plus_base = int(marker_count_plus)
-    scene.new_marker_count = scene.min_marker_count_plus
+from marker_count_plus import update_marker_count_plus
+
+
+def update_min_marker_props(scene, context):
+    """Update derived marker properties when ``min_marker_count`` changes."""
+
+    return update_marker_count_plus(scene, context)
 


### PR DESCRIPTION
## Summary
- add single helper `update_marker_count_plus` for derived marker properties
- call the helper from `update_min_marker_props.update_min_marker_props`
- use `update_marker_count_plus` throughout the addon
- avoid heavy imports when Blender isn't available
- document consolidated helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687270b628cc832db812f10de1e1dd56