### PR TITLE
Add tracking debug output

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -175,6 +175,11 @@ def run_tracking_cycle(context, clip, min_marker, min_track_len):
 
         settings.default_pattern_size = pattern_size
         settings.default_search_size = settings.default_pattern_size * 2
+        logger.info(
+            "Tracking: pattern_size=%s motion_model=%s",
+            pattern_size,
+            settings.default_motion_model,
+        )
 
         compute_margin_distance()
         update_marker_count_plus(scene)

--- a/iterative_detect.py
+++ b/iterative_detect.py
@@ -31,6 +31,7 @@ def detect_until_count_matches(context):
 
     compute_margin_distance()
 
+    settings = clip.tracking.settings
     base_idx = len(clip.tracking.tracks)
     threshold = 1.0
     margin, distance, _ = ensure_margin_distance(clip, threshold)
@@ -45,11 +46,13 @@ def detect_until_count_matches(context):
         new_tracks = list(clip.tracking.tracks)[base_idx:]
         rename_new_tracks(new_tracks)
         logger.info(
-            "Detect step: %s %s %s",
-            f"threshold={threshold:.4f}",
-            f"→ erzeugt {len(new_tracks)} Marker",
-            f"{[t.name for t in new_tracks]}",
+            "Detect step: pattern_size=%s motion_model=%s threshold=%.4f -> %s",
+            settings.default_pattern_size,
+            settings.default_motion_model,
+            threshold,
+            len(new_tracks),
         )
+        logger.info("Neue Marker: %s", [t.name for t in new_tracks])
         new_count = count_new_markers(context, clip)
         logger.info(f"Gespeicherte NEW_-Marker: {scene.new_marker_count}")
         return new_count


### PR DESCRIPTION
## Summary
- log pattern size and motion model during tracking
- include pattern size and motion model in detection logs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68740885f484832d9065d9f6c783b8d0