### PR TITLE
Improve proxy directory checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ from modules.proxy.proxy_wait import create_proxy_and_wait
 
 * Separate Thread-Logik zur Dateiprüfung
 * Fehlerbehandlung via Logging
+* Proxy-Pfad-Validierung (Existenz & Schreibrechte)
 * Sauberes Abbrechen nach Timeout
 * ✉ Referenzdatei: `proxy_wait (1).py`
 

--- a/tracking_tracksycle/modules/operators/tracksycle_operator.py
+++ b/tracking_tracksycle/modules/operators/tracksycle_operator.py
@@ -34,7 +34,7 @@ class KAISERLICH_OT_auto_track_cycle(bpy.types.Operator):
         # state machine property
         scene.kaiserlich_tracking_state = 'WAIT_FOR_PROXY'
 
-        remove_existing_proxies(clip)
+        remove_existing_proxies(clip, logger=logger)
         logger.info("Generating proxy...")
         if not create_proxy_and_wait(clip, logger=logger):
             self.report({'ERROR'}, "Proxy creation timed out")


### PR DESCRIPTION
## Summary
- log failures when removing existing proxies
- validate proxy directory existence and writability
- forward logger to proxy removal in core operator
- document proxy path validation

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6875245c465c832db1ed00ef5a51fc12