### PR TITLE
Improve context safety for clip operations

### DIFF
--- a/modules/proxy/proxy_wait.py
+++ b/modules/proxy/proxy_wait.py
@@ -268,23 +268,27 @@ def detect_features_in_ui_context(threshold=1.0, margin=0, min_distance=0, place
         if area.type == 'CLIP_EDITOR':
             for region in area.regions:
                 if region.type == 'WINDOW':
-                    override = {
-                        'area': area,
-                        'region': region,
-                        'space_data': area.spaces.active,
-                        'scene': bpy.context.scene,
-                    }
-                    if logger:
-                        logger.info("Running feature detection in UI context")
-                    bpy.ops.clip.detect_features(
-                        override,
-                        "EXEC_DEFAULT",
-                        threshold=threshold,
-                        margin=margin,
-                        min_distance=min_distance,
-                        placement=placement,
-                    )
-                    return True
+                    spaces = area.spaces
+                    try:
+                        space_iter = list(spaces)
+                    except TypeError:
+                        space_iter = [spaces.active]
+                    for space in space_iter:
+                        if space.type == 'CLIP_EDITOR':
+                            if logger:
+                                logger.info("Running feature detection in UI context")
+                            with bpy.context.temp_override(
+                                area=area,
+                                region=region,
+                                space_data=space,
+                            ):
+                                bpy.ops.clip.detect_features(
+                                    threshold=threshold,
+                                    margin=margin,
+                                    min_distance=min_distance,
+                                    placement=placement,
+                                )
+                            return True
     if logger:
         logger.error("No valid UI context found")
     else:

--- a/tests/test_proxy_wait.py
+++ b/tests/test_proxy_wait.py
@@ -42,18 +42,29 @@ def test_detect_features_in_ui_context(monkeypatch):
         SimpleNamespace(
             type="CLIP_EDITOR",
             regions=[SimpleNamespace(type="WINDOW")],
-            spaces=SimpleNamespace(active="active"),
+            spaces=SimpleNamespace(active=SimpleNamespace(type="CLIP_EDITOR"), __iter__=lambda self: iter([self.active])),
         )
     ]
+    class DummyOverride:
+        def __init__(self, **_kw):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            return False
+
     dummy_context = SimpleNamespace(
         window=SimpleNamespace(screen=SimpleNamespace(areas=areas)),
         scene="scene",
+        temp_override=lambda **kw: DummyOverride(**kw),
     )
 
     import bpy  # provided by conftest
 
     bpy.context = dummy_context
-    bpy.ops.clip.detect_features = lambda override=None, exec_ctx=None, **k: called.update({"override": override, "ctx": exec_ctx, **k})
+    bpy.ops.clip.detect_features = lambda *a, **k: called.update({"override": a[0] if a else None, **k})
 
     result = detect_features_in_ui_context(threshold=0.2, margin=5, min_distance=3, placement="FRAME")
     assert result is True
@@ -61,8 +72,7 @@ def test_detect_features_in_ui_context(monkeypatch):
     assert called["margin"] == 5
     assert called["min_distance"] == 3
     assert called["placement"] == "FRAME"
-    assert called["override"]["area"] is areas[0]
-    assert called["ctx"] == "EXEC_DEFAULT"
+    assert called["override"] is None
 
 
 def test_wait_for_proxy_and_trigger_detection(tmp_path, monkeypatch):
@@ -72,12 +82,23 @@ def test_wait_for_proxy_and_trigger_detection(tmp_path, monkeypatch):
         SimpleNamespace(
             type="CLIP_EDITOR",
             regions=[SimpleNamespace(type="WINDOW")],
-            spaces=SimpleNamespace(active="active"),
+            spaces=SimpleNamespace(active=SimpleNamespace(type="CLIP_EDITOR"), __iter__=lambda self: iter([self.active])),
         )
     ]
+    class DummyOverride:
+        def __init__(self, **_kw):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            return False
+
     dummy_context = SimpleNamespace(
         window=SimpleNamespace(screen=SimpleNamespace(areas=areas)),
         scene="scene",
+        temp_override=lambda **kw: DummyOverride(**kw),
     )
 
     import bpy  # provided by conftest
@@ -89,7 +110,7 @@ def test_wait_for_proxy_and_trigger_detection(tmp_path, monkeypatch):
         fn()
 
     bpy.app = SimpleNamespace(timers=SimpleNamespace(register=dummy_register))
-    bpy.ops.clip.detect_features = lambda *a, **k: calls.update({"called": True, "ctx": a[1] if len(a) > 1 else None})
+    bpy.ops.clip.detect_features = lambda *a, **k: calls.update({"called": True})
 
     # run threads immediately
     monkeypatch.setattr(threading.Thread, "start", lambda self: self.run())
@@ -101,4 +122,3 @@ def test_wait_for_proxy_and_trigger_detection(tmp_path, monkeypatch):
 
     wait_for_proxy_and_trigger_detection(None, str(proxy))
     assert calls.get("called")
-    assert calls.get("ctx") == "EXEC_DEFAULT"


### PR DESCRIPTION
## Summary
- safely rebuild proxies and detect features with `context.temp_override`
- add `detect_features_in_ui_context` helper for safe operator calls
- update unit tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68758f171bdc832d9dae0221420d6a10