### PR TITLE
Ensure direct proxy control

### DIFF
--- a/New/track.py
+++ b/New/track.py
@@ -22,6 +22,10 @@ class TRACK_OT_auto_track_bidir(bpy.types.Operator):
             self.report({'WARNING'}, "Keine Marker vorhanden")
             return {'CANCELLED'}
 
+        if not clip.use_proxy:
+            print("Proxy für Tracking aktivieren…")
+            clip.use_proxy = True
+
         scene = context.scene
         current_frame = scene.frame_current
         print(f"Aktueller Frame: {current_frame}")

--- a/__init__.py
+++ b/__init__.py
@@ -273,7 +273,7 @@ class CLIP_OT_kaiserlich_track(Operator):
             def run_ops():
                 # Proxy einschalten, falls noch deaktiviert
                 if clip and not clip.use_proxy:
-                    bpy.ops.clip.toggle_proxy()
+                    clip.use_proxy = True
 
                 scene.tracking_progress = 0.0
 

--- a/detect.py
+++ b/detect.py
@@ -30,6 +30,11 @@ class DetectFeaturesCustomOperator(bpy.types.Operator):
             self.report({'WARNING'}, "Kein Clip gefunden")
             return {'CANCELLED'}
 
+        # Proxy vor der Erkennung ausschalten
+        if clip.use_proxy:
+            logger.info("Proxy für Detection deaktivieren")
+            clip.use_proxy = False
+
         threshold = 1.0
         base_plus = context.scene.min_marker_count_plus
         min_new = context.scene.min_marker_count

--- a/iterative_detect.py
+++ b/iterative_detect.py
@@ -37,6 +37,9 @@ def detect_until_count_matches(context):
     margin, distance, _ = ensure_margin_distance(clip, threshold)
 
     def detect_step():
+        if clip.use_proxy:
+            logger.info("Proxy für Detection deaktivieren")
+            clip.use_proxy = False
         bpy.ops.clip.detect_features(
             threshold=threshold,
             margin=margin,

--- a/track_cycle.py
+++ b/track_cycle.py
@@ -13,7 +13,8 @@ def auto_track_bidirectional(context):
 
     # Proxy vor dem Tracking aktivieren
     if not clip.use_proxy:
-        bpy.ops.clip.toggle_proxy()
+        logger.info("Proxy für Tracking aktivieren")
+        clip.use_proxy = True
 
     scene = context.scene
     current_frame = scene.frame_current


### PR DESCRIPTION
## Summary
- disable proxy before detection by setting `clip.use_proxy = False`
- enable proxy before tracking with `clip.use_proxy = True`
- update run cycle to set proxy flag instead of using the toggle operator

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68740e9053cc832db94013b5dd690c27