### PR TITLE
Fix detect_features call context

### DIFF
--- a/modules/detection/detect_no_proxy.py
+++ b/modules/detection/detect_no_proxy.py
@@ -42,6 +42,7 @@ def detect_features_no_proxy(clip, threshold=1.0, margin=None, min_distance=None
     clip.use_proxy = False
 
     bpy.ops.clip.detect_features(
+        "EXEC_DEFAULT",
         threshold=threshold,
         margin=margin,
         min_distance=min_distance,

--- a/modules/operators/tracksycle_operator.py
+++ b/modules/operators/tracksycle_operator.py
@@ -70,6 +70,7 @@ class KAISERLICH_OT_auto_track_cycle(bpy.types.Operator):
 
                         bpy.ops.clip.detect_features(
                             override,
+                            "EXEC_DEFAULT",
                             threshold=1.0,
                             margin=26,
                             min_distance=265,

--- a/modules/proxy/proxy_wait.py
+++ b/modules/proxy/proxy_wait.py
@@ -278,6 +278,7 @@ def detect_features_in_ui_context(threshold=1.0, margin=0, min_distance=0, place
                         logger.info("Running feature detection in UI context")
                     bpy.ops.clip.detect_features(
                         override,
+                        "EXEC_DEFAULT",
                         threshold=threshold,
                         margin=margin,
                         min_distance=min_distance,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,9 @@ from types import SimpleNamespace
 # Provide dummy bpy and mathutils modules so addon can be imported during tests
 dummy_bpy = sys.modules.setdefault("bpy", SimpleNamespace())
 dummy_bpy.types = SimpleNamespace(Operator=object, Panel=object)
-dummy_bpy.ops = SimpleNamespace(clip=SimpleNamespace(detect_features=lambda **k: None))
+dummy_bpy.ops = SimpleNamespace(
+    clip=SimpleNamespace(detect_features=lambda *a, **k: None)
+)
 dummy_bpy.props = SimpleNamespace(
     FloatProperty=lambda *a, **k: None,
     IntProperty=lambda *a, **k: None,


### PR DESCRIPTION
## Summary
- pass `"EXEC_DEFAULT"` when invoking `bpy.ops.clip.detect_features`
- adjust proxies and tracking operators accordingly
- make dummy `bpy.ops.clip.detect_features` handle positional args
- update tests for the new operator call signature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68758bb987cc832db4dd3861f04d0558