### PR TITLE
Add callback unregister tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,8 @@ import track_cycle
 
 tracking.register_after_detect_callback(track_cycle.run)
 ```
+Call ``unregister_after_detect_callback`` again when the callback is no longer needed to restore the default behavior.
 
-Call ``unregister_after_detect_callback`` to remove the callback again when it
-is no longer needed.
 
 The callback receives the current ``context`` object. The example in
 ``track_cycle.py`` enables proxy/timecode again using the toggle operator.

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import types
+import unittest
+
+# Ensure the tracking package can be imported when tests are run from the
+# repository root. Insert the parent directory (which contains the package) at the start of ``sys.path``.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+# Patch bpy before importing modules that expect it
+sys.modules.setdefault('bpy', types.SimpleNamespace())
+
+import tracking
+from tracking import register_after_detect_callback, unregister_after_detect_callback
+
+
+def dummy_cb(context):
+    pass
+
+
+class AfterDetectCallbackTests(unittest.TestCase):
+    def tearDown(self):
+        unregister_after_detect_callback()
+
+    def test_register_sets_callback(self):
+        register_after_detect_callback(dummy_cb)
+        self.assertIs(tracking.after_detect_callback, dummy_cb)
+
+    def test_unregister_clears_callback(self):
+        register_after_detect_callback(dummy_cb)
+        unregister_after_detect_callback()
+        self.assertIsNone(tracking.after_detect_callback)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- update callback docs in README
- add unit tests for register and unregister functions

## Testing
- `python -m unittest -v`

------
https://chatgpt.com/codex/tasks/task_e_68732bac3b10832d8b1e8eb8658d35f4