### PR TITLE
Add KAISERLICH_OT_detect_features operator

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -19,11 +19,13 @@ from .modules.util.tracker_logger import configure_logger
 
 from .modules.operators.tracksycle_operator import KAISERLICH_OT_auto_track_cycle
 from .modules.operators.rename_tracks_modal import KAISERLICH_OT_rename_tracks_modal
+from .modules.operators.detect_features_operator import KAISERLICH_OT_detect_features
 from .modules.ui.kaiserlich_panel import KAISERLICH_PT_tracking_tools
 
 classes = [
     KAISERLICH_OT_auto_track_cycle,
     KAISERLICH_OT_rename_tracks_modal,
+    KAISERLICH_OT_detect_features,
     KAISERLICH_PT_tracking_tools,
 ]
 

--- a/modules/operators/__init__.py
+++ b/modules/operators/__init__.py
@@ -2,8 +2,10 @@
 
 from .tracksycle_operator import KAISERLICH_OT_auto_track_cycle
 from .rename_tracks_modal import KAISERLICH_OT_rename_tracks_modal
+from .detect_features_operator import KAISERLICH_OT_detect_features
 
 __all__ = [
     "KAISERLICH_OT_auto_track_cycle",
     "KAISERLICH_OT_rename_tracks_modal",
+    "KAISERLICH_OT_detect_features",
 ]

--- a/modules/operators/detect_features_operator.py
+++ b/modules/operators/detect_features_operator.py
@@ -1,0 +1,59 @@
+"""Operator wrapper for feature detection."""
+
+from __future__ import annotations
+
+import bpy
+from bpy.props import FloatProperty
+
+from ..detection.detect_no_proxy import detect_features_no_proxy
+from ..util.tracker_logger import TrackerLogger, configure_logger
+
+
+class KAISERLICH_OT_detect_features(bpy.types.Operator):  # type: ignore[misc]
+    """Detect features on the active movie clip."""
+
+    bl_idname = "kaiserlich.detect_features"
+    bl_label = "Detect Features"
+    bl_options = {'REGISTER', 'UNDO'}
+
+    threshold: FloatProperty(
+        name="Threshold",
+        description="Detection threshold",
+        default=1.0,
+        min=0.0,
+    )
+    margin: FloatProperty(
+        name="Margin",
+        description="Margin around detected features (0 = auto)",
+        default=0.0,
+        min=0.0,
+    )
+    distance: FloatProperty(
+        name="Distance",
+        description="Minimum distance between features (0 = auto)",
+        default=0.0,
+        min=0.0,
+    )
+
+    def execute(self, context):  # type: ignore[override]
+        space = context.space_data
+        clip = getattr(space, "clip", None)
+        if not clip:
+            self.report({'ERROR'}, "No clip loaded")
+            return {'CANCELLED'}
+
+        scene = context.scene
+        configure_logger(debug=getattr(scene, "debug_output", False))
+        logger = TrackerLogger()
+
+        detect_features_no_proxy(
+            clip,
+            threshold=self.threshold,
+            margin=self.margin or None,
+            distance=self.distance or None,
+            logger=logger,
+        )
+        return {'FINISHED'}
+
+
+__all__ = ["KAISERLICH_OT_detect_features"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,5 +4,14 @@ from types import SimpleNamespace
 # Provide dummy bpy and mathutils modules so addon can be imported during tests
 dummy_bpy = sys.modules.setdefault("bpy", SimpleNamespace())
 dummy_bpy.types = SimpleNamespace(Operator=object, Panel=object)
+dummy_bpy.ops = SimpleNamespace(clip=SimpleNamespace(detect_features=lambda **k: None))
+dummy_bpy.props = SimpleNamespace(
+    FloatProperty=lambda *a, **k: None,
+    IntProperty=lambda *a, **k: None,
+    BoolProperty=lambda *a, **k: None,
+    EnumProperty=lambda *a, **k: None,
+)
+sys.modules.setdefault("bpy.ops", dummy_bpy.ops)
+sys.modules.setdefault("bpy.props", dummy_bpy.props)
 mathutils = SimpleNamespace(Vector=lambda *a, **k: None)
 sys.modules.setdefault("mathutils", mathutils)

--- a/tests/test_detect_features_operator.py
+++ b/tests/test_detect_features_operator.py
@@ -1,0 +1,53 @@
+import os, sys
+from types import SimpleNamespace
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from modules.operators.detect_features_operator import KAISERLICH_OT_detect_features
+
+
+class DummyClip:
+    size = (1000, 500)
+    tracking = SimpleNamespace(tracks=[])
+
+
+class DummyContext:
+    def __init__(self, clip):
+        self.scene = SimpleNamespace(debug_output=False)
+        self.space_data = SimpleNamespace(clip=clip)
+
+
+def test_operator_no_clip():
+    op = KAISERLICH_OT_detect_features()
+    op.report = lambda *a, **k: None
+    context = DummyContext(None)
+    result = op.execute(context)
+    assert result == {'CANCELLED'}
+
+
+def test_operator_calls_detection(monkeypatch):
+    called = {}
+
+    def dummy_detect(clip, threshold=1.0, margin=None, distance=None, logger=None):
+        called['args'] = (clip, threshold, margin, distance, logger)
+
+    monkeypatch.setattr(
+        'modules.operators.detect_features_operator.detect_features_no_proxy',
+        dummy_detect,
+    )
+
+    op = KAISERLICH_OT_detect_features()
+    op.report = lambda *a, **k: None
+    op.threshold = 0.5
+    op.margin = 10.0
+    op.distance = 5.0
+    context = DummyContext(DummyClip())
+
+    result = op.execute(context)
+
+    assert result == {'FINISHED'}
+    clip, thr, marg, dist, _ = called['args']
+    assert clip is context.space_data.clip
+    assert thr == 0.5
+    assert marg == 10.0
+    assert dist == 5.0


### PR DESCRIPTION
## Summary
- implement `KAISERLICH_OT_detect_features` as standalone operator
- expose new operator in package init files
- extend test utilities with dummy bpy submodules
- add tests for the new operator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687532bedfe0832d9c1c3760b7186117