### PR TITLE
Fix missing proxy rebuild trigger

### DIFF
--- a/tracking_tracksycle/modules/proxy/proxy_wait.py
+++ b/tracking_tracksycle/modules/proxy/proxy_wait.py
@@ -48,6 +48,7 @@ def create_proxy_and_wait(clip, timeout=300, logger=None):
 
     clip.proxy.build_50 = True
     clip.use_proxy = True
+    bpy.ops.clip.rebuild_proxy()
 
     proxy_path = os.path.join(directory, "proxy_50.avi")
 


### PR DESCRIPTION
## Summary
- trigger proxy build by calling `bpy.ops.clip.rebuild_proxy()`

## Testing
- `pytest -q`
- `python -m py_compile tracking_tracksycle/modules/proxy/proxy_wait.py`
- `pip install flake8` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687523aa83a0832da9adcc0e91b85e1d