### PR TITLE
Ensure proxy state for detect and tracking

### DIFF
--- a/New/track.py
+++ b/New/track.py
@@ -22,6 +22,10 @@ class TRACK_OT_auto_track_bidir(bpy.types.Operator):
             self.report({'WARNING'}, "Keine Marker vorhanden")
             return {'CANCELLED'}
 
+        if not clip.use_proxy:
+            print("Proxy für Tracking aktivieren…")
+            bpy.ops.clip.toggle_proxy()
+
         scene = context.scene
         current_frame = scene.frame_current
         print(f"Aktueller Frame: {current_frame}")

--- a/detect.py
+++ b/detect.py
@@ -30,6 +30,11 @@ class DetectFeaturesCustomOperator(bpy.types.Operator):
             self.report({'WARNING'}, "Kein Clip gefunden")
             return {'CANCELLED'}
 
+        # Proxy vor der Erkennung ausschalten
+        if clip.use_proxy:
+            logger.info("Proxy für Detection deaktivieren")
+            bpy.ops.clip.toggle_proxy()
+
         threshold = 1.0
         base_plus = context.scene.min_marker_count_plus
         min_new = context.scene.min_marker_count

--- a/iterative_detect.py
+++ b/iterative_detect.py
@@ -37,6 +37,9 @@ def detect_until_count_matches(context):
     margin, distance, _ = ensure_margin_distance(clip, threshold)
 
     def detect_step():
+        if clip.use_proxy:
+            logger.info("Proxy für Detection deaktivieren")
+            bpy.ops.clip.toggle_proxy()
         bpy.ops.clip.detect_features(
             threshold=threshold,
             margin=margin,


### PR DESCRIPTION
## Summary
- disable proxy before running detection
- ensure proxy is enabled before tracking

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68740e9053cc832db94013b5dd690c27