### PR TITLE
Fix min_distance parameter in detection ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ from modules.proxy.proxy_wait import create_proxy_and_wait
 ### 2. **Detect Features**
 
 ```python
-bpy.ops.clip.detect_features(threshold=dynamic, margin=width/200, distance=width/20)
+bpy.ops.clip.detect_features(threshold=dynamic, margin=width/200, min_distance=width/20)
 ```
 
 * Proxy-Status wird vor jedem Aufruf deaktiviert: `clip.proxy.build_50 = False`, `clip.use_proxy = False`

--- a/modules/detection/async_detection.py
+++ b/modules/detection/async_detection.py
@@ -8,52 +8,52 @@ from .detect_no_proxy import detect_features_no_proxy
 
 
 def detect_features_async(scene, clip, logger=None, attempts=10):
-     """Detect features asynchronously via :mod:`bpy.app.timers`.
+    """Detect features asynchronously via :mod:`bpy.app.timers`.
 
-     Parameters
-     ----------
-     scene : :class:`bpy.types.Scene`
-         Scene containing detection settings like ``min_marker_count``.
-     clip : :class:`bpy.types.MovieClip`
-         Movie clip on which features should be detected.
-     logger : :class:`TrackerLogger`, optional
-         Logger for debug output.
-     attempts : int, optional
-         Maximum number of detection attempts. Defaults to 10.
-     """
+    Parameters
+    ----------
+    scene : :class:`bpy.types.Scene`
+        Scene containing detection settings like ``min_marker_count``.
+    clip : :class:`bpy.types.MovieClip`
+        Movie clip on which features should be detected.
+    logger : :class:`TrackerLogger`, optional
+        Logger for debug output.
+    attempts : int, optional
+        Maximum number of detection attempts. Defaults to 10.
+    """
 
-     settings = clip.tracking.settings
-     state = {
-         "attempt": 0,
-         "threshold": 1.0,
-         "pattern_size": getattr(settings, "default_pattern_size", 11),
-         "expected": getattr(scene, "min_marker_count", 10) * 4,
-     }
+    settings = clip.tracking.settings
+    state = {
+        "attempt": 0,
+        "threshold": 1.0,
+        "pattern_size": getattr(settings, "default_pattern_size", 11),
+        "expected": getattr(scene, "min_marker_count", 10) * 4,
+    }
 
-     def _step():
-         detect_features_no_proxy(
-             clip,
-             threshold=state["threshold"],
-             margin=clip.size[0] / 200,
-             distance=clip.size[0] / 20,
-             logger=logger,
-         )
-         marker_count = len(clip.tracking.tracks)
-         if marker_count >= getattr(scene, "min_marker_count", 10) or state["attempt"] >= attempts:
-             return None
-         state["threshold"] = max(
-             round(state["threshold"] * ((marker_count + 0.1) / state["expected"]), 5),
-             0.0001,
-         )
-         if state["pattern_size"] < 100:
-             state["pattern_size"] = min(int(state["pattern_size"] * 1.1), 100)
-             settings.default_pattern_size = state["pattern_size"]
-             if logger:
-                 logger.debug(f"Pattern size adjusted to {state['pattern_size']}")
-         state["attempt"] += 1
-         return 0.1
+    def _step():
+        detect_features_no_proxy(
+            clip,
+            threshold=state["threshold"],
+            margin=clip.size[0] / 200,
+            min_distance=clip.size[0] / 20,
+            logger=logger,
+        )
+        marker_count = len(clip.tracking.tracks)
+        if marker_count >= getattr(scene, "min_marker_count", 10) or state["attempt"] >= attempts:
+            return None
+        state["threshold"] = max(
+            round(state["threshold"] * ((marker_count + 0.1) / state["expected"]), 5),
+            0.0001,
+        )
+        if state["pattern_size"] < 100:
+            state["pattern_size"] = min(int(state["pattern_size"] * 1.1), 100)
+            settings.default_pattern_size = state["pattern_size"]
+            if logger:
+                logger.debug(f"Pattern size adjusted to {state['pattern_size']}")
+        state["attempt"] += 1
+        return 0.1
 
-     bpy.app.timers.register(_step)
+    bpy.app.timers.register(_step)
 
 
 __all__ = ["detect_features_async"]

--- a/modules/detection/detect_no_proxy.py
+++ b/modules/detection/detect_no_proxy.py
@@ -3,7 +3,7 @@
 import bpy
 
 
-def detect_features_no_proxy(clip, threshold=1.0, margin=None, distance=None, logger=None):
+def detect_features_no_proxy(clip, threshold=1.0, margin=None, min_distance=None, logger=None):
     """Run :func:`bpy.ops.clip.detect_features` with proxies disabled.
 
     Parameters
@@ -15,7 +15,7 @@ def detect_features_no_proxy(clip, threshold=1.0, margin=None, distance=None, lo
     margin : int, optional
         Margin value passed to the operator. If ``None`` it is derived from
         ``clip.size``.
-    distance : float, optional
+    min_distance : float, optional
         Minimum distance between detected features. If ``None`` it is derived
         from ``clip.size``.
     logger : :class:`TrackerLogger`, optional
@@ -24,12 +24,12 @@ def detect_features_no_proxy(clip, threshold=1.0, margin=None, distance=None, lo
     if margin is None:
         margin = clip.size[0] / 200
     margin = int(margin)
-    if distance is None:
-        distance = clip.size[0] / 20
+    if min_distance is None:
+        min_distance = clip.size[0] / 20
 
     message = (
         f"Detecting features with threshold={threshold}, "
-        f"margin={margin}, distance={distance}"
+        f"margin={margin}, min_distance={min_distance}"
     )
     if logger:
         logger.debug(message)
@@ -43,7 +43,7 @@ def detect_features_no_proxy(clip, threshold=1.0, margin=None, distance=None, lo
     bpy.ops.clip.detect_features(
         threshold=threshold,
         margin=margin,
-        distance=distance,
+        min_distance=min_distance,
     )
 
 __all__ = ["detect_features_no_proxy"]

--- a/modules/operators/detect_features_operator.py
+++ b/modules/operators/detect_features_operator.py
@@ -28,8 +28,8 @@ class KAISERLICH_OT_detect_features(bpy.types.Operator):  # type: ignore[misc]
         default=0.0,
         min=0.0,
     )
-    distance: FloatProperty(
-        name="Distance",
+    min_distance: FloatProperty(
+        name="Min Distance",
         description="Minimum distance between features (0 = auto)",
         default=0.0,
         min=0.0,
@@ -50,7 +50,7 @@ class KAISERLICH_OT_detect_features(bpy.types.Operator):  # type: ignore[misc]
             clip,
             threshold=self.threshold,
             margin=self.margin or None,
-            distance=self.distance or None,
+            min_distance=self.min_distance or None,
             logger=logger,
         )
         return {'FINISHED'}

--- a/modules/operators/tracksycle_operator.py
+++ b/modules/operators/tracksycle_operator.py
@@ -54,7 +54,7 @@ class KAISERLICH_OT_auto_track_cycle(bpy.types.Operator):
                 clip,
                 threshold=threshold,
                 margin=clip.size[0] / 200,
-                distance=clip.size[0] / 20,
+                min_distance=clip.size[0] / 20,
                 logger=logger,
             )
             marker_count = len(clip.tracking.tracks)

--- a/tests/test_detect_features_operator.py
+++ b/tests/test_detect_features_operator.py
@@ -28,8 +28,8 @@ def test_operator_no_clip():
 def test_operator_calls_detection(monkeypatch):
     called = {}
 
-    def dummy_detect(clip, threshold=1.0, margin=None, distance=None, logger=None):
-        called['args'] = (clip, threshold, margin, distance, logger)
+    def dummy_detect(clip, threshold=1.0, margin=None, min_distance=None, logger=None):
+        called['args'] = (clip, threshold, margin, min_distance, logger)
 
     monkeypatch.setattr(
         'modules.operators.detect_features_operator.detect_features_no_proxy',
@@ -40,7 +40,7 @@ def test_operator_calls_detection(monkeypatch):
     op.report = lambda *a, **k: None
     op.threshold = 0.5
     op.margin = 10.0
-    op.distance = 5.0
+    op.min_distance = 5.0
     context = DummyContext(DummyClip())
 
     result = op.execute(context)


### PR DESCRIPTION
## Summary
- use correct `min_distance` parameter for `bpy.ops.clip.detect_features`
- update async detection utility with new parameter name
- rename property in detect features operator
- adjust tracking cycle operator calls
- update README snippet and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875459bf8c0832dae73be0c0897a155