### PR TITLE
Remove obsolete marker range check

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -110,7 +110,7 @@ if BLENDER_AVAILABLE:
     from motion_model import cycle_motion_model, reset_motion_model
     from margin_utils import compute_margin_distance
 
-    from count_new_markers import check_marker_range, count_new_markers
+    from count_new_markers import count_new_markers
     import proxy_wait
     importlib.reload(proxy_wait)
     from proxy_wait import create_proxy_and_wait, remove_existing_proxies

--- a/count_new_markers.py
+++ b/count_new_markers.py
@@ -3,11 +3,6 @@
 import bpy
 import logging
 
-from delete_helpers import delete_close_new_markers, delete_new_markers
-from adjust_marker_count_plus import adjust_marker_count_plus
-from margin_utils import ensure_margin_distance
-from rename_new import rename_tracks
-
 logger = logging.getLogger(__name__)
 
 
@@ -19,33 +14,3 @@ def count_new_markers(context, clip, prefix="NEW_"):
     return new_count
 
 
-def check_marker_range(context, clip, prefix="NEW_"):
-    """Validate the count of NEW_ markers and rerun detection if needed."""
-
-    scene = context.scene
-    new_count = count_new_markers(context, clip, prefix)
-    min_count = getattr(scene, "marker_count_plus_min", 0)
-    max_count = getattr(scene, "marker_count_plus_max", 0)
-
-    if min_count <= new_count <= max_count:
-        logger.info(
-            f"NEW_-Marker {new_count} liegt im Bereich {min_count}-{max_count}"
-        )
-        return new_count
-
-    deleted = delete_new_markers(context)
-    if deleted:
-        logger.info(f"🗑️ Gelöscht: {deleted} NEW_-Marker")
-    else:
-        delete_close_new_markers(context)
-    adjust_marker_count_plus(scene, new_count)
-    ensure_margin_distance(clip)
-    logger.info(
-        f"NEW_-Marker {new_count} außerhalb des Bereichs {min_count}-{max_count}"
-        " → erneute Erkennung"
-    )
-    start_idx = len(clip.tracking.tracks)
-    bpy.ops.clip.detect_features_custom()
-    rename_tracks(list(clip.tracking.tracks)[start_idx:])
-    new_count = count_new_markers(context, clip, prefix)
-    return new_count


### PR DESCRIPTION
## Summary
- remove unused `check_marker_range` function
- stop importing the removed function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687278e4676c832d97c0cc5d29c84027