### PR TITLE
Add asynchronous helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ bpy.ops.clip.detect_features(threshold=dynamic, margin=width/200, distance=width
 * `threshold` wird bei unzureichender Markeranzahl iterativ angepasst (max. 10 Versuche)
 * `default_pattern_size` dynamisch, max. 100
 * Optionales Debug-Logging via `detect_features_no_proxy(..., logger=TrackerLogger())`
+* Bei sehr großen Clips kann `detect_features_async` genutzt werden, um die Erkennung per Timer zu unterteilen
 
 #### 📊 Threshold-Formel (Feature Detection)
 

--- a/__init__.py
+++ b/__init__.py
@@ -18,10 +18,12 @@ except ModuleNotFoundError:  # pragma: no cover - allows running tests without B
 from .modules.util.tracker_logger import configure_logger
 
 from .modules.operators.tracksycle_operator import KAISERLICH_OT_auto_track_cycle
+from .modules.operators.rename_tracks_modal import KAISERLICH_OT_rename_tracks_modal
 from .modules.ui.kaiserlich_panel import KAISERLICH_PT_tracking_tools
 
 classes = [
     KAISERLICH_OT_auto_track_cycle,
+    KAISERLICH_OT_rename_tracks_modal,
     KAISERLICH_PT_tracking_tools,
 ]
 

--- a/modules/detection/__init__.py
+++ b/modules/detection/__init__.py
@@ -1,4 +1,8 @@
 # Feature detection utilities
 from .detect_no_proxy import detect_features_no_proxy
+from .async_detection import detect_features_async
 
-__all__ = ["detect_features_no_proxy"]
+__all__ = [
+    "detect_features_no_proxy",
+    "detect_features_async",
+]

--- a/modules/detection/async_detection.py
+++ b/modules/detection/async_detection.py
@@ -1,0 +1,59 @@
+"""Asynchronous feature detection utilities using :mod:`bpy.app.timers`."""
+
+from __future__ import annotations
+
+import bpy
+
+from .detect_no_proxy import detect_features_no_proxy
+
+
+def detect_features_async(scene, clip, logger=None, attempts=10):
+     """Detect features asynchronously via :mod:`bpy.app.timers`.
+
+     Parameters
+     ----------
+     scene : :class:`bpy.types.Scene`
+         Scene containing detection settings like ``min_marker_count``.
+     clip : :class:`bpy.types.MovieClip`
+         Movie clip on which features should be detected.
+     logger : :class:`TrackerLogger`, optional
+         Logger for debug output.
+     attempts : int, optional
+         Maximum number of detection attempts. Defaults to 10.
+     """
+
+     settings = clip.tracking.settings
+     state = {
+         "attempt": 0,
+         "threshold": 1.0,
+         "pattern_size": getattr(settings, "default_pattern_size", 11),
+         "expected": getattr(scene, "min_marker_count", 10) * 4,
+     }
+
+     def _step():
+         detect_features_no_proxy(
+             clip,
+             threshold=state["threshold"],
+             margin=clip.size[0] / 200,
+             distance=clip.size[0] / 20,
+             logger=logger,
+         )
+         marker_count = len(clip.tracking.tracks)
+         if marker_count >= getattr(scene, "min_marker_count", 10) or state["attempt"] >= attempts:
+             return None
+         state["threshold"] = max(
+             round(state["threshold"] * ((marker_count + 0.1) / state["expected"]), 5),
+             0.0001,
+         )
+         if state["pattern_size"] < 100:
+             state["pattern_size"] = min(int(state["pattern_size"] * 1.1), 100)
+             settings.default_pattern_size = state["pattern_size"]
+             if logger:
+                 logger.debug(f"Pattern size adjusted to {state['pattern_size']}")
+         state["attempt"] += 1
+         return 0.1
+
+     bpy.app.timers.register(_step)
+
+
+__all__ = ["detect_features_async"]

--- a/modules/operators/__init__.py
+++ b/modules/operators/__init__.py
@@ -1,5 +1,9 @@
 """Operators package for Kaiserlich Tracksycle addon."""
 
 from .tracksycle_operator import KAISERLICH_OT_auto_track_cycle
+from .rename_tracks_modal import KAISERLICH_OT_rename_tracks_modal
 
-__all__ = ["KAISERLICH_OT_auto_track_cycle"]
+__all__ = [
+    "KAISERLICH_OT_auto_track_cycle",
+    "KAISERLICH_OT_rename_tracks_modal",
+]

--- a/modules/operators/rename_tracks_modal.py
+++ b/modules/operators/rename_tracks_modal.py
@@ -1,0 +1,60 @@
+"""Modal operator for asynchronous track renaming."""
+
+from __future__ import annotations
+
+import bpy
+
+from ..util.tracker_logger import TrackerLogger
+
+
+class KAISERLICH_OT_rename_tracks_modal(bpy.types.Operator):
+    """Rename tracking tracks asynchronously."""
+
+    bl_idname = "kaiserlich.rename_tracks_modal"
+    bl_label = "Rename Tracks"
+    bl_options = {'REGISTER', 'UNDO'}
+
+    _timer = None
+    _tracks = []
+    _index = 0
+    _logger = None
+
+    def execute(self, context):
+        space = context.space_data
+        clip = getattr(space, "clip", None)
+        if not clip:
+            self.report({'ERROR'}, "No clip loaded")
+            return {'CANCELLED'}
+
+        self._tracks = list(clip.tracking.tracks)
+        self._index = 0
+        self._logger = TrackerLogger()
+
+        wm = context.window_manager
+        self._timer = wm.event_timer_add(0.1, window=context.window)
+        wm.modal_handler_add(self)
+        return {'RUNNING_MODAL'}
+
+    def modal(self, context, event):
+        if event.type == 'TIMER':
+            if self._index >= len(self._tracks):
+                context.window_manager.event_timer_remove(self._timer)
+                return {'FINISHED'}
+            track = self._tracks[self._index]
+            if not track.name.startswith("TRACK_"):
+                new_name = f"TRACK_{track.name}"
+                try:
+                    track.name = new_name
+                except RuntimeError as exc:
+                    if self._logger:
+                        self._logger.warn(f"Failed to rename track {track.name} -> {new_name}: {exc}")
+            self._index += 1
+        return {'PASS_THROUGH'}
+
+    def cancel(self, context):
+        if self._timer:
+            context.window_manager.event_timer_remove(self._timer)
+        return {'CANCELLED'}
+
+
+__all__ = ["KAISERLICH_OT_rename_tracks_modal"]


### PR DESCRIPTION
## Summary
- add `detect_features_async` using `bpy.app.timers`
- provide a modal operator to rename tracks asynchronously
- expose the async helpers in package init files
- document async detection option in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68752ee087b4832d9e5f117caa4599ce