### PR TITLE
Fix integer type for min_distance

### DIFF
--- a/modules/detection/async_detection.py
+++ b/modules/detection/async_detection.py
@@ -35,7 +35,7 @@ def detect_features_async(scene, clip, logger=None, attempts=10):
             clip,
             threshold=state["threshold"],
             margin=clip.size[0] / 200,
-            min_distance=clip.size[0] / 20,
+            min_distance=int(clip.size[0] / 20),
             logger=logger,
         )
         marker_count = len(clip.tracking.tracks)

--- a/modules/detection/detect_no_proxy.py
+++ b/modules/detection/detect_no_proxy.py
@@ -15,7 +15,7 @@ def detect_features_no_proxy(clip, threshold=1.0, margin=None, min_distance=None
     margin : int, optional
         Margin value passed to the operator. If ``None`` it is derived from
         ``clip.size``.
-    min_distance : float, optional
+    min_distance : int, optional
         Minimum distance between detected features. If ``None`` it is derived
         from ``clip.size``.
     logger : :class:`TrackerLogger`, optional
@@ -26,6 +26,7 @@ def detect_features_no_proxy(clip, threshold=1.0, margin=None, min_distance=None
     margin = int(margin)
     if min_distance is None:
         min_distance = clip.size[0] / 20
+    min_distance = int(min_distance)
 
     message = (
         f"Detecting features with threshold={threshold}, "

--- a/modules/operators/detect_features_operator.py
+++ b/modules/operators/detect_features_operator.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import bpy
-from bpy.props import FloatProperty
+from bpy.props import FloatProperty, IntProperty
 
 from ..detection.detect_no_proxy import detect_features_no_proxy
 from ..util.tracker_logger import TrackerLogger, configure_logger
@@ -28,11 +28,11 @@ class KAISERLICH_OT_detect_features(bpy.types.Operator):  # type: ignore[misc]
         default=0.0,
         min=0.0,
     )
-    min_distance: FloatProperty(
+    min_distance: IntProperty(
         name="Min Distance",
         description="Minimum distance between features (0 = auto)",
-        default=0.0,
-        min=0.0,
+        default=0,
+        min=0,
     )
 
     def execute(self, context):  # type: ignore[override]

--- a/modules/operators/tracksycle_operator.py
+++ b/modules/operators/tracksycle_operator.py
@@ -54,7 +54,7 @@ class KAISERLICH_OT_auto_track_cycle(bpy.types.Operator):
                 clip,
                 threshold=threshold,
                 margin=clip.size[0] / 200,
-                min_distance=clip.size[0] / 20,
+                min_distance=int(clip.size[0] / 20),
                 logger=logger,
             )
             marker_count = len(clip.tracking.tracks)

--- a/tests/test_detect_features_operator.py
+++ b/tests/test_detect_features_operator.py
@@ -40,7 +40,7 @@ def test_operator_calls_detection(monkeypatch):
     op.report = lambda *a, **k: None
     op.threshold = 0.5
     op.margin = 10.0
-    op.min_distance = 5.0
+    op.min_distance = 5
     context = DummyContext(DummyClip())
 
     result = op.execute(context)
@@ -50,4 +50,4 @@ def test_operator_calls_detection(monkeypatch):
     assert clip is context.space_data.clip
     assert thr == 0.5
     assert marg == 10.0
-    assert dist == 5.0
+    assert dist == 5


### PR DESCRIPTION
## Summary
- cast `min_distance` to int in detection utilities
- update tracksycle operator to pass integer distance
- use `IntProperty` for operator option
- adjust related tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68754a81af30832da7cd8c2fa4ec1adb