### PR TITLE
Switch to async proxy creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Der Operator `KAISERLICH_OT_auto_track_cycle` durchläuft automatisch folgende S
 ### 1. **Proxy-Handling (async)**
 
 ```python
-from modules.proxy.proxy_wait import create_proxy_and_wait
+from modules.proxy.proxy_wait import create_proxy_and_wait_async
 ```
 
 * Entfernt zuvor generierte Proxy-Dateien via `remove_existing_proxies()`

--- a/modules/operators/tracksycle_operator.py
+++ b/modules/operators/tracksycle_operator.py
@@ -2,7 +2,10 @@
 
 import bpy
 
-from ..proxy.proxy_wait import create_proxy_and_wait, remove_existing_proxies
+from ..proxy.proxy_wait import (
+    create_proxy_and_wait_async,
+    remove_existing_proxies,
+)
 from ..detection.distance_remove import distance_remove
 from ..detection.detect_no_proxy import detect_features_no_proxy
 from ..detection.find_frame_with_few_tracking_markers import (
@@ -51,79 +54,90 @@ class KAISERLICH_OT_auto_track_cycle(bpy.types.Operator):
         # state machine property
         scene.kaiserlich_tracking_state = 'WAIT_FOR_PROXY'
 
+        def nach_proxy():
+            scene.kaiserlich_tracking_state = 'DETECTING'
+
+            settings = clip.tracking.settings
+            threshold = 1.0
+            expected = scene.min_marker_count * 4
+            pattern_size = getattr(settings, "default_pattern_size", 11)
+
+            for _ in range(10):
+                detect_features_no_proxy(
+                    clip,
+                    threshold=threshold,
+                    margin=clip.size[0] / 200,
+                    min_distance=int(clip.size[0] / 20),
+                    logger=logger,
+                )
+                marker_count = len(clip.tracking.tracks)
+                if marker_count >= scene.min_marker_count:
+                    break
+                threshold = max(round(threshold * ((marker_count + 0.1) / expected), 5), 0.0001)
+                logger.debug(f"Threshold adjusted to {threshold}")
+                if pattern_size < 100:
+                    pattern_size = min(int(pattern_size * 1.1), 100)
+                    settings.default_pattern_size = pattern_size
+                    logger.debug(f"Pattern size adjusted to {pattern_size}")
+
+            scene.kaiserlich_tracking_state = 'TRACKING'
+
+            # Filter markers near GOOD_ markers
+            margin = clip.size[0] / 20
+            for track in list(clip.tracking.tracks):
+                if track.name.startswith("GOOD_"):
+                    try:
+                        marker_co = track.markers[0].co
+                    except (IndexError, AttributeError):
+                        logger.warn(
+                            f"Track {track.name} has no markers; skipping distance check"
+                        )
+                        continue
+                    distance_remove(clip.tracking.tracks, marker_co, margin)
+
+            for track in clip.tracking.tracks:
+                if not track.name.startswith("TRACK_"):
+                    new_name = f"TRACK_{track.name}"
+                    try:
+                        track.name = new_name
+                    except RuntimeError as exc:
+                        logger.warn(
+                            f"Failed to rename track {track.name} -> {new_name}: {exc}"
+                        )
+
+            if not track_markers(context, logger=logger):
+                self.report(
+                    {'ERROR'},
+                    "Tracking markers failed; check console for details",
+                )
+                return
+
+            scene.kaiserlich_tracking_state = 'CLEANUP'
+
+            for track in list(clip.tracking.tracks):
+                if get_track_length(track) < scene.min_track_length:
+                    clip.tracking.tracks.remove(track)
+
+            sparse_frame = find_frame_with_few_tracking_markers(
+                clip, scene.min_marker_count
+            )
+            if sparse_frame is not None:
+                next_model(settings)
+                if pattern_size < 100:
+                    pattern_size = min(int(pattern_size * 1.1), 100)
+                    settings.default_pattern_size = pattern_size
+                    logger.debug(f"Pattern size adjusted to {pattern_size}")
+                set_playhead(sparse_frame)
+
+            scene.kaiserlich_tracking_state = 'REVIEW'
+            logger.info("Tracking cycle finished")
+
         remove_existing_proxies(clip, logger=logger)
         logger.info("Generating proxy...")
-        if not create_proxy_and_wait(clip, logger=logger):
+        if not create_proxy_and_wait_async(clip, callback=nach_proxy, logger=logger):
             self.report({'ERROR'}, "Proxy creation timed out")
             return {'CANCELLED'}
 
-        scene.kaiserlich_tracking_state = 'DETECTING'
-
-        settings = clip.tracking.settings
-        threshold = 1.0
-        expected = scene.min_marker_count * 4
-        pattern_size = getattr(settings, "default_pattern_size", 11)
-
-        for _ in range(10):
-            detect_features_no_proxy(
-                clip,
-                threshold=threshold,
-                margin=clip.size[0] / 200,
-                min_distance=int(clip.size[0] / 20),
-                logger=logger,
-            )
-            marker_count = len(clip.tracking.tracks)
-            if marker_count >= scene.min_marker_count:
-                break
-            threshold = max(round(threshold * ((marker_count + 0.1) / expected), 5), 0.0001)
-            logger.debug(f"Threshold adjusted to {threshold}")
-            if pattern_size < 100:
-                pattern_size = min(int(pattern_size * 1.1), 100)
-                settings.default_pattern_size = pattern_size
-                logger.debug(f"Pattern size adjusted to {pattern_size}")
-
-        scene.kaiserlich_tracking_state = 'TRACKING'
-
-        # Filter markers near GOOD_ markers
-        margin = clip.size[0] / 20
-        for track in list(clip.tracking.tracks):
-            if track.name.startswith("GOOD_"):
-                try:
-                    marker_co = track.markers[0].co
-                except (IndexError, AttributeError):
-                    logger.warn(f"Track {track.name} has no markers; skipping distance check")
-                    continue
-                distance_remove(clip.tracking.tracks, marker_co, margin)
-
-        for track in clip.tracking.tracks:
-            if not track.name.startswith("TRACK_"):
-                new_name = f"TRACK_{track.name}"
-                try:
-                    track.name = new_name
-                except RuntimeError as exc:
-                    logger.warn(f"Failed to rename track {track.name} -> {new_name}: {exc}")
-
-        if not track_markers(context, logger=logger):
-            self.report({'ERROR'}, "Tracking markers failed; check console for details")
-            return {'CANCELLED'}
-
-        scene.kaiserlich_tracking_state = 'CLEANUP'
-
-        for track in list(clip.tracking.tracks):
-            if get_track_length(track) < scene.min_track_length:
-                clip.tracking.tracks.remove(track)
-
-        sparse_frame = find_frame_with_few_tracking_markers(clip, scene.min_marker_count)
-        if sparse_frame is not None:
-            next_model(settings)
-            if pattern_size < 100:
-                pattern_size = min(int(pattern_size * 1.1), 100)
-                settings.default_pattern_size = pattern_size
-                logger.debug(f"Pattern size adjusted to {pattern_size}")
-            set_playhead(sparse_frame)
-
-        scene.kaiserlich_tracking_state = 'REVIEW'
-        logger.info("Tracking cycle finished")
         return {'FINISHED'}
 
 

--- a/modules/proxy/proxy_wait.py
+++ b/modules/proxy/proxy_wait.py
@@ -115,3 +115,88 @@ def create_proxy_and_wait(clip, timeout=300, logger=None):
     return True
 
 
+def create_proxy_and_wait_async(clip, callback=None, timeout=300, logger=None):
+    """Create a 50% proxy and run ``callback`` once it exists.
+
+    This works like :func:`create_proxy_and_wait` but executes the
+    provided ``callback`` after the proxy file was detected.  The
+    function itself returns immediately after registering the timer.
+
+    Parameters
+    ----------
+    clip : :class:`bpy.types.MovieClip`
+        Movie clip for which the proxy should be generated.
+    callback : callable, optional
+        Function to run after the proxy has been created.  If ``None``
+        no callback is executed.
+    timeout : int, optional
+        Maximum time to wait for the proxy in seconds.
+    logger : :class:`TrackerLogger`, optional
+        Logger used for debug output.
+    """
+
+    if clip is None:
+        message = "No clip provided to create_proxy_and_wait_async"
+        if logger:
+            logger.error(message)
+        else:
+            print(f"ERROR: {message}")
+        return False
+
+    # enable proxies before generating them
+    clip.use_proxy = True
+    clip.use_proxy_custom_directory = True
+    if not clip.proxy.directory:
+        if logger:
+            logger.warn("Proxy directory was not set; using default '//proxies'")
+        clip.proxy.directory = "//proxies"
+
+    directory = bpy.path.abspath(clip.proxy.directory)
+    try:
+        os.makedirs(directory, exist_ok=True)
+    except OSError as exc:
+        message = f"Failed to create proxy directory: {directory} ({exc})"
+        if logger:
+            logger.error(message)
+        else:
+            print(f"ERROR: {message}")
+        return False
+
+    proxy_path = os.path.join(directory, "proxy_50.avi")
+
+    try:
+        clip.proxy.build_50 = True
+    except Exception as e:  # pylint: disable=broad-except
+        if logger:
+            logger.error(f"Proxy-Build-Setup fehlgeschlagen: {e}")
+        else:
+            print(f"ERROR: Proxy-Build-Setup fehlgeschlagen: {e}")
+        return False
+
+    if logger:
+        logger.info(f"Waiting for proxy file: {proxy_path}")
+
+    state = {"start": time.time()}
+
+    def _wait_for_proxy():
+        if os.path.exists(proxy_path):
+            if logger:
+                logger.info("Proxy file found.")
+            if callback:
+                callback()
+            return None
+        elapsed = time.time() - state["start"]
+        if elapsed > timeout:
+            if logger:
+                logger.error(f"Proxy creation timed out after {timeout} seconds.")
+            if callback:
+                callback()
+            return None
+        if logger:
+            logger.info(f"Proxy not found yet... {int(elapsed)}s elapsed")
+        return 1.0
+
+    bpy.app.timers.register(_wait_for_proxy)
+    return True
+
+


### PR DESCRIPTION
## Summary
- add `create_proxy_and_wait_async` helper
- use callback-based proxy creation in the tracking operator
- update README to reference async function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68756c1d76c4832d95cf5626f4058489