### PR TITLE
Add debug logging for feature detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ bpy.ops.clip.detect_features(threshold=dynamic, margin=width/200, distance=width
 * Proxy-Status wird vor jedem Aufruf deaktiviert: `clip.proxy.build_50 = False`, `clip.use_proxy = False`
 * `threshold` wird bei unzureichender Markeranzahl iterativ angepasst (max. 10 Versuche)
 * `default_pattern_size` dynamisch, max. 100
+* Optionales Debug-Logging via `detect_features_no_proxy(..., logger=TrackerLogger())`
 
 #### 📊 Threshold-Formel (Feature Detection)
 

--- a/modules/detection/detect_no_proxy.py
+++ b/modules/detection/detect_no_proxy.py
@@ -3,7 +3,7 @@
 import bpy
 
 
-def detect_features_no_proxy(clip, threshold=1.0, margin=None, distance=None):
+def detect_features_no_proxy(clip, threshold=1.0, margin=None, distance=None, logger=None):
     """Run :func:`bpy.ops.clip.detect_features` with proxies disabled.
 
     Parameters
@@ -18,11 +18,22 @@ def detect_features_no_proxy(clip, threshold=1.0, margin=None, distance=None):
     distance : float, optional
         Minimum distance between detected features. If ``None`` it is derived
         from ``clip.size``.
+    logger : :class:`TrackerLogger`, optional
+        Logger for debug output. When omitted ``print`` is used.
     """
     if margin is None:
         margin = clip.size[0] / 200
     if distance is None:
         distance = clip.size[0] / 20
+
+    message = (
+        f"Detecting features with threshold={threshold}, "
+        f"margin={margin}, distance={distance}"
+    )
+    if logger:
+        logger.debug(message)
+    else:
+        print(message)
 
     # ensure proxies are disabled during detection
     clip.proxy.build_50 = False

--- a/modules/operators/tracksycle_operator.py
+++ b/modules/operators/tracksycle_operator.py
@@ -55,6 +55,7 @@ class KAISERLICH_OT_auto_track_cycle(bpy.types.Operator):
                 threshold=threshold,
                 margin=clip.size[0] / 200,
                 distance=clip.size[0] / 20,
+                logger=logger,
             )
             marker_count = len(clip.tracking.tracks)
             if marker_count >= scene.min_marker_count:


### PR DESCRIPTION
## Summary
- log detection parameters when calling `detect_features_no_proxy`
- pass logger from `tracksycle_operator`
- mention optional logging in the docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68752f3bb9b8832dbd5fdd312d08b4fc