### PR TITLE
Add explicit proxy rebuild invocation

### DIFF
--- a/modules/proxy/proxy_wait.py
+++ b/modules/proxy/proxy_wait.py
@@ -196,6 +196,9 @@ def create_proxy_and_wait(clip, timeout=300, logger=None):
     # Enable proxy generation and set up building the proxy
     try:
         clip.proxy.build_50 = True
+        bpy.context.scene.use_proxy = True
+        clip.proxy.timecode = 'RECORD_RUN'
+        bpy.ops.clip.rebuild_proxy({'clip': clip})
         # clip.proxy.build_proxy() gibt es so nicht – stattdessen ggf. durch Timer auf das File warten wie bisher
     except Exception as e:  # pylint: disable=broad-except
         if logger:
@@ -303,6 +306,9 @@ def create_proxy_and_wait_async(clip, callback=None, timeout=300, logger=None):
 
     try:
         clip.proxy.build_50 = True
+        bpy.context.scene.use_proxy = True
+        clip.proxy.timecode = 'RECORD_RUN'
+        bpy.ops.clip.rebuild_proxy({'clip': clip})
     except Exception as e:  # pylint: disable=broad-except
         if logger:
             logger.error(f"Proxy-Build-Setup fehlgeschlagen: {e}")


### PR DESCRIPTION
## Summary
- rebuild proxies explicitly in `create_proxy_and_wait`
- ensure same rebuild step for async version

## Testing
- `pytest -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875a27d0220832d946a434ecd3b7035