### PR TITLE
Expose delete_new_markers via UI operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Several utility modules are included for experimentation:
 - `proxy_switch.py` – disable proxies after generation.
 - `detect.py` – adaptive feature detection script that relies on `margin_utils.py` for margin and distance values.
 - `distance_remove.py` – filter NEW_ markers near GOOD_ markers.
+- `delete_new_markers` – remove all NEW_ markers from the active clip via the NEW_-Cleanup panel.
 - `count_new_markers.py` – helper to count NEW_ markers on a clip.
 - `iterative_detect.py` – repeatedly detect markers until the count fits and
   rename them with the prefix `TRACK_`.

--- a/distance_remove.py
+++ b/distance_remove.py
@@ -6,7 +6,7 @@ than a configurable distance to existing GOOD_ markers.
 """
 
 import bpy
-from delete_helpers import delete_close_new_markers
+from delete_helpers import delete_close_new_markers, delete_new_markers
 
 bl_info = {
     "name": "NEW_ Marker Cleanup",
@@ -52,6 +52,24 @@ class CLIP_OT_remove_close_new_markers(bpy.types.Operator):
         return {'FINISHED'} if success else {'CANCELLED'}
 
 
+class CLIP_OT_delete_all_new_markers(bpy.types.Operator):
+    bl_idname = "clip.delete_all_new_markers"
+    bl_label = "Alle NEW_ Marker löschen"
+    bl_description = "Löscht alle NEW_ Marker im aktiven Clip"
+
+    @classmethod
+    def poll(cls, context):
+        return (
+            context.space_data
+            and context.space_data.type == 'CLIP_EDITOR'
+            and context.space_data.clip
+        )
+
+    def execute(self, context):
+        removed = delete_new_markers(context, report=self.report)
+        return {'FINISHED'} if removed else {'CANCELLED'}
+
+
 class CLIP_PT_new_cleanup_tools(bpy.types.Panel):
     bl_label = "NEW_-Cleanup"
     bl_space_type = 'CLIP_EDITOR'
@@ -63,10 +81,13 @@ class CLIP_PT_new_cleanup_tools(bpy.types.Panel):
         layout.prop(context.window_manager, "cleanup_min_distance")
         op = layout.operator(CLIP_OT_remove_close_new_markers.bl_idname)
         op.min_distance = context.window_manager.cleanup_min_distance
+        layout.separator()
+        layout.operator(CLIP_OT_delete_all_new_markers.bl_idname)
 
 
 def register():
     bpy.utils.register_class(CLIP_OT_remove_close_new_markers)
+    bpy.utils.register_class(CLIP_OT_delete_all_new_markers)
     bpy.utils.register_class(CLIP_PT_new_cleanup_tools)
     if not hasattr(bpy.types.WindowManager, "cleanup_min_distance"):
         bpy.types.WindowManager.cleanup_min_distance = bpy.props.FloatProperty(
@@ -80,6 +101,7 @@ def register():
 def unregister():
     if hasattr(bpy.types.WindowManager, "cleanup_min_distance"):
         del bpy.types.WindowManager.cleanup_min_distance
+    bpy.utils.unregister_class(CLIP_OT_delete_all_new_markers)
     bpy.utils.unregister_class(CLIP_OT_remove_close_new_markers)
     bpy.utils.unregister_class(CLIP_PT_new_cleanup_tools)
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -6,11 +6,13 @@ from unittest import mock
 
 # Patch bpy before importing modules that expect it
 sys.modules.setdefault('bpy', types.SimpleNamespace())
+sys.modules.setdefault('mathutils', types.SimpleNamespace(Vector=lambda co=None: types.SimpleNamespace(co=co)))
 
 import adjust_marker_count_plus as acp
 import rename_new
 import margin_utils
 import utils
+import delete_helpers
 
 
 class DummyScene:
@@ -115,6 +117,13 @@ class GetActiveClipTests(unittest.TestCase):
         clip = object()
         ctx = self.DummyContext(space_clip=None, scene_clip=clip)
         self.assertIs(utils.get_active_clip(ctx), clip)
+
+
+class DeleteNewMarkersTests(unittest.TestCase):
+    def test_returns_zero_without_clip(self):
+        ctx = types.SimpleNamespace(space_data=None, screen=types.SimpleNamespace(areas=[]))
+        removed = delete_helpers.delete_new_markers(ctx)
+        self.assertEqual(removed, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `CLIP_OT_delete_all_new_markers` operator
- show the operator in the NEW_-Cleanup panel
- document the helper in README
- test `delete_new_markers`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687280247790832d9707440cdc7153a7