### PR TITLE
Implement auto tracking cycle

### DIFF
--- a/track_cycle.py
+++ b/track_cycle.py
@@ -1,0 +1,23 @@
+import bpy
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def auto_track_bidirectional(context):
+    """Track selected markers backward then forward from the current frame."""
+    clip = getattr(context.space_data, "clip", None)
+    if clip is None:
+        logger.info("Kein Clip gefunden")
+        return
+
+    scene = context.scene
+    current_frame = scene.frame_current
+    logger.info("Starte Rueckwaerts-Tracking")
+    bpy.ops.clip.track_markers(backwards=True, sequence=True)
+    logger.info("Rueckwaerts-Tracking abgeschlossen")
+    scene.frame_current = current_frame
+    logger.info("Starte Vorwaerts-Tracking")
+    bpy.ops.clip.track_markers(backwards=False, sequence=True)
+    logger.info("Vorwaerts-Tracking abgeschlossen")
+    scene.frame_current = current_frame


### PR DESCRIPTION
## Summary
- add helper `track_cycle.py` with `auto_track_bidirectional`
- call auto tracking after detection loop finishes
- guard addon imports for environments without Blender so tests run

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873a1cd3624832d88fe98194b840c34