### PR TITLE
Ignore git hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 *.pyc
+.git/hooks/
 


### PR DESCRIPTION
## Summary
- ignore `.git/hooks/`
- removed `sendemail-validate.sample` from the repo's hooks directory

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6872803cf52c832d9a2baa02259a222a