### PR TITLE
Refactor marker count helpers

### DIFF
--- a/marker_count_plus.py
+++ b/marker_count_plus.py
@@ -1,6 +1,22 @@
 """Calculate and store marker count thresholds."""
 
 
+def compute_marker_count_plus(base):
+    """Return marker count values derived from ``base``.
+
+    The main value is ``marker_count_plus`` which is four times ``base``. Two
+    additional values represent 80% and 120% of this number and are returned as
+    a tuple ``(marker_count_plus, count_min, count_max)``.
+    """
+
+    marker_count_plus = int(base * 4)
+    return (
+        marker_count_plus,
+        int(marker_count_plus * 0.8),
+        int(marker_count_plus * 1.2),
+    )
+
+
 def update_marker_count_plus(scene):
     """Compute marker count limits from ``min_marker_count``.
 
@@ -11,9 +27,9 @@ def update_marker_count_plus(scene):
     """
 
     base = getattr(scene, "min_marker_count", 0)
-    marker_count_plus = int(base * 4)
+    marker_count_plus, count_min, count_max = compute_marker_count_plus(base)
     scene.min_marker_count_plus = marker_count_plus
-    scene.marker_count_plus_min = int(marker_count_plus * 0.8)
-    scene.marker_count_plus_max = int(marker_count_plus * 1.2)
+    scene.marker_count_plus_min = count_min
+    scene.marker_count_plus_max = count_max
     scene.new_marker_count = marker_count_plus
     return marker_count_plus

--- a/update_min_marker_props.py
+++ b/update_min_marker_props.py
@@ -7,14 +7,16 @@ count.
 """
 
 
+from marker_count_plus import compute_marker_count_plus
+
+
 def update_min_marker_props(scene, _context):
     """Update derived marker count properties when the base count changes."""
     base = scene.min_marker_count
-    # Compute the target marker count as four times the base value
-    marker_count_plus = base * 4
-    scene.min_marker_count_plus = int(marker_count_plus)
-    scene.marker_count_plus_min = int(marker_count_plus * 0.8)
-    scene.marker_count_plus_max = int(marker_count_plus * 1.2)
-    scene.marker_count_plus_base = int(marker_count_plus)
-    scene.new_marker_count = scene.min_marker_count_plus
+    marker_count_plus, count_min, count_max = compute_marker_count_plus(base)
+    scene.min_marker_count_plus = marker_count_plus
+    scene.marker_count_plus_min = count_min
+    scene.marker_count_plus_max = count_max
+    scene.marker_count_plus_base = marker_count_plus
+    scene.new_marker_count = marker_count_plus
 


### PR DESCRIPTION
## Summary
- add `compute_marker_count_plus` to centralize marker calculations
- refactor `update_marker_count_plus` and `update_min_marker_props` to use the helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687276088760832dbb3361515c451dd9