### PR TITLE
Add delayed_call helper

### DIFF
--- a/modules/detection/async_detection.py
+++ b/modules/detection/async_detection.py
@@ -56,4 +56,18 @@ def detect_features_async(scene, clip, logger=None, attempts=10):
     bpy.app.timers.register(_step)
 
 
-__all__ = ["detect_features_async"]
+
+def delayed_call(callback, delay=0.1):
+    """Execute ``callback`` after ``delay`` seconds if a clip is active."""
+
+    def _delayed():
+        if not getattr(bpy.context.space_data, "clip", None):
+            print("Kein Clip verf\u00fcgbar \u2013 Feature Detection abgebrochen.")
+            return None
+        callback()
+        return None
+
+    bpy.app.timers.register(_delayed, first_interval=delay)
+
+
+__all__ = ["detect_features_async", "delayed_call"]


### PR DESCRIPTION
## Summary
- provide `delayed_call` utility in `async_detection`
- call feature detection only if a clip is present

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687570826b90832dbc1f1e383ed4dbe1