### PR TITLE
Handle frame start in bidirectional tracking

### DIFF
--- a/auto_track_bidir.py
+++ b/auto_track_bidir.py
@@ -40,11 +40,15 @@ class TRACK_OT_auto_track_bidir(bpy.types.Operator):
 
         scene = context.scene
         current_frame = scene.frame_current
+        start_frame = scene.frame_start
         logger.info("Aktueller Frame: %s", current_frame)
 
-        logger.info("Starte Rückwärts-Tracking...")
-        bpy.ops.clip.track_markers(backwards=True, sequence=True)
-        logger.info("Rückwärts-Tracking abgeschlossen.")
+        if current_frame == start_frame:
+            logger.info("Playhead at start; skipping backward tracking")
+        else:
+            logger.info("Starte Rückwärts-Tracking...")
+            bpy.ops.clip.track_markers(backwards=True, sequence=True)
+            logger.info("Rückwärts-Tracking abgeschlossen.")
 
         # Zurück zum ursprünglichen Frame springen
         scene.frame_current = current_frame

--- a/tests/test_auto_track_bidir.py
+++ b/tests/test_auto_track_bidir.py
@@ -1,0 +1,66 @@
+import os
+import sys
+import types
+import unittest
+from unittest import mock
+
+# Insert package root into sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+# Basic bpy stub
+bpy = types.SimpleNamespace(
+    ops=types.SimpleNamespace(clip=types.SimpleNamespace(track_markers=lambda **kwargs: None)),
+    types=types.SimpleNamespace(Operator=object, Panel=object),
+)
+sys.modules['bpy'] = bpy
+
+from tracking.auto_track_bidir import TRACK_OT_auto_track_bidir
+
+
+class DummyTrack:
+    def __init__(self, name):
+        self.name = name
+        self.select = False
+
+
+class DummyClip:
+    def __init__(self):
+        track = DummyTrack("TRACK_test")
+        self.tracking = types.SimpleNamespace(
+            tracks=[track],
+            objects=types.SimpleNamespace(active=types.SimpleNamespace(tracks=[track])),
+        )
+
+
+class DummyContext:
+    def __init__(self, start, current):
+        self.scene = types.SimpleNamespace(frame_start=start, frame_current=current)
+        self.space_data = types.SimpleNamespace(type='CLIP_EDITOR', clip=DummyClip())
+
+
+def execute_op(context):
+    op = TRACK_OT_auto_track_bidir()
+    return op.execute(context)
+
+
+class AutoTrackBidirTests(unittest.TestCase):
+    def test_skip_backward_at_start(self):
+        context = DummyContext(start=1, current=1)
+        with mock.patch.object(bpy.ops.clip, 'track_markers') as track:
+            result = execute_op(context)
+            self.assertEqual(track.call_count, 1)
+            self.assertFalse(track.call_args[1]['backwards'])
+            self.assertEqual(result, {'FINISHED'})
+
+    def test_run_backward_when_not_start(self):
+        context = DummyContext(start=1, current=2)
+        with mock.patch.object(bpy.ops.clip, 'track_markers') as track:
+            result = execute_op(context)
+            self.assertEqual(track.call_count, 2)
+            self.assertTrue(track.call_args_list[0][1]['backwards'])
+            self.assertFalse(track.call_args_list[1][1]['backwards'])
+            self.assertEqual(result, {'FINISHED'})
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a start-frame check in `TRACK_OT_auto_track_bidir.execute`
- skip backwards tracking when playhead is already at the first frame
- test the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687331681e04832d954ea079276e632d