### PR TITLE
Aktiviere Proxy bei Trackingstart

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -137,13 +137,17 @@ class CLIP_OT_kaiserlich_track(Operator):
         # Der aktuelle Clip wird übergeben, damit der Callback unabhängig vom
         # aktiven Kontext funktioniert.
         def after_proxy(clip):
-            if clip and clip.use_proxy:
-                logger.info("Proxy-Zeitlinie wird deaktiviert")
-                clip.use_proxy = False
-                show_popup("Proxy-Zeitlinie wurde deaktiviert")
+            if clip:
+                if not clip.use_proxy:
+                    logger.info("Proxy-Zeitlinie wird aktiviert")
+                    clip.use_proxy = True
+                    show_popup("Proxy-Zeitlinie wurde aktiviert")
+                else:
+                    logger.info("Proxy bereits aktiviert")
+                    show_popup("Proxy bereits aktiviert")
             else:
-                logger.info("Proxy bereits deaktiviert oder kein Clip")
-                show_popup("Proxy bereits deaktiviert oder kein Clip")
+                logger.info("Kein Clip für Proxy-Schaltung")
+                show_popup("Kein Clip für Proxy-Schaltung")
 
             logger.info("Berechne minimale Marker-Eigenschaften")
             update_min_marker_props(scene, context)
@@ -155,6 +159,10 @@ class CLIP_OT_kaiserlich_track(Operator):
 
 
             def run_ops():
+                # Proxy einschalten, falls noch deaktiviert
+                if clip and not clip.use_proxy:
+                    bpy.ops.clip.toggle_proxy()
+
                 compute_margin_distance()
                 marker_plus = update_marker_count_plus(scene)
                 msg = (

--- a/track_cycle.py
+++ b/track_cycle.py
@@ -11,6 +11,10 @@ def auto_track_bidirectional(context):
         logger.info("Kein Clip gefunden")
         return
 
+    # Proxy vor dem Tracking aktivieren
+    if not clip.use_proxy:
+        bpy.ops.clip.toggle_proxy()
+
     scene = context.scene
     current_frame = scene.frame_current
     logger.info("Starte Rueckwaerts-Tracking")


### PR DESCRIPTION
## Summary
- enable proxies immediately after building to avoid memory issues
- ensure proxy playback before tracking starts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873b0437a88832d82973b86635ad598