### PR TITLE
Add progress display during tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The panel exposes several options:
 - **min marker pro frame** – minimum marker count per frame (default 10)
 - **min tracking length** – minimum length for each track (default 20)
 - **Error Threshold** – maximum error allowed for trackers (default 0.04)
+- **Tracking Progress** – shows progress of the tracking process
 
 ### Helper Scripts
 


### PR DESCRIPTION
## Summary
- show tracking progress in UI
- add progress handling in operator
- document new property in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873e1f22270832db844e7c4d1035fe4