### PR TITLE
Update README with completion message note

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,9 @@ logger.info(), logger.warn(), logger.error(), logger.debug()
   layout.operator("kaiserlich.auto_track_cycle", text="Auto Track")
   ```
 
+* Bei Beendigung des gesamten Tracking-Zyklus erscheint die Meldung:
+  „Es war sehr sch\u00f6n, es hat mich sehr gefreut."
+
 ---
 
 ## 🪺 UI-Integration (Blender Sidebar)


### PR DESCRIPTION
## Summary
- add note about final message displayed after the tracking cycle finishes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68751680e1fc832d8e42db3ab2137d92