### PR TITLE
Remove prints from scripts

### DIFF
--- a/New/Track Length.py
+++ b/New/Track Length.py
@@ -1,4 +1,7 @@
 import bpy
+import logging
+
+logger = logging.getLogger(__name__)
 
 class TRACKING_OT_delete_short_tracks_with_prefix(bpy.types.Operator):
     bl_idname = "tracking.delete_short_tracks_with_prefix"
@@ -6,18 +9,18 @@ class TRACKING_OT_delete_short_tracks_with_prefix(bpy.types.Operator):
     bl_description = "Delete tracking tracks with prefix 'TRACK_' and less than 25 frames"
 
     def execute(self, context):
-        print("\n=== [Operator gestartet: TRACKING_OT_delete_short_tracks_with_prefix] ===")
+        logger.info("=== [Operator gestartet: TRACKING_OT_delete_short_tracks_with_prefix] ===")
 
         clip = context.space_data.clip
         if not clip:
             self.report({'WARNING'}, "No clip loaded")
-            print("❌ Kein Movie Clip geladen – Abbruch.")
+            logger.info("❌ Kein Movie Clip geladen – Abbruch.")
             return {'CANCELLED'}
-        print(f"🎬 Clip: {clip.name}")
+        logger.info(f"🎬 Clip: {clip.name}")
 
         active_obj = clip.tracking.objects.active
         tracks = active_obj.tracks
-        print(f"📷 Aktives Objekt: {active_obj.name} — {len(tracks)} Tracks vorhanden")
+        logger.info(f"📷 Aktives Objekt: {active_obj.name} — {len(tracks)} Tracks vorhanden")
 
         # Filter nach Präfix und Marker-Anzahl
         tracks_to_delete = [
@@ -25,40 +28,40 @@ class TRACKING_OT_delete_short_tracks_with_prefix(bpy.types.Operator):
             if t.name.startswith("TRACK_") and len(t.markers) < 25
         ]
 
-        print("🎯 Tracks mit Präfix 'TRACK_' und < 25 Frames:")
+        logger.info("🎯 Tracks mit Präfix 'TRACK_' und < 25 Frames:")
         for t in tracks_to_delete:
-            print(f"   - {t.name} ({len(t.markers)} Frames)")
+            logger.info(f"   - {t.name} ({len(t.markers)} Frames)")
 
         for track in tracks:
             track.select = track in tracks_to_delete
 
         if not tracks_to_delete:
-            print("ℹ️ Keine passenden Tracks gefunden – beende.")
+            logger.info("ℹ️ Keine passenden Tracks gefunden – beende.")
             self.report({'INFO'}, "No short tracks found with prefix 'TRACK_'")
             return {'CANCELLED'}
 
-        print("🔎 Suche nach CLIP_EDITOR Bereich für Operator...")
+        logger.info("🔎 Suche nach CLIP_EDITOR Bereich für Operator...")
         for area in context.screen.areas:
             if area.type == 'CLIP_EDITOR':
                 for region in area.regions:
                     if region.type == 'WINDOW':
                         for space in area.spaces:
                             if space.type == 'CLIP_EDITOR':
-                                print("✅ Kontext bereit – führe delete_track() aus")
+                                logger.info("✅ Kontext bereit – führe delete_track() aus")
                                 with context.temp_override(
                                     area=area,
                                     region=region,
                                     space_data=space
                                 ):
                                     bpy.ops.clip.delete_track()
-                                print(f"🗑️ {len(tracks_to_delete)} Track(s) gelöscht.")
+                                logger.info(f"🗑️ {len(tracks_to_delete)} Track(s) gelöscht.")
                                 self.report({'INFO'}, f"Deleted {len(tracks_to_delete)} short tracks with prefix 'TRACK_'")
-                                print("=== [Operator erfolgreich beendet] ===\n")
+                                logger.info("=== [Operator erfolgreich beendet] ===")
                                 return {'FINISHED'}
 
-        print("❌ Kein geeigneter Clip Editor Bereich gefunden.")
+        logger.info("❌ Kein geeigneter Clip Editor Bereich gefunden.")
         self.report({'ERROR'}, "No Clip Editor area found.")
-        print("=== [Operator abgebrochen] ===\n")
+        logger.info("=== [Operator abgebrochen] ===")
         return {'CANCELLED'}
 
 class TRACKING_PT_custom_panel(bpy.types.Panel):
@@ -74,12 +77,12 @@ class TRACKING_PT_custom_panel(bpy.types.Panel):
 def register():
     bpy.utils.register_class(TRACKING_OT_delete_short_tracks_with_prefix)
     bpy.utils.register_class(TRACKING_PT_custom_panel)
-    print("🔧 Operator & Panel registriert")
+    logger.info("🔧 Operator & Panel registriert")
 
 def unregister():
     bpy.utils.unregister_class(TRACKING_OT_delete_short_tracks_with_prefix)
     bpy.utils.unregister_class(TRACKING_PT_custom_panel)
-    print("🧹 Operator & Panel entfernt")
+    logger.info("🧹 Operator & Panel entfernt")
 
 if __name__ == "__main__":
     register()

--- a/New/track.py
+++ b/New/track.py
@@ -1,4 +1,7 @@
 import bpy
+import logging
+
+logger = logging.getLogger(__name__)
 
 class TRACK_OT_auto_track_bidir(bpy.types.Operator):
     """Trackt ausgewählte Marker rückwärts und dann vorwärts vom aktuellen Frame aus"""
@@ -23,29 +26,29 @@ class TRACK_OT_auto_track_bidir(bpy.types.Operator):
             return {'CANCELLED'}
 
         if not clip.use_proxy:
-            print("Proxy für Tracking aktivieren…")
+            logger.info("Proxy für Tracking aktivieren…")
             clip.use_proxy = True
-            print("Proxy aktiviert")
+            logger.info("Proxy aktiviert")
 
         scene = context.scene
         current_frame = scene.frame_current
-        print(f"Aktueller Frame: {current_frame}")
+        logger.info(f"Aktueller Frame: {current_frame}")
 
-        print("Starte Rückwärts-Tracking...")
+        logger.info("Starte Rückwärts-Tracking...")
         bpy.ops.clip.track_markers(backwards=True, sequence=True)
-        print("Rückwärts-Tracking abgeschlossen.")
+        logger.info("Rückwärts-Tracking abgeschlossen.")
 
         # Zurück zum ursprünglichen Frame springen
         scene.frame_current = current_frame
-        print(f"Zurück zum Ausgangsframe: {current_frame}")
+        logger.info(f"Zurück zum Ausgangsframe: {current_frame}")
 
-        print("Starte Vorwärts-Tracking...")
+        logger.info("Starte Vorwärts-Tracking...")
         bpy.ops.clip.track_markers(backwards=False, sequence=True)
-        print("Vorwärts-Tracking abgeschlossen.")
+        logger.info("Vorwärts-Tracking abgeschlossen.")
 
         # Sicherstellen, dass Frame wieder korrekt gesetzt ist
         scene.frame_current = current_frame
-        print(f"Finaler Frame gesetzt auf: {current_frame}")
+        logger.info(f"Finaler Frame gesetzt auf: {current_frame}")
 
         return {'FINISHED'}
 

--- a/__init__.py
+++ b/__init__.py
@@ -253,7 +253,7 @@ class CLIP_OT_kaiserlich_track(Operator):
                 if not clip.use_proxy:
                     logger.info("Proxy-Zeitlinie wird aktiviert")
                     clip.use_proxy = True
-                    print("Proxy aktiviert")
+                    logger.info("Proxy aktiviert")
                     show_popup("Proxy-Zeitlinie wurde aktiviert")
                 else:
                     logger.info("Proxy bereits aktiviert")
@@ -275,7 +275,7 @@ class CLIP_OT_kaiserlich_track(Operator):
                 # Proxy einschalten, falls noch deaktiviert
                 if clip and not clip.use_proxy:
                     clip.use_proxy = True
-                    print("Proxy aktiviert")
+                    logger.info("Proxy aktiviert")
 
                 scene.tracking_progress = 0.0
 

--- a/detect.py
+++ b/detect.py
@@ -34,7 +34,7 @@ class DetectFeaturesCustomOperator(bpy.types.Operator):
         if clip.use_proxy:
             logger.info("Proxy für Detection deaktivieren")
             clip.use_proxy = False
-            print("Proxy deaktiviert")
+            logger.info("Proxy deaktiviert")
 
         threshold = 1.0
         base_plus = context.scene.min_marker_count_plus

--- a/iterative_detect.py
+++ b/iterative_detect.py
@@ -40,7 +40,7 @@ def detect_until_count_matches(context):
         if clip.use_proxy:
             logger.info("Proxy für Detection deaktivieren")
             clip.use_proxy = False
-            print("Proxy deaktiviert")
+            logger.info("Proxy deaktiviert")
         bpy.ops.clip.detect_features(
             threshold=threshold,
             margin=margin,

--- a/proxy_switch.py
+++ b/proxy_switch.py
@@ -21,7 +21,6 @@ class ToggleProxyOperator(bpy.types.Operator):
         if clip:
             clip.use_proxy = not clip.use_proxy
             state = "aktiviert" if clip.use_proxy else "deaktiviert"
-            print(f"Proxy {state}")
             self.report({'INFO'}, f"Proxy/Timecode {state}")
         else:
             self.report({'WARNING'}, "Kein Clip geladen")

--- a/proxy_wait.py
+++ b/proxy_wait.py
@@ -52,7 +52,7 @@ def create_proxy_and_wait(wait_time=0.0, on_finish=None, clip=None):
         return
 
     clip.use_proxy = True
-    print("Proxy aktiviert")
+    logger.info("Proxy aktiviert")
     # Proxy-Timecode aktivieren
     if hasattr(clip, "use_proxy_timecode"):
         clip.use_proxy_timecode = True

--- a/track_cycle.py
+++ b/track_cycle.py
@@ -14,7 +14,7 @@ def auto_track_bidirectional(context):
     # Proxy vor dem Tracking aktivieren
     if not clip.use_proxy:
         clip.use_proxy = True
-        print("Proxy aktiviert")
+        logger.info("Proxy aktiviert")
 
     scene = context.scene
     current_frame = scene.frame_current


### PR DESCRIPTION
## Summary
- eliminate all `print()` calls in Blender addon scripts
- replace informational prints with `logger.info` or `self.report`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687420179e18832d9165e01e793df6c1