### PR TITLE
Improve debug logging in detection functions

### DIFF
--- a/modules/detection/async_detection.py
+++ b/modules/detection/async_detection.py
@@ -41,13 +41,17 @@ def detect_features_async(scene, clip, logger=None, attempts=10):
             logger.debug(
                 f"Attempt {state['attempt'] + 1}: threshold={state['threshold']}, pattern_size={state['pattern_size']}"
             )
-        detect_features_no_proxy(
+        ok = detect_features_no_proxy(
             clip,
             threshold=state["threshold"],
             margin=clip.size[0] / 200,
             min_distance=int(clip.size[0] / 20),
             logger=logger,
         )
+        if not ok:
+            if logger:
+                logger.error("Detection step failed")
+            return None
         marker_count = len(clip.tracking.tracks)
         if logger:
             logger.debug(f"Markers detected: {marker_count}")


### PR DESCRIPTION
## Summary
- return success from `detect_features_no_proxy`
- log markers before/after running detection
- stop async detection when a detection step fails

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687626ed95a0832da9f9ce2add66ac60