### PR TITLE
Refactor clip lookup with helper

### DIFF
--- a/delete_helpers.py
+++ b/delete_helpers.py
@@ -6,6 +6,7 @@ NEW_ markers that are too close to GOOD_ markers in the current frame and
 
 import bpy
 import mathutils
+from utils import get_active_clip
 
 
 def delete_close_new_markers(context, min_distance=0.02, report=None):
@@ -83,10 +84,7 @@ def delete_close_new_markers(context, min_distance=0.02, report=None):
 def delete_new_markers(context, prefix="NEW_", report=None):
     """Delete all tracks starting with ``prefix`` using the delete operator."""
 
-    space = getattr(context, "space_data", None)
-    clip = getattr(space, "clip", None)
-    if clip is None:
-        clip = getattr(context.scene, "clip", None)
+    clip = get_active_clip(context)
     if not clip:
         if report:
             report({'WARNING'}, "❌ Kein aktiver Clip gefunden.")

--- a/detect.py
+++ b/detect.py
@@ -2,6 +2,7 @@ import bpy
 import logging
 from margin_utils import compute_margin_distance, ensure_margin_distance
 from adjust_marker_count_plus import adjust_marker_count_plus
+from utils import get_active_clip
 
 logger = logging.getLogger(__name__)
 
@@ -17,10 +18,7 @@ class DetectFeaturesCustomOperator(bpy.types.Operator):
         ``space_data``. In that case use the scene's active clip.
         """
 
-        space = getattr(context, "space_data", None)
-        clip = getattr(space, "clip", None)
-        if clip is None:
-            clip = getattr(context.scene, "clip", None)
+        clip = get_active_clip(context)
 
         if not clip:
             self.report({'WARNING'}, "Kein Clip gefunden")

--- a/iterative_detect.py
+++ b/iterative_detect.py
@@ -13,6 +13,7 @@ import logging
 from margin_utils import compute_margin_distance, ensure_margin_distance
 from count_new_markers import count_new_markers
 from rename_new import rename_tracks as rename_new_tracks
+from utils import get_active_clip
 
 logger = logging.getLogger(__name__)
 
@@ -21,10 +22,7 @@ def detect_until_count_matches(context):
     """Detect markers repeatedly until the count is within the desired range."""
 
     scene = context.scene
-    space = getattr(context, "space_data", None)
-    clip = getattr(space, "clip", None)
-    if clip is None:
-        clip = getattr(scene, "clip", None)
+    clip = get_active_clip(context)
     if not clip:
         logger.info("Kein Clip gefunden")
         return 0

--- a/proxy_switch.py
+++ b/proxy_switch.py
@@ -1,4 +1,5 @@
 import bpy
+from utils import get_active_clip
 
 class ToggleProxyOperator(bpy.types.Operator):
     """Proxy/Timecode Umschalten"""
@@ -13,10 +14,7 @@ class ToggleProxyOperator(bpy.types.Operator):
         scene's active clip if possible.
         """
 
-        space = getattr(context, "space_data", None)
-        clip = getattr(space, "clip", None)
-        if clip is None:
-            clip = getattr(context.scene, "clip", None)
+        clip = get_active_clip(context)
 
         if clip:
             clip.use_proxy = not clip.use_proxy

--- a/proxy_wait.py
+++ b/proxy_wait.py
@@ -13,6 +13,8 @@ import time
 import glob
 import logging
 
+from utils import get_active_clip
+
 PROXY_DIR = "//BL_proxy/"
 
 logger = logging.getLogger(__name__)
@@ -21,10 +23,7 @@ logger = logging.getLogger(__name__)
 def remove_existing_proxies(clip=None):
     """Remove previously generated proxy files for ``clip`` or the active one."""
     if clip is None:
-        space = getattr(bpy.context, "space_data", None)
-        clip = getattr(space, "clip", None)
-        if clip is None:
-            clip = getattr(bpy.context.scene, "clip", None)
+        clip = get_active_clip(bpy.context)
     if not clip:
         logger.info("Kein aktiver Clip.")
         return
@@ -40,7 +39,7 @@ def create_proxy_and_wait(wait_time=0.0, on_finish=None, clip=None):
     logger.info("Starte Proxy-Erstellung (50%, custom Pfad)")
     sys.stdout.flush()
     if clip is None:
-        clip = bpy.context.space_data.clip
+        clip = get_active_clip(bpy.context)
     if not clip:
         logger.info("Kein aktiver Clip.")
         return

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -10,6 +10,7 @@ sys.modules.setdefault('bpy', types.SimpleNamespace())
 import adjust_marker_count_plus as acp
 import rename_new
 import margin_utils
+import utils
 
 
 class DummyScene:
@@ -97,6 +98,23 @@ class EnsureMarginDistanceTests(unittest.TestCase):
         self.assertEqual(margin, expected_margin)
         self.assertEqual(distance, expected_distance)
         self.assertEqual(base, clip["DISTANCE"])
+
+
+class GetActiveClipTests(unittest.TestCase):
+    class DummyContext:
+        def __init__(self, space_clip=None, scene_clip=None):
+            self.space_data = types.SimpleNamespace(clip=space_clip) if space_clip else None
+            self.scene = types.SimpleNamespace(clip=scene_clip)
+
+    def test_returns_space_clip_when_available(self):
+        clip = object()
+        ctx = self.DummyContext(space_clip=clip, scene_clip=object())
+        self.assertIs(utils.get_active_clip(ctx), clip)
+
+    def test_falls_back_to_scene(self):
+        clip = object()
+        ctx = self.DummyContext(space_clip=None, scene_clip=clip)
+        self.assertIs(utils.get_active_clip(ctx), clip)
 
 
 if __name__ == "__main__":

--- a/track_Cycle.py
+++ b/track_Cycle.py
@@ -3,6 +3,7 @@ import logging
 from proxy_switch import ToggleProxyOperator
 from track_length import delete_short_tracks_with_prefix
 from few_marker_frame import set_playhead_to_low_marker_frame
+from utils import get_active_clip
 
 logger = logging.getLogger(__name__)
 
@@ -13,10 +14,7 @@ def run(context):
     It toggles proxy/timecode on the current clip to ensure proxies are
     enabled before starting another tracking cycle.
     """
-    space = getattr(context, "space_data", None)
-    clip = getattr(space, "clip", None)
-    if clip is None:
-        clip = getattr(context.scene, "clip", None)
+    clip = get_active_clip(context)
 
     if clip and not clip.use_proxy:
         bpy.ops.clip.toggle_proxy()

--- a/track_length.py
+++ b/track_length.py
@@ -1,16 +1,14 @@
 import bpy
 import logging
 from rename_new import rename_tracks
+from utils import get_active_clip
 
 logger = logging.getLogger(__name__)
 
 def delete_short_tracks_with_prefix(context, prefix="TRACK_", min_frames=25):
     """Delete tracks whose names start with ``prefix`` that are shorter than
     ``min_frames`` frames."""
-    space = getattr(context, "space_data", None)
-    clip = getattr(space, "clip", None)
-    if clip is None:
-        clip = getattr(context.scene, "clip", None)
+    clip = get_active_clip(context)
     if not clip:
         logger.warning("Kein Clip gefunden")
         return 0

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,16 @@
+"""Utility helpers for various clip operations."""
+
+
+def get_active_clip(context):
+    """Return the active clip from ``context``.
+
+    The function first checks ``context.space_data`` for a clip and falls
+    back to ``context.scene`` if necessary. ``None`` is returned when no
+    clip is found.
+    """
+    space = getattr(context, "space_data", None)
+    clip = getattr(space, "clip", None)
+    if clip is None:
+        scene = getattr(context, "scene", None)
+        clip = getattr(scene, "clip", None)
+    return clip


### PR DESCRIPTION
## Summary
- add `utils.get_active_clip` utility
- replace repeated clip retrieval code in various modules
- cover helper with unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68727e44f014832dafc9093f1315ba1a