### PR TITLE
Ensure proxy disabled during feature detection

### DIFF
--- a/modules/detection/__init__.py
+++ b/modules/detection/__init__.py
@@ -1,1 +1,4 @@
 # Feature detection utilities
+from .detect_no_proxy import detect_features_no_proxy
+
+__all__ = ["detect_features_no_proxy"]

--- a/modules/detection/detect_no_proxy.py
+++ b/modules/detection/detect_no_proxy.py
@@ -1,0 +1,37 @@
+"""Feature detection with proxy disabled."""
+
+import bpy
+
+
+def detect_features_no_proxy(clip, threshold=1.0, margin=None, distance=None):
+    """Run :func:`bpy.ops.clip.detect_features` with proxies disabled.
+
+    Parameters
+    ----------
+    clip : :class:`bpy.types.MovieClip`
+        The movie clip on which to perform feature detection.
+    threshold : float, optional
+        Detection threshold, defaults to ``1.0``.
+    margin : float, optional
+        Margin value passed to the operator. If ``None`` it is derived from
+        ``clip.size``.
+    distance : float, optional
+        Minimum distance between detected features. If ``None`` it is derived
+        from ``clip.size``.
+    """
+    if margin is None:
+        margin = clip.size[0] / 200
+    if distance is None:
+        distance = clip.size[0] / 20
+
+    # ensure proxies are disabled during detection
+    clip.proxy.build_50 = False
+    clip.use_proxy = False
+
+    bpy.ops.clip.detect_features(
+        threshold=threshold,
+        margin=margin,
+        distance=distance,
+    )
+
+__all__ = ["detect_features_no_proxy"]

--- a/modules/operators/tracksycle_operator.py
+++ b/modules/operators/tracksycle_operator.py
@@ -4,6 +4,7 @@ import bpy
 
 from ..proxy.proxy_wait import create_proxy_and_wait, remove_existing_proxies
 from ..detection.distance_remove import distance_remove
+from ..detection.detect_no_proxy import detect_features_no_proxy
 from ..detection.find_frame_with_few_tracking_markers import (
     find_frame_with_few_tracking_markers,
 )
@@ -49,11 +50,12 @@ class KAISERLICH_OT_auto_track_cycle(bpy.types.Operator):
         pattern_size = getattr(settings, "default_pattern_size", 11)
 
         for _ in range(10):
-            clip.proxy.build_50 = False
-            clip.use_proxy = False
-            bpy.ops.clip.detect_features(threshold=threshold,
-                                        margin=clip.size[0]/200,
-                                        distance=clip.size[0]/20)
+            detect_features_no_proxy(
+                clip,
+                threshold=threshold,
+                margin=clip.size[0] / 200,
+                distance=clip.size[0] / 20,
+            )
             marker_count = len(clip.tracking.tracks)
             if marker_count >= scene.min_marker_count:
                 break


### PR DESCRIPTION
## Summary
- add `detect_no_proxy` helper to ensure proxies are disabled when detecting features
- use new helper in `tracksycle_operator` for feature detection loop
- export helper from detection package

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687528d253e8832da84acd8a07669f2c