### PR TITLE
Fix track removal with index

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ REVIEW / LOOP
 | Kontext setzen        | `context.temp_override()`                        |
 | Pattern Size setzen   | `clip.tracking.settings.default_pattern_size`    |
 | Motion Model wechseln | `clip.tracking.settings.motion_model = 'Affine'` |
-| Tracks löschen        | `clip.tracking.tracks.remove(...)`               |
+| Tracks löschen        | `idx = clip.tracking.tracks.find(name)`<br>`clip.tracking.tracks.remove(idx)` |
 | Playhead setzen       | `context.scene.frame_current = frame`            |
 
 ---

--- a/modules/detection/distance_remove.py
+++ b/modules/detection/distance_remove.py
@@ -13,5 +13,7 @@ def distance_remove(tracks, good_marker, margin):
         except (AttributeError, IndexError):
             continue
         if (Vector(pos) - good_pos).length < margin:
-            tracks.remove(track)
+            idx = tracks.find(track.name)
+            if idx != -1:
+                tracks.remove(idx)
 

--- a/modules/operators/tracksycle_operator.py
+++ b/modules/operators/tracksycle_operator.py
@@ -96,7 +96,10 @@ class KAISERLICH_OT_auto_track_cycle(bpy.types.Operator):
 
         for track in list(clip.tracking.tracks):
             if get_track_length(track) < scene.min_track_length:
-                clip.tracking.tracks.remove(track)
+                tracks = clip.tracking.tracks
+                idx = tracks.find(track.name)
+                if idx != -1:
+                    tracks.remove(idx)
 
         sparse_frame = find_frame_with_few_tracking_markers(clip, scene.min_marker_count)
         if sparse_frame is not None:

--- a/tests/test_distance_remove.py
+++ b/tests/test_distance_remove.py
@@ -23,8 +23,14 @@ class DummyTrack:
     name = "DUMMY"
 
 class DummyTracks(list):
-    def remove(self, track):
-        super().remove(track)
+    def find(self, name):
+        for i, tr in enumerate(self):
+            if tr.name == name:
+                return i
+        return -1
+
+    def remove(self, index):
+        del self[index]
         self.removed = True
 
 def test_distance_remove_empty_markers():


### PR DESCRIPTION
## Summary
- fix incorrect use of `tracks.remove(track)`
- remove tracks via `find` index
- update distance remove helper and related test
- document recommended track removal in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687550d18488832da213a09211ac24d9