### PR TITLE
Improve exception handling

### DIFF
--- a/modules/operators/tracksycle_operator.py
+++ b/modules/operators/tracksycle_operator.py
@@ -79,7 +79,7 @@ class KAISERLICH_OT_auto_track_cycle(bpy.types.Operator):
                 new_name = f"TRACK_{track.name}"
                 try:
                     track.name = new_name
-                except Exception as exc:  # pylint: disable=broad-except
+                except RuntimeError as exc:
                     logger.warn(f"Failed to rename track {track.name} -> {new_name}: {exc}")
 
         if not track_markers(context, logger=logger):

--- a/modules/tracking/track.py
+++ b/modules/tracking/track.py
@@ -28,7 +28,7 @@ def track_markers(context, forwards=True, backwards=True, logger=None):
             bpy.ops.clip.track_markers('INVOKE_DEFAULT', backwards=False, sequence=True)
         if backwards:
             bpy.ops.clip.track_markers('INVOKE_DEFAULT', backwards=True, sequence=True)
-    except Exception as exc:  # pylint: disable=broad-except
+    except RuntimeError as exc:
         if logger:
             logger.error(f"track_markers failed: {exc}")
         else:


### PR DESCRIPTION
## Summary
- handle Blender runtime errors in `track_markers`
- catch `RuntimeError` when renaming markers in the auto-track operator

## Testing
- `python -m py_compile $(git ls-files '*.py') && echo "py_compile success"`

------
https://chatgpt.com/codex/tasks/task_e_68752ab8d6a8832da273f4e6e0ab0b0f