### PR TITLE
Clamp pattern size

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -24,6 +24,10 @@ import sys
 import importlib
 import logging
 
+# pattern size handling
+PATTERN_SIZE_START = 50
+PATTERN_SIZE_MAX = 100
+
 logger = logging.getLogger(__name__)
 if not logger.handlers:
     handler = logging.StreamHandler()
@@ -136,7 +140,8 @@ def run_tracking_cycle(context, clip, min_marker, min_track_len):
     settings = clip.tracking.settings
     global visited_frames
     visited_frames.clear()
-    pattern_size = settings.default_pattern_size
+    pattern_size = min(PATTERN_SIZE_START, PATTERN_SIZE_MAX)
+    settings.default_pattern_size = pattern_size
     start = scene.frame_start
     end = scene.frame_end
     total = end - start + 1
@@ -162,9 +167,11 @@ def run_tracking_cycle(context, clip, min_marker, min_track_len):
             visited_frames.add(frame)
             reset_motion_model(settings)
             pattern_size = max(1, int(pattern_size * 0.9))
+            pattern_size = min(pattern_size, PATTERN_SIZE_MAX)
         else:
             cycle_motion_model(settings)
             pattern_size = int(pattern_size * 1.1)
+            pattern_size = min(pattern_size, PATTERN_SIZE_MAX)
 
         settings.default_pattern_size = pattern_size
         settings.default_search_size = settings.default_pattern_size * 2

--- a/detect.py
+++ b/detect.py
@@ -3,6 +3,10 @@ import logging
 from margin_utils import compute_margin_distance, ensure_margin_distance
 from adjust_marker_count_plus import adjust_marker_count_plus
 
+# Clamp pattern sizes to a sane range
+PATTERN_SIZE_START = 50
+PATTERN_SIZE_MAX = 100
+
 logger = logging.getLogger(__name__)
 
 # Operator-Klasse
@@ -31,7 +35,7 @@ class DetectFeaturesCustomOperator(bpy.types.Operator):
         min_new = context.scene.min_marker_count
         base_count = len(clip.tracking.tracks)
         settings = clip.tracking.settings
-        settings.default_pattern_size = 50
+        settings.default_pattern_size = min(PATTERN_SIZE_START, PATTERN_SIZE_MAX)
         settings.default_search_size = settings.default_pattern_size * 2
 
         # Werte aus margin_utils verwenden und an Threshold anpassen


### PR DESCRIPTION
## Summary
- cap the pattern size at 100 and start at 50
- start tracking cycles with PATTERN_SIZE_START
- clamp pattern size whenever it increases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687402ed2a24832d8eb30e1d441a5a66