### PR TITLE
Add proxy timecode setting

### DIFF
--- a/modules/proxy/proxy_wait.py
+++ b/modules/proxy/proxy_wait.py
@@ -73,6 +73,7 @@ def create_proxy_and_wait(clip, timeout=300, logger=None):
     try:
         clip.use_proxy = True
         clip.proxy.build_50 = True
+        clip.proxy.use_timecode = 'RECORD_RUN'
         # clip.proxy.build_proxy() gibt es so nicht – stattdessen ggf. durch Timer auf das File warten wie bisher
     except Exception as e:  # pylint: disable=broad-except
         if logger:


### PR DESCRIPTION
## Summary
- set the proxy timecode to `RECORD_RUN` when enabling the proxy

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687555af4028832d91f6d98fc207eee9