### PR TITLE
Improve robustness for track marker loops

### DIFF
--- a/modules/detection/distance_remove.py
+++ b/modules/detection/distance_remove.py
@@ -8,8 +8,10 @@ def distance_remove(tracks, good_marker, margin):
     """Remove tracks within a margin of a given marker."""
     good_pos = Vector(good_marker)
     for track in list(tracks):
-        if track.markers:
+        try:
             pos = track.markers[0].co
-            if (Vector(pos) - good_pos).length < margin:
-                tracks.remove(track)
+        except (AttributeError, IndexError):
+            continue
+        if (Vector(pos) - good_pos).length < margin:
+            tracks.remove(track)
 

--- a/modules/operators/tracksycle_operator.py
+++ b/modules/operators/tracksycle_operator.py
@@ -72,7 +72,12 @@ class KAISERLICH_OT_auto_track_cycle(bpy.types.Operator):
         margin = clip.size[0] / 20
         for track in list(clip.tracking.tracks):
             if track.name.startswith("GOOD_"):
-                distance_remove(clip.tracking.tracks, track.markers[0].co, margin)
+                try:
+                    marker_co = track.markers[0].co
+                except (IndexError, AttributeError):
+                    logger.warn(f"Track {track.name} has no markers; skipping distance check")
+                    continue
+                distance_remove(clip.tracking.tracks, marker_co, margin)
 
         for track in clip.tracking.tracks:
             if not track.name.startswith("TRACK_"):

--- a/tests/test_distance_remove.py
+++ b/tests/test_distance_remove.py
@@ -1,0 +1,36 @@
+import os, sys; sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from modules.detection import distance_remove
+
+
+class DummyVector(list):
+    def __sub__(self, other):
+        return DummyVector([a - b for a, b in zip(self, other)])
+
+    @property
+    def length(self):
+        return sum(c * c for c in self) ** 0.5
+
+distance_remove.Vector = DummyVector
+
+class DummyMarker:
+    def __init__(self, co):
+        self.co = co
+
+class DummyTrack:
+    def __init__(self, markers=None):
+        self.markers = markers or []
+    name = "DUMMY"
+
+class DummyTracks(list):
+    def remove(self, track):
+        super().remove(track)
+        self.removed = True
+
+def test_distance_remove_empty_markers():
+    tracks = DummyTracks([DummyTrack(), DummyTrack([DummyMarker((0, 0))])])
+    distance_remove.distance_remove(tracks, (0, 0), 1.0)
+    # The track with markers should be removed; the empty one remains
+    assert getattr(tracks, 'removed', False)
+    assert len(tracks) == 1
+


### PR DESCRIPTION
## Summary
- avoid crashes when GOOD_ tracks have no markers
- safely handle missing markers in `distance_remove`
- test `distance_remove` with empty tracks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68752f0b1c9c832d966dc9e473d12274