### PR TITLE
Remove redundant detection loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ This repository contains a simple Blender addon. **Important:** zip the files di
 2. Press **N** to reveal the sidebar and choose the **Kaiserlich** tab.
 3. Adjust the properties and click **Start** to run the operator.
 4. Existing proxies are removed, then a 50% proxy and a timecode
-   index are built. The addon waits up to 300&nbsp;s for a proxy
-   file to appear, printing a countdown in the console. After that it
+   index are built. The addon waits up to 300&nbsp;s for the proxy
+   render to finish, printing a countdown in the console. After that it
    disables the proxy timeline, detects features and filters them
    automatically. When a callback is registered, additional actions
    such as bidirectional tracking can run afterward without a separate

--- a/__init__.py
+++ b/__init__.py
@@ -53,6 +53,12 @@ if not logger.handlers:
 # Optional callback invoked after feature detection has finished
 after_detect_callback = None
 
+
+def unregister_after_detect_callback():
+    """Clear the after-detect callback."""
+    global after_detect_callback
+    after_detect_callback = None
+
 def register_after_detect_callback(func):
     """Register ``func`` to run after feature detection completes."""
     global after_detect_callback
@@ -220,9 +226,7 @@ class CLIP_OT_kaiserlich_track(Operator):
                             scene.repeat_frame_hits = 1
                             reset_motion_model(settings)
                             decrease_marker_count_plus(scene, scene.marker_count_plus_base)
-                        new_count = detect_until_count_matches(context)
-                        scene.new_marker_count = new_count
-                        logger.info(f"TRACK_ Marker nach Iteration: {new_count}")
+                        logger.info("Marker gesetzt -> Tracking wird gestartet")
 
                 if on_after_detect:
                     try:

--- a/auto_track_bidir.py
+++ b/auto_track_bidir.py
@@ -46,7 +46,8 @@ class TRACK_OT_auto_track_bidir(bpy.types.Operator):
         print("Marker gesetzt -> beginne Tracking")
 
         def track_range(track):
-            frames = [m.frame for m in track.markers]
+            markers = getattr(track, "markers", [])
+            frames = [m.frame for m in markers]
             return (min(frames), max(frames)) if frames else (None, None)
 
         ranges_before = {t.name: track_range(t) for t in track_sel}
@@ -59,16 +60,20 @@ class TRACK_OT_auto_track_bidir(bpy.types.Operator):
         logger.info("Aktueller Frame: %s", current_frame)
         print(f"Aktueller Frame: {current_frame}")
 
-        logger.info("Starte Rückwärts-Tracking...")
-        print("Starte Rückwärts-Tracking...")
-        logger.info(
-            "-- Rueckwaerts: %d Marker ab Frame %d",
-            len(track_sel),
-            current_frame,
-        )
-        bpy.ops.clip.track_markers(backwards=True, sequence=True)
-        logger.info("Rückwärts-Tracking abgeschlossen.")
-        print("Rückwärts-Tracking abgeschlossen.")
+        start_frame = scene.frame_start
+        if current_frame == start_frame:
+            logger.info("Playhead at start; skipping backward tracking")
+        else:
+            logger.info("Starte Rückwärts-Tracking...")
+            print("Starte Rückwärts-Tracking...")
+            logger.info(
+                "-- Rueckwaerts: %d Marker ab Frame %d",
+                len(track_sel),
+                current_frame,
+            )
+            bpy.ops.clip.track_markers(backwards=True, sequence=True)
+            logger.info("Rückwärts-Tracking abgeschlossen.")
+            print("Rückwärts-Tracking abgeschlossen.")
 
         ranges_after_back = {t.name: track_range(t) for t in track_sel}
         for name, rng in ranges_after_back.items():

--- a/proxy_wait.py
+++ b/proxy_wait.py
@@ -69,6 +69,7 @@ def create_proxy_and_wait(wait_time=0.0, on_finish=None, clip=None):
     sys.stdout.flush()
 
     proxy_pattern = os.path.join(full_proxy, "**", "proxy_50.*")
+    partial_pattern = os.path.join(full_proxy, "**", "*.part")
     wait_seconds = wait_time if wait_time > 0 else 180
     start = time.time()
 
@@ -78,8 +79,11 @@ def create_proxy_and_wait(wait_time=0.0, on_finish=None, clip=None):
             for p in glob.glob(proxy_pattern, recursive=True)
             if os.path.isfile(p) and "_part" not in os.path.basename(p)
         ]
-        if matches:
-            logger.info("Proxy-Datei gefunden")
+        partials = [
+            p for p in glob.glob(partial_pattern, recursive=True) if os.path.isfile(p)
+        ]
+        if matches and not partials:
+            logger.info("Alle Proxy-Dateien vorhanden")
             logger.info("Proxy-Erstellung abgeschlossen")
             if on_finish:
                 logger.info("Führe nachgelagerte Schritte aus")


### PR DESCRIPTION
## Summary
- expose function to unregister callbacks
- skip second detection loop after markers exist
- restore backward tracking check and tolerate missing marker data
- wait until all proxy frames are rendered before continuing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6873437ebdec832daa9d8e90906d791a