### PR TITLE
Fix proxy checks to use clip property

### DIFF
--- a/modules/operators/tracksycle_operator.py
+++ b/modules/operators/tracksycle_operator.py
@@ -60,8 +60,8 @@ class KAISERLICH_OT_auto_track_cycle(bpy.types.Operator):
                 scene = bpy.context.scene
                 space = bpy.context.space_data
                 clip = getattr(space, "clip", None)
-                if clip and clip.tracking.use_proxy:
-                    clip.tracking.use_proxy = False
+                if clip and clip.use_proxy:
+                    clip.use_proxy = False
                     logger.debug("Proxy deaktiviert f\u00fcr Feature-Erkennung")
 
                 # Optional: Sicherstellen, dass der richtige Frame gesetzt ist

--- a/modules/proxy/proxy_wait.py
+++ b/modules/proxy/proxy_wait.py
@@ -216,7 +216,7 @@ def create_proxy_and_wait(clip, timeout=300, logger=None):
     # Enable proxy generation and set up building the proxy
     try:
         clip.proxy.build_50 = True
-        bpy.context.scene.use_proxy = True
+        clip.use_proxy = True
         clip.proxy.timecode = 'RECORD_RUN'
         bpy.ops.clip.rebuild_proxy({'clip': clip})
         # clip.proxy.build_proxy() gibt es so nicht – stattdessen ggf. durch Timer auf das File warten wie bisher
@@ -332,7 +332,7 @@ def create_proxy_and_wait_async(clip, callback=None, timeout=300, logger=None):
 
     try:
         clip.proxy.build_50 = True
-        bpy.context.scene.use_proxy = True
+        clip.use_proxy = True
         clip.proxy.timecode = 'RECORD_RUN'
         bpy.ops.clip.rebuild_proxy({'clip': clip})
     except Exception as e:  # pylint: disable=broad-except


### PR DESCRIPTION
## Summary
- avoid use of `scene.use_proxy`
- check and manipulate proxy state via `clip.use_proxy`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875a5d2e458832da23b71d5df000f0f