### PR TITLE
Refactor logging setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,8 +253,10 @@ REVIEW / LOOP
 ## 🔧 Debug-Logging
 
 ```python
-from modules.util.tracker_logger import TrackerLogger
-logger = TrackerLogger(debug=True)
+from modules.util.tracker_logger import TrackerLogger, configure_logger
+
+configure_logger(debug=True)
+logger = TrackerLogger()
 logger.info(), logger.warn(), logger.error(), logger.debug()
 ```
 

--- a/tracking_tracksycle/__init__.py
+++ b/tracking_tracksycle/__init__.py
@@ -10,6 +10,8 @@ bl_info = {
 
 import bpy
 
+from .modules.util.tracker_logger import configure_logger
+
 from .modules.operators.tracksycle_operator import KAISERLICH_OT_auto_track_cycle
 from .modules.ui.kaiserlich_panel import KAISERLICH_PT_tracking_tools
 from bpy.props import IntProperty, FloatProperty, BoolProperty, EnumProperty
@@ -21,6 +23,7 @@ classes = [
 
 
 def register():
+    configure_logger()
     for cls in classes:
         bpy.utils.register_class(cls)
 

--- a/tracking_tracksycle/modules/operators/tracksycle_operator.py
+++ b/tracking_tracksycle/modules/operators/tracksycle_operator.py
@@ -11,7 +11,7 @@ from ..tracking.track import track_markers
 from ..tracking.track_length import get_track_length
 from ..tracking.motion_model import next_model
 from ..playback.set_playhead import set_playhead
-from ..util.tracker_logger import TrackerLogger
+from ..util.tracker_logger import TrackerLogger, configure_logger
 
 
 class KAISERLICH_OT_auto_track_cycle(bpy.types.Operator):
@@ -29,7 +29,8 @@ class KAISERLICH_OT_auto_track_cycle(bpy.types.Operator):
             self.report({'ERROR'}, "No clip loaded")
             return {'CANCELLED'}
 
-        logger = TrackerLogger(debug=scene.debug_output)
+        configure_logger(debug=scene.debug_output)
+        logger = TrackerLogger()
 
         # state machine property
         scene.kaiserlich_tracking_state = 'WAIT_FOR_PROXY'

--- a/tracking_tracksycle/modules/util/tracker_logger.py
+++ b/tracking_tracksycle/modules/util/tracker_logger.py
@@ -1,13 +1,43 @@
 """Simple logger utility for Kaiserlich Tracksycle."""
 
+from __future__ import annotations
+
 import logging
+
+LOGGER_NAME = "Tracksycle"
+
+
+def configure_logger(debug: bool = False) -> logging.Logger:
+    """Configure the Tracksycle logger once.
+
+    Parameters
+    ----------
+    debug : bool, optional
+        Whether debug level logging should be enabled, by default ``False``.
+
+    Returns
+    -------
+    :class:`logging.Logger`
+        The configured logger instance.
+    """
+
+    logger = logging.getLogger(LOGGER_NAME)
+    level = logging.DEBUG if debug else logging.INFO
+    logger.setLevel(level)
+
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter('[Tracksycle] %(message)s'))
+        logger.addHandler(handler)
+
+    return logger
 
 
 class TrackerLogger:
-    def __init__(self, debug=False):
-        level = logging.DEBUG if debug else logging.INFO
-        logging.basicConfig(level=level, format='[Tracksycle] %(message)s')
-        self._logger = logging.getLogger('Tracksycle')
+    """Wrapper around :mod:`logging` for convenience."""
+
+    def __init__(self):
+        self._logger = logging.getLogger(LOGGER_NAME)
 
     def info(self, msg):
         self._logger.info(msg)


### PR DESCRIPTION
## Summary
- setup a configure_logger utility for controlled output
- use TrackerLogger without basicConfig and configure once
- update add-on operator and registration to use new logger setup
- document new logger usage

## Testing
- `python -m py_compile tracking_tracksycle/modules/util/tracker_logger.py`
- `python -m py_compile tracking_tracksycle/modules/operators/tracksycle_operator.py tracking_tracksycle/__init__.py`
- `python -m py_compile $(git ls-files '*.py')`
- `python -m compileall -q tracking_tracksycle`

------
https://chatgpt.com/codex/tasks/task_e_687524125478832dbf94402fe27a0ee1