### PR TITLE
Add stable file wait for proxy creation

### DIFF
--- a/tests/test_proxy_wait.py
+++ b/tests/test_proxy_wait.py
@@ -1,0 +1,29 @@
+import os
+import threading
+import time
+import pytest
+
+from modules.proxy.proxy_wait import wait_for_stable_file
+
+
+def test_wait_for_stable_file(tmp_path):
+    path = tmp_path / "file.txt"
+
+    def writer():
+        with open(path, "wb") as fh:
+            fh.write(b"a")
+        time.sleep(0.2)
+        with open(path, "ab") as fh:
+            fh.write(b"b")
+
+    t = threading.Thread(target=writer)
+    t.start()
+
+    assert wait_for_stable_file(path, timeout=2, check_interval=0.1, stable_time=3)
+    t.join()
+
+
+def test_wait_for_stable_file_timeout(tmp_path):
+    path = tmp_path / "missing.txt"
+    with pytest.raises(TimeoutError):
+        wait_for_stable_file(path, timeout=0.3, check_interval=0.1, stable_time=2)


### PR DESCRIPTION
## Summary
- add `wait_for_stable_file` helper to monitor file size stability
- use it in proxy creation helpers
- export functions via `__all__`
- test waiting logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687574c6c34c832dbf1ad89fa650fa32