### PR TITLE
Add threshold monitoring logs

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -48,6 +48,8 @@ class DetectFeaturesCustomOperator(bpy.types.Operator):
         compute_margin_distance()
         margin, distance, _ = ensure_margin_distance(clip, threshold)
 
+        logger.info("Initialer Threshold: %.4f", threshold)
+
         bpy.ops.clip.detect_features(
             threshold=threshold,
             margin=margin,
@@ -85,6 +87,8 @@ class DetectFeaturesCustomOperator(bpy.types.Operator):
                 threshold * ((context.scene.new_marker_count + 0.1) / min_plus),
                 0.0001,
             )
+
+            logger.info("Neuer Threshold: %.4f", threshold)
 
             margin, distance, _ = ensure_margin_distance(clip, threshold)
 

--- a/iterative_detect.py
+++ b/iterative_detect.py
@@ -36,6 +36,8 @@ def detect_until_count_matches(context):
     threshold = 1.0
     margin, distance, _ = ensure_margin_distance(clip, threshold)
 
+    logger.info("Initialer Threshold: %.4f", threshold)
+
     def detect_step():
         if clip.use_proxy:
             logger.info("Proxy für Detection deaktivieren")
@@ -75,6 +77,7 @@ def detect_until_count_matches(context):
 
         min_plus = max(1, scene.min_marker_count_plus)
         threshold = max(threshold * ((prev_count + 0.1) / min_plus), 0.0001)
+        logger.info("Neuer Threshold: %.4f", threshold)
         margin, distance, _ = ensure_margin_distance(clip, threshold)
         new_count = detect_step()
         min_expected = scene.marker_count_plus_min


### PR DESCRIPTION
## Summary
- show the starting threshold before running detection
- log the updated threshold on each iteration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687426e0f0cc832db9d560f2b0caab98