### PR TITLE
Fix sys import duplication

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,3 +1,5 @@
+import sys
+
 BLENDER_AVAILABLE = False
 bl_info = {
     "name": "Kaiserlich Track",
@@ -16,7 +18,6 @@ try:
     BLENDER_AVAILABLE = True
 except ModuleNotFoundError:  # pragma: no cover - not running inside Blender
     import types
-    import sys
 
     bpy = types.SimpleNamespace()
     sys.modules['bpy'] = bpy
@@ -39,7 +40,6 @@ except ModuleNotFoundError:  # pragma: no cover - not running inside Blender
     def BoolProperty(**_kwargs):
         return None
 import os
-import sys
 import importlib
 import logging
 


### PR DESCRIPTION
## Summary
- remove redundant `import sys` from exception block
- place a single `import sys` at module level

## Testing
- `pytest -q`
- `python -m py_compile __init__.py`

------
https://chatgpt.com/codex/tasks/task_e_687286e7785c832d888eb45577f04ce6