### PR TITLE
Add timeout feedback in proxy creation

### DIFF
--- a/tracking_tracksycle/modules/operators/tracksycle_operator.py
+++ b/tracking_tracksycle/modules/operators/tracksycle_operator.py
@@ -36,7 +36,7 @@ class KAISERLICH_OT_auto_track_cycle(bpy.types.Operator):
 
         remove_existing_proxies(clip)
         logger.info("Generating proxy...")
-        if not create_proxy_and_wait(clip):
+        if not create_proxy_and_wait(clip, logger=logger):
             self.report({'ERROR'}, "Proxy creation timed out")
             return {'CANCELLED'}
 

--- a/tracking_tracksycle/modules/proxy/proxy_wait.py
+++ b/tracking_tracksycle/modules/proxy/proxy_wait.py
@@ -18,8 +18,18 @@ def remove_existing_proxies(clip):
             pass
 
 
-def create_proxy_and_wait(clip, timeout=300):
-    """Create a 50% proxy and wait until the proxy file exists."""
+def create_proxy_and_wait(clip, timeout=300, logger=None):
+    """Create a 50% proxy and wait until the proxy file exists.
+
+    Parameters
+    ----------
+    clip : :class:`bpy.types.MovieClip`
+        Clip on which the proxy should be built.
+    timeout : int, optional
+        Maximum time in seconds to wait for the proxy file.
+    logger : :class:`TrackerLogger`, optional
+        Optional logger for timeout feedback.
+    """
     clip.proxy.build_50 = True
     clip.use_proxy = True
 
@@ -29,6 +39,10 @@ def create_proxy_and_wait(clip, timeout=300):
     start = time.time()
     while proxy_path and not os.path.exists(proxy_path):
         if time.time() - start > timeout:
+            if logger:
+                logger.warn("Proxy creation timed out")
+            else:
+                print("Proxy creation timed out")
             return False
         time.sleep(1)
     return True


### PR DESCRIPTION
## Summary
- log a warning when proxy creation times out
- forward logger instance to create_proxy_and_wait

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687517b70d10832d95b07858f1902d98