### PR TITLE
Add proxy directory warning

### DIFF
--- a/tracking_tracksycle/modules/operators/tracksycle_operator.py
+++ b/tracking_tracksycle/modules/operators/tracksycle_operator.py
@@ -36,7 +36,7 @@ class KAISERLICH_OT_auto_track_cycle(bpy.types.Operator):
 
         remove_existing_proxies(clip)
         logger.info("Generating proxy...")
-        if not create_proxy_and_wait(clip):
+        if not create_proxy_and_wait(clip, logger=logger):
             self.report({'ERROR'}, "Proxy creation timed out")
             return {'CANCELLED'}
 

--- a/tracking_tracksycle/modules/proxy/proxy_wait.py
+++ b/tracking_tracksycle/modules/proxy/proxy_wait.py
@@ -18,16 +18,41 @@ def remove_existing_proxies(clip):
             pass
 
 
-def create_proxy_and_wait(clip, timeout=300):
-    """Create a 50% proxy and wait until the proxy file exists."""
+def create_proxy_and_wait(clip, timeout=300, logger=None):
+    """Create a 50% proxy and wait until the proxy file exists.
+
+    Parameters
+    ----------
+    clip : :class:`bpy.types.MovieClip`
+        MovieClip for which the proxy should be generated.
+    timeout : int, optional
+        Maximum time in seconds to wait for proxy generation.
+    logger : :class:`TrackerLogger`, optional
+        Logger used for warning output.
+
+    Returns
+    -------
+    bool
+        ``True`` if the proxy file exists within ``timeout``,
+        otherwise ``False``.
+    """
+
+    directory = clip.proxy.directory
+    if directory is None:
+        warning = "Proxy directory is not set; clip may not be initialized."
+        if logger:
+            logger.warn(warning)
+        else:
+            print(f"WARNING: {warning}")
+        return False
+
     clip.proxy.build_50 = True
     clip.use_proxy = True
 
-    directory = clip.proxy.directory
-    proxy_path = os.path.join(directory, "proxy_50.avi") if directory else None
+    proxy_path = os.path.join(directory, "proxy_50.avi")
 
     start = time.time()
-    while proxy_path and not os.path.exists(proxy_path):
+    while not os.path.exists(proxy_path):
         if time.time() - start > timeout:
             return False
         time.sleep(1)


### PR DESCRIPTION
## Summary
- add warning when the proxy directory isn't set
- pass logger to proxy helper

## Testing
- `python -m py_compile tracking_tracksycle/modules/proxy/proxy_wait.py tracking_tracksycle/modules/operators/tracksycle_operator.py`

------
https://chatgpt.com/codex/tasks/task_e_687517df2eb8832dbbfd9ddde93483b4