### PR TITLE
Improve Blender tracking robustness

### DIFF
--- a/tracking_tracksycle/modules/operators/tracksycle_operator.py
+++ b/tracking_tracksycle/modules/operators/tracksycle_operator.py
@@ -71,9 +71,15 @@ class KAISERLICH_OT_auto_track_cycle(bpy.types.Operator):
 
         for track in clip.tracking.tracks:
             if not track.name.startswith("TRACK_"):
-                track.name = f"TRACK_{track.name}"
+                new_name = f"TRACK_{track.name}"
+                try:
+                    track.name = new_name
+                except Exception as exc:  # pylint: disable=broad-except
+                    logger.warn(f"Failed to rename track {track.name} -> {new_name}: {exc}")
 
-        track_markers(context)
+        if not track_markers(context, logger=logger):
+            self.report({'ERROR'}, "Tracking markers failed; check console for details")
+            return {'CANCELLED'}
 
         scene.kaiserlich_tracking_state = 'CLEANUP'
 

--- a/tracking_tracksycle/modules/tracking/track.py
+++ b/tracking_tracksycle/modules/tracking/track.py
@@ -3,10 +3,37 @@
 import bpy
 
 
-def track_markers(context, forwards=True, backwards=True):
-    """Track markers in both directions based on arguments."""
-    if forwards:
-        bpy.ops.clip.track_markers('INVOKE_DEFAULT', backwards=False, sequence=True)
-    if backwards:
-        bpy.ops.clip.track_markers('INVOKE_DEFAULT', backwards=True, sequence=True)
+def track_markers(context, forwards=True, backwards=True, logger=None):
+    """Track markers in both directions based on arguments.
+
+    Parameters
+    ----------
+    context : :class:`bpy.types.Context`
+        Blender context used for the operator call.
+    forwards : bool, optional
+        Track forwards if ``True``.
+    backwards : bool, optional
+        Track backwards if ``True``.
+    logger : :class:`TrackerLogger`, optional
+        Logger instance for error reporting.
+
+    Returns
+    -------
+    bool
+        ``True`` on success, ``False`` if an exception occurred.
+    """
+
+    try:
+        if forwards:
+            bpy.ops.clip.track_markers('INVOKE_DEFAULT', backwards=False, sequence=True)
+        if backwards:
+            bpy.ops.clip.track_markers('INVOKE_DEFAULT', backwards=True, sequence=True)
+    except Exception as exc:  # pylint: disable=broad-except
+        if logger:
+            logger.error(f"track_markers failed: {exc}")
+        else:
+            print(f"track_markers failed: {exc}")
+        return False
+
+    return True
 


### PR DESCRIPTION
## Summary
- add logger-based error handling for track_markers
- warn on marker rename failures and abort if tracking fails

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m unittest discover` *(fails: ModuleNotFoundError: No module named 'bpy')*
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_687516ab7b68832d90544bd96b7092fa