### PR TITLE
Improve Tracksycle debug output

### DIFF
--- a/modules/operators/tracksycle_operator.py
+++ b/modules/operators/tracksycle_operator.py
@@ -56,12 +56,13 @@ class KAISERLICH_OT_auto_track_cycle(bpy.types.Operator):
 
         def nach_proxy():
             def delayed_call():
+                logger.debug("Executing detection callback")
                 scene = bpy.context.scene
                 space = bpy.context.space_data
                 clip = getattr(space, "clip", None)
                 if clip and clip.tracking.use_proxy:
                     clip.tracking.use_proxy = False
-                    print("Proxy deaktiviert f\u00fcr Feature-Erkennung")
+                    logger.debug("Proxy deaktiviert f\u00fcr Feature-Erkennung")
 
                 # Optional: Sicherstellen, dass der richtige Frame gesetzt ist
                 scene.frame_set(scene.frame_current)
@@ -71,10 +72,12 @@ class KAISERLICH_OT_auto_track_cycle(bpy.types.Operator):
                 threshold=1.0,
                 margin=26,
                 min_distance=265,
+                logger=logger,
                 )
                 return None  # nur einmal ausf\u00fchren
 
             # Verzögerung von 0.5 Sekunden
+            logger.info("Proxy ready, scheduling feature detection")
             bpy.app.timers.register(delayed_call, first_interval=0.5)
 
         remove_existing_proxies(clip, logger=logger)

--- a/modules/proxy/proxy_wait.py
+++ b/modules/proxy/proxy_wait.py
@@ -296,6 +296,8 @@ def create_proxy_and_wait_async(clip, callback=None, timeout=300, logger=None):
                         f"Proxy generation took {time.time() - state['start']:.2f}s"
                     )
             if callback:
+                if logger:
+                    logger.debug("Executing proxy callback")
                 callback()
             return None
         elapsed = time.time() - state["start"]


### PR DESCRIPTION
## Summary
- add log when executing proxy callback
- pass logger to detection function and log detection callback start

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68759d68b3fc832dbdeea59352f26c77