### PR TITLE
Fix proxy rebuild call

### DIFF
--- a/modules/operators/tracksycle_operator.py
+++ b/modules/operators/tracksycle_operator.py
@@ -46,7 +46,7 @@ class KAISERLICH_OT_auto_track_cycle(bpy.types.Operator):
             if area.type == 'CLIP_EDITOR':
                 ctx['area'] = area
                 break
-        bpy.ops.clip.rebuild_proxy(ctx)
+        bpy.ops.clip.rebuild_proxy('INVOKE_DEFAULT')
 
         # state machine property
         scene.kaiserlich_tracking_state = 'WAIT_FOR_PROXY'


### PR DESCRIPTION
## Summary
- fix `rebuild_proxy` invocation so it uses `INVOKE_DEFAULT`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687567755d24832d96f1a5db5da35dbe