### PR TITLE
Add tests and CLI debug tool

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -8,13 +8,17 @@ bl_info = {
     "category": "Tracking",
 }
 
-import bpy
+try:
+    import bpy
+    from bpy.props import IntProperty, FloatProperty, BoolProperty, EnumProperty
+except ModuleNotFoundError:  # pragma: no cover - allows running tests without Blender
+    bpy = None
+    IntProperty = FloatProperty = BoolProperty = EnumProperty = lambda *a, **k: None
 
 from .modules.util.tracker_logger import configure_logger
 
 from .modules.operators.tracksycle_operator import KAISERLICH_OT_auto_track_cycle
 from .modules.ui.kaiserlich_panel import KAISERLICH_PT_tracking_tools
-from bpy.props import IntProperty, FloatProperty, BoolProperty, EnumProperty
 
 classes = [
     KAISERLICH_OT_auto_track_cycle,
@@ -23,7 +27,11 @@ classes = [
 
 
 def register():
+    if bpy is None:
+        raise RuntimeError("bpy module is required to register the add-on")
+
     configure_logger()
+
     for cls in classes:
         bpy.utils.register_class(cls)
 

--- a/debug_cli.py
+++ b/debug_cli.py
@@ -1,0 +1,65 @@
+"""Simple CLI debug tool for Kaiserlich Tracksycle."""
+
+import argparse
+import os
+import sys
+from types import SimpleNamespace
+
+# Ensure modules are importable when run directly
+sys.path.insert(0, os.path.dirname(__file__))
+
+# Provide dummy bpy module when running outside Blender
+try:
+    import bpy  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - only for environments w/o Blender
+    sys.modules['bpy'] = SimpleNamespace()
+
+from modules.tracking import motion_model
+from modules.tracking.track_length import get_track_length
+from modules.util.tracker_logger import configure_logger
+
+
+def cycle_models(steps: int) -> None:
+    """Cycle through motion models and print them."""
+    for _ in range(steps):
+        model = motion_model.next_model()
+        print(model)
+
+
+def show_track_length(frames):
+    """Display the length of a dummy track."""
+    class DummyMarker:
+        def __init__(self, frame):
+            self.frame = frame
+
+    class DummyTrack:
+        def __init__(self, frames):
+            self.markers = [DummyMarker(f) for f in frames]
+
+    track = DummyTrack(frames)
+    length = get_track_length(track)
+    print(f"Track length: {length}")
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Tracksycle debug CLI")
+    subparsers = parser.add_subparsers(dest="cmd", required=True)
+
+    parser_cycle = subparsers.add_parser("cycle-models", help="Cycle motion models")
+    parser_cycle.add_argument("steps", type=int, nargs="?", default=3)
+
+    parser_length = subparsers.add_parser("track-length", help="Compute track length")
+    parser_length.add_argument("frames", type=int, nargs="+")
+
+    args = parser.parse_args(argv)
+    configure_logger(debug=True)
+
+    if args.cmd == "cycle-models":
+        cycle_models(args.steps)
+    elif args.cmd == "track-length":
+        show_track_length(args.frames)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import sys
+from types import SimpleNamespace
+
+# Provide dummy bpy and mathutils modules so addon can be imported during tests
+dummy_bpy = sys.modules.setdefault("bpy", SimpleNamespace())
+dummy_bpy.types = SimpleNamespace(Operator=object, Panel=object)
+mathutils = SimpleNamespace(Vector=lambda *a, **k: None)
+sys.modules.setdefault("mathutils", mathutils)

--- a/tests/test_motion_model.py
+++ b/tests/test_motion_model.py
@@ -1,0 +1,27 @@
+import os, sys; sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from types import SimpleNamespace
+
+# Provide dummy bpy module
+sys.modules.setdefault('bpy', SimpleNamespace())
+
+from modules.tracking import motion_model
+
+
+class DummySettings:
+    def __init__(self):
+        self.motion_model = None
+
+
+def test_next_model_cycles():
+    motion_model._index = -1  # reset
+    settings = DummySettings()
+    first = motion_model.next_model(settings)
+    second = motion_model.next_model(settings)
+    third = motion_model.next_model(settings)
+    # Should cycle through the list
+    assert first == 'Perspective'
+    assert second == 'Affine'
+    assert third == 'LocRotScale'
+    # settings attribute updated
+    assert settings.motion_model == third
+

--- a/tests/test_track_length.py
+++ b/tests/test_track_length.py
@@ -1,0 +1,26 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from modules.tracking.track_length import get_track_length
+
+
+class DummyMarker:
+    def __init__(self, frame):
+        self.frame = frame
+
+
+class DummyTrack:
+    def __init__(self, frames):
+        self.markers = [DummyMarker(f) for f in frames]
+
+
+def test_get_track_length():
+    track = DummyTrack([1, 5, 10])
+    assert get_track_length(track) == 9
+
+
+def test_get_track_length_empty():
+    track = DummyTrack([])
+    assert get_track_length(track) == 0
+

--- a/tests/test_tracker_logger.py
+++ b/tests/test_tracker_logger.py
@@ -1,0 +1,25 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from modules.util.tracker_logger import configure_logger, TrackerLogger
+
+
+def test_configure_logger_debug():
+    logger = configure_logger(debug=True)
+    assert logger.level == 10  # logging.DEBUG
+
+
+def test_tracker_logger_methods(caplog):
+    logger = configure_logger(debug=True)
+    tlogger = TrackerLogger()
+    with caplog.at_level(logger.level):
+        tlogger.info('info')
+        tlogger.warn('warn')
+        tlogger.error('error')
+        tlogger.debug('debug')
+    assert 'info' in caplog.text
+    assert 'warn' in caplog.text
+    assert 'error' in caplog.text
+    assert 'debug' in caplog.text
+


### PR DESCRIPTION
## Summary
- add a simple CLI debug utility for inspecting motion models and track length
- allow importing the addon without Blender by stubbing `bpy` usage
- provide unit tests covering logger, motion model cycling and track length
- supply dummy `bpy` and `mathutils` modules for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68752accc8d4832dab0cf3ef12474262