### PR TITLE
Fix context usage in auto tracking

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -165,11 +165,11 @@ class CLIP_OT_kaiserlich_track(Operator):
                 logger.info("Starte Feature-Erkennung")
                 sys.stdout.flush()
 
-                new_count = detect_until_count_matches(context)
+                new_count = detect_until_count_matches(bpy.context)
                 scene.new_marker_count = new_count
                 logger.info(f"TRACK_ Marker nach Iteration: {new_count}")
                 logger.info("Starte Auto-Tracking")
-                auto_track_bidirectional(context)
+                auto_track_bidirectional(bpy.context)
                 logger.info("Auto-Tracking abgeschlossen")
 
             if not run_in_clip_editor(clip, run_ops):


### PR DESCRIPTION
## Summary
- use the overridden context when running detection and tracking

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873a6ee5214832db8c39e98d4314661