### PR TITLE
Document unregister callback usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ import track_cycle
 tracking.register_after_detect_callback(track_cycle.run)
 ```
 
+Remove the callback later with:
+
+```python
+tracking.unregister_after_detect_callback()
+```
+
 The callback receives the current ``context`` object. The example in
 ``track_cycle.py`` enables proxy/timecode again using the toggle operator.
 It then launches ``auto_track_bidir`` to track all ``TRACK_`` markers and

--- a/__init__.py
+++ b/__init__.py
@@ -59,6 +59,12 @@ def register_after_detect_callback(func):
     after_detect_callback = func
 
 
+def unregister_after_detect_callback():
+    """Clear the callback registered with ``register_after_detect_callback``."""
+    global after_detect_callback
+    after_detect_callback = None
+
+
 def configure_logging():
     """Set log level based on addon preferences."""
     addon = bpy.context.preferences.addons.get(__name__)
@@ -342,6 +348,7 @@ def register():
 
 
 def unregister():
+    unregister_after_detect_callback()
     bpy.utils.unregister_class(CLIP_OT_kaiserlich_track)
     bpy.utils.unregister_class(CLIP_PT_kaiserlich_track)
     bpy.utils.unregister_class(CLIP_OT_remove_close_new_markers)

--- a/auto_track_bidir.py
+++ b/auto_track_bidir.py
@@ -46,7 +46,7 @@ class TRACK_OT_auto_track_bidir(bpy.types.Operator):
         print("Marker gesetzt -> beginne Tracking")
 
         def track_range(track):
-            frames = [m.frame for m in track.markers]
+            frames = [m.frame for m in getattr(track, "markers", [])]
             return (min(frames), max(frames)) if frames else (None, None)
 
         ranges_before = {t.name: track_range(t) for t in track_sel}
@@ -56,19 +56,24 @@ class TRACK_OT_auto_track_bidir(bpy.types.Operator):
 
         scene = context.scene
         current_frame = scene.frame_current
+        start_frame = scene.frame_start
         logger.info("Aktueller Frame: %s", current_frame)
         print(f"Aktueller Frame: {current_frame}")
 
-        logger.info("Starte Rückwärts-Tracking...")
-        print("Starte Rückwärts-Tracking...")
-        logger.info(
-            "-- Rueckwaerts: %d Marker ab Frame %d",
-            len(track_sel),
-            current_frame,
-        )
-        bpy.ops.clip.track_markers(backwards=True, sequence=True)
-        logger.info("Rückwärts-Tracking abgeschlossen.")
-        print("Rückwärts-Tracking abgeschlossen.")
+        if current_frame == start_frame:
+            logger.info("Playhead at start; skipping backward tracking")
+            print("Playhead at start; skipping backward tracking")
+        else:
+            logger.info("Starte Rückwärts-Tracking...")
+            print("Starte Rückwärts-Tracking...")
+            logger.info(
+                "-- Rueckwaerts: %d Marker ab Frame %d",
+                len(track_sel),
+                current_frame,
+            )
+            bpy.ops.clip.track_markers(backwards=True, sequence=True)
+            logger.info("Rückwärts-Tracking abgeschlossen.")
+            print("Rückwärts-Tracking abgeschlossen.")
 
         ranges_after_back = {t.name: track_range(t) for t in track_sel}
         for name, rng in ranges_after_back.items():


### PR DESCRIPTION
## Summary
- document how to unregister callbacks in the README
- restore `unregister_after_detect_callback` helper
- guard bidirectional tracking against start frame

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68739270d284832db8e6abd9694753a9