### PR TITLE
Use track object removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ REVIEW / LOOP
 | Kontext setzen        | `context.temp_override()`                        |
 | Pattern Size setzen   | `clip.tracking.settings.default_pattern_size`    |
 | Motion Model wechseln | `clip.tracking.settings.motion_model = 'Affine'` |
-| Tracks löschen        | `idx = clip.tracking.tracks.find(name)`<br>`clip.tracking.tracks.remove(idx)` |
+| Tracks löschen        | `track = clip.tracking.tracks.get(name)`<br>`clip.tracking.tracks.remove(track)` |
 | Playhead setzen       | `context.scene.frame_current = frame`            |
 
 ---

--- a/modules/detection/distance_remove.py
+++ b/modules/detection/distance_remove.py
@@ -13,7 +13,5 @@ def distance_remove(tracks, good_marker, margin):
         except (AttributeError, IndexError):
             continue
         if (Vector(pos) - good_pos).length < margin:
-            idx = tracks.find(track.name)
-            if idx != -1:
-                tracks.remove(idx)
+            tracks.remove(track)
 

--- a/modules/operators/tracksycle_operator.py
+++ b/modules/operators/tracksycle_operator.py
@@ -96,10 +96,7 @@ class KAISERLICH_OT_auto_track_cycle(bpy.types.Operator):
 
         for track in list(clip.tracking.tracks):
             if get_track_length(track) < scene.min_track_length:
-                tracks = clip.tracking.tracks
-                idx = tracks.find(track.name)
-                if idx != -1:
-                    tracks.remove(idx)
+                clip.tracking.tracks.remove(track)
 
         sparse_frame = find_frame_with_few_tracking_markers(clip, scene.min_marker_count)
         if sparse_frame is not None:

--- a/tests/test_distance_remove.py
+++ b/tests/test_distance_remove.py
@@ -29,8 +29,13 @@ class DummyTracks(list):
                 return i
         return -1
 
-    def remove(self, index):
-        del self[index]
+    def remove(self, track):
+        self.remove_called_with = track
+        try:
+            idx = self.index(track)
+        except ValueError:
+            return
+        del self[idx]
         self.removed = True
 
 def test_distance_remove_empty_markers():


### PR DESCRIPTION
## Summary
- remove tracks directly via objects instead of indices
- update README instructions for deleting tracks
- adjust dummy tracks in tests to remove by object

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68756066f7c8832dbec7a50967becb0f