### PR TITLE
Implement proxy build modal operator

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -20,12 +20,14 @@ from .modules.util.tracker_logger import configure_logger
 from .modules.operators.tracksycle_operator import KAISERLICH_OT_auto_track_cycle
 from .modules.operators.rename_tracks_modal import KAISERLICH_OT_rename_tracks_modal
 from .modules.operators.detect_features_operator import KAISERLICH_OT_detect_features
+from .modules.operators.proxy_build_modal import KAISERLICH_OT_proxy_build_modal
 from .modules.ui.kaiserlich_panel import KAISERLICH_PT_tracking_tools
 
 classes = [
     KAISERLICH_OT_auto_track_cycle,
     KAISERLICH_OT_rename_tracks_modal,
     KAISERLICH_OT_detect_features,
+    KAISERLICH_OT_proxy_build_modal,
     KAISERLICH_PT_tracking_tools,
 ]
 
@@ -66,6 +68,12 @@ def register():
         default=False,
     )
 
+    bpy.types.Scene.proxy_built = BoolProperty(
+        name="Proxy Built",
+        description="Indicates whether a proxy was built",
+        default=False,
+    )
+
     bpy.types.Scene.kaiserlich_tracking_state = EnumProperty(
         name="Tracking State",
         description="Internal state for the Kaiserlich Tracksycle operator",
@@ -89,6 +97,7 @@ def unregister():
     del bpy.types.Scene.error_threshold
     del bpy.types.Scene.debug_output
     del bpy.types.Scene.kaiserlich_tracking_state
+    del bpy.types.Scene.proxy_built
 
 
 if __name__ == "__main__":

--- a/modules/operators/__init__.py
+++ b/modules/operators/__init__.py
@@ -3,9 +3,11 @@
 from .tracksycle_operator import KAISERLICH_OT_auto_track_cycle
 from .rename_tracks_modal import KAISERLICH_OT_rename_tracks_modal
 from .detect_features_operator import KAISERLICH_OT_detect_features
+from .proxy_build_modal import KAISERLICH_OT_proxy_build_modal
 
 __all__ = [
     "KAISERLICH_OT_auto_track_cycle",
     "KAISERLICH_OT_rename_tracks_modal",
     "KAISERLICH_OT_detect_features",
+    "KAISERLICH_OT_proxy_build_modal",
 ]

--- a/modules/operators/proxy_build_modal.py
+++ b/modules/operators/proxy_build_modal.py
@@ -1,0 +1,85 @@
+"""Modal operator to rebuild 50% proxy and start tracking cycle."""
+
+import bpy
+import os
+
+
+class KAISERLICH_OT_proxy_build_modal(bpy.types.Operator):
+    """Rebuild proxy and trigger tracking once finished."""
+
+    bl_idname = "kaiserlich.proxy_build_modal"
+    bl_label = "Build Proxy and Track"
+    bl_options = {'REGISTER', 'UNDO'}
+
+    _timer = None
+    _proxy_paths = []
+    _clip = None
+    _checks = 0
+
+    def execute(self, context):  # type: ignore[override]
+        space = context.space_data
+        clip = getattr(space, "clip", None)
+        if not clip:
+            self.report({'ERROR'}, "No clip loaded")
+            return {'CANCELLED'}
+
+        proxy = clip.proxy
+        proxy_dir = bpy.path.abspath(proxy.directory)
+        os.makedirs(proxy_dir, exist_ok=True)
+
+        alt_dir = os.path.join(proxy_dir, os.path.basename(clip.filepath))
+        for d in (proxy_dir, alt_dir):
+            if os.path.isdir(d):
+                for f in os.listdir(d):
+                    if f.startswith("proxy_"):
+                        try:
+                            os.remove(os.path.join(d, f))
+                        except OSError:
+                            pass
+
+        print("[Proxy] building 50% proxy...")
+
+        override = context.copy()
+        override['area'] = next(a for a in context.screen.areas if a.type == 'CLIP_EDITOR')
+        override['region'] = next(r for r in override['area'].regions if r.type == 'WINDOW')
+        override['space_data'] = override['area'].spaces.active
+        override['clip'] = clip
+
+        with context.temp_override(**override):
+            bpy.ops.clip.rebuild_proxy()
+
+        proxy_file = "proxy_50.avi"
+        direct_path = os.path.join(proxy_dir, proxy_file)
+        alt_path = os.path.join(proxy_dir, os.path.basename(clip.filepath), proxy_file)
+
+        self._clip = clip
+        self._proxy_paths = [direct_path, alt_path]
+        self._checks = 0
+        wm = context.window_manager
+        self._timer = wm.event_timer_add(0.5, window=context.window)
+        wm.modal_handler_add(self)
+
+        self.report({'INFO'}, "Proxy 50% Erstellung gestartet")
+        print("[Proxy] build started")
+        return {'RUNNING_MODAL'}
+
+    def modal(self, context, event):  # type: ignore[override]
+        if event.type == 'TIMER':
+            if any(os.path.exists(p) for p in self._proxy_paths):
+                context.window_manager.event_timer_remove(self._timer)
+                context.scene.proxy_built = True
+                self.report({'INFO'}, "\u2705 Proxy-Erstellung abgeschlossen")
+                print("[Proxy] build finished")
+
+                bpy.ops.clip.tracking_cycle('INVOKE_DEFAULT')
+                return {'FINISHED'}
+            self._checks += 1
+        return {'PASS_THROUGH'}
+
+    def cancel(self, context):  # type: ignore[override]
+        if self._timer:
+            context.window_manager.event_timer_remove(self._timer)
+        return {'CANCELLED'}
+
+
+__all__ = ["KAISERLICH_OT_proxy_build_modal"]

--- a/modules/ui/kaiserlich_panel.py
+++ b/modules/ui/kaiserlich_panel.py
@@ -3,6 +3,7 @@
 import bpy
 
 from ..operators.tracksycle_operator import KAISERLICH_OT_auto_track_cycle
+from ..operators.proxy_build_modal import KAISERLICH_OT_proxy_build_modal
 
 
 class KAISERLICH_PT_tracking_tools(bpy.types.Panel):
@@ -24,7 +25,12 @@ class KAISERLICH_PT_tracking_tools(bpy.types.Panel):
 
         layout.operator(KAISERLICH_OT_auto_track_cycle.bl_idname,
                         text="Auto Track starten")
+        layout.operator("kaiserlich.proxy_build_modal",
+                        text="Build Proxy and Track")
         layout.prop(scene, "min_marker_count")
         layout.prop(scene, "min_track_length")
         layout.prop(scene, "error_threshold")
         layout.prop(scene, "debug_output")
+
+__all__ = ["KAISERLICH_PT_tracking_tools"]
+


### PR DESCRIPTION
## Summary
- add a new modal operator to rebuild proxies and start tracking
- expose new operator through operators package and panel UI
- register `proxy_built` scene property

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875b0e39488832da395905920227ce7