### PR TITLE
Add callback unregister helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ import track_cycle
 tracking.register_after_detect_callback(track_cycle.run)
 ```
 
+Call ``unregister_after_detect_callback`` to remove the callback again when it
+is no longer needed.
+
 The callback receives the current ``context`` object. The example in
 ``track_cycle.py`` enables proxy/timecode again using the toggle operator.
 It then launches ``auto_track_bidir`` to track all ``TRACK_`` markers and

--- a/__init__.py
+++ b/__init__.py
@@ -59,6 +59,12 @@ def register_after_detect_callback(func):
     after_detect_callback = func
 
 
+def unregister_after_detect_callback():
+    """Clear the callback registered with ``register_after_detect_callback``."""
+    global after_detect_callback
+    after_detect_callback = None
+
+
 def configure_logging():
     """Set log level based on addon preferences."""
     addon = bpy.context.preferences.addons.get(__name__)
@@ -320,6 +326,7 @@ def register():
 
 
 def unregister():
+    unregister_after_detect_callback()
     bpy.utils.unregister_class(CLIP_OT_kaiserlich_track)
     bpy.utils.unregister_class(CLIP_PT_kaiserlich_track)
     bpy.utils.unregister_class(CLIP_OT_remove_close_new_markers)


### PR DESCRIPTION
## Summary
- add `unregister_after_detect_callback` helper in `__init__.py`
- call this helper in the addon `unregister` function
- document callback cleanup in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873284413e4832d8c5fc4ad6d8a48ba