### PR TITLE
Fix integer margin for feature detection

### DIFF
--- a/modules/detection/detect_no_proxy.py
+++ b/modules/detection/detect_no_proxy.py
@@ -12,7 +12,7 @@ def detect_features_no_proxy(clip, threshold=1.0, margin=None, distance=None, lo
         The movie clip on which to perform feature detection.
     threshold : float, optional
         Detection threshold, defaults to ``1.0``.
-    margin : float, optional
+    margin : int, optional
         Margin value passed to the operator. If ``None`` it is derived from
         ``clip.size``.
     distance : float, optional
@@ -23,6 +23,7 @@ def detect_features_no_proxy(clip, threshold=1.0, margin=None, distance=None, lo
     """
     if margin is None:
         margin = clip.size[0] / 200
+    margin = int(margin)
     if distance is None:
         distance = clip.size[0] / 20
 


### PR DESCRIPTION
## Summary
- convert `margin` to `int` when detecting features without proxies
- update docs accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68753c714604832dba25312aa1afa3bb