### PR TITLE
Implement automatic short track removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ The main operator now relies on `detect_until_count_matches`. This helper
 repeatedly runs feature detection and adapts the settings until the number of
 markers falls within the expected range. Once a satisfactory count is achieved,
 all newly created tracks are renamed with the ``TRACK_`` prefix.
+Tracks shorter than the configured **min tracking length** are deleted
+automatically after tracking.
 
 ### Properties
 

--- a/__init__.py
+++ b/__init__.py
@@ -92,6 +92,7 @@ if _BPy:
     from detect import DetectFeaturesCustomOperator
     from iterative_detect import detect_until_count_matches
     from track_cycle import auto_track_bidirectional
+    from delete_helpers import delete_short_tracks
 
 def show_popup(message, title="Info", icon='INFO'):
     """Display a temporary popup in Blender's UI."""
@@ -179,6 +180,12 @@ class CLIP_OT_kaiserlich_track(Operator):
                 logger.info("Starte Auto-Tracking")
                 auto_track_bidirectional(bpy.context)
                 logger.info("Auto-Tracking abgeschlossen")
+                deleted = delete_short_tracks(
+                    bpy.context, min_track_len, prefix="TRACK_"
+                )
+                if deleted:
+                    logger.info(f"🗑️ Gelöscht: {deleted} kurze TRACK_ Marker")
+                    show_popup(f"Gelöscht: {deleted} kurze TRACK_ Marker")
 
             if not run_in_clip_editor(clip, run_ops):
                 logger.info("Kein Clip Editor zum Ausführen der Operatoren gefunden")


### PR DESCRIPTION
## Summary
- remove tracking tracks shorter than the configured minimum
- notify user how many tracks were removed
- document this behaviour in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873c8c31c64832db76ce8b8de32de1c