### PR TITLE
Add optional file logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ REVIEW / LOOP
 ```python
 from modules.util.tracker_logger import TrackerLogger, configure_logger
 
-configure_logger(debug=True)
+configure_logger(debug=True, log_file="tracksycle.log")
 logger = TrackerLogger()
 logger.info(), logger.warn(), logger.error(), logger.debug()
 ```

--- a/modules/util/tracker_logger.py
+++ b/modules/util/tracker_logger.py
@@ -3,17 +3,21 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 
 LOGGER_NAME = "Tracksycle"
 
 
-def configure_logger(debug: bool = False) -> logging.Logger:
+def configure_logger(debug: bool = False, log_file: str | Path | None = None) -> logging.Logger:
     """Configure the Tracksycle logger once.
 
     Parameters
     ----------
     debug : bool, optional
         Whether debug level logging should be enabled, by default ``False``.
+    log_file : str | Path, optional
+        If given, a :class:`logging.FileHandler` will also be attached and
+        write to this file.
 
     Returns
     -------
@@ -29,6 +33,11 @@ def configure_logger(debug: bool = False) -> logging.Logger:
         handler = logging.StreamHandler()
         handler.setFormatter(logging.Formatter('[Tracksycle] %(message)s'))
         logger.addHandler(handler)
+
+    if log_file and not any(isinstance(h, logging.FileHandler) for h in logger.handlers):
+        file_handler = logging.FileHandler(log_file)
+        file_handler.setFormatter(logging.Formatter('[Tracksycle] %(message)s'))
+        logger.addHandler(file_handler)
 
     return logger
 

--- a/tests/test_tracker_logger.py
+++ b/tests/test_tracker_logger.py
@@ -23,3 +23,14 @@ def test_tracker_logger_methods(caplog):
     assert 'error' in caplog.text
     assert 'debug' in caplog.text
 
+
+def test_configure_logger_file(tmp_path):
+    log_file = tmp_path / "test.log"
+    logger = configure_logger(debug=True, log_file=log_file)
+    logger.info('file')
+    for h in logger.handlers:
+        if hasattr(h, 'flush'):
+            h.flush()
+    assert log_file.exists()
+    assert 'file' in log_file.read_text()
+


### PR DESCRIPTION
## Summary
- add optional `log_file` parameter to `configure_logger`
- document file logging in README
- test writing to the log file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68752f5a24ac832daab9b4fff0d7033c