### PR TITLE
Improve detection loop with async evaluation

### DIFF
--- a/modules/detection/async_detection.py
+++ b/modules/detection/async_detection.py
@@ -55,6 +55,11 @@ def detect_features_async(scene, clip, logger=None, attempts=10):
         marker_count = len(clip.tracking.tracks)
         if logger:
             logger.debug(f"Markers detected: {marker_count}")
+            logger.debug(
+                f"Evaluating: marker_count={marker_count}, "
+                f"min_marker_count={getattr(scene, 'min_marker_count', 10)}, "
+                f"attempt={state['attempt']}, attempts={attempts}"
+            )
         if marker_count >= getattr(scene, "min_marker_count", 10) or state["attempt"] >= attempts:
             if logger:
                 logger.info(

--- a/modules/operators/tracksycle_operator.py
+++ b/modules/operators/tracksycle_operator.py
@@ -4,6 +4,7 @@ import bpy
 import os
 
 from ..proxy.proxy_wait import detect_features_in_ui_context
+from ..detection import detect_features_async
 from ..util.tracker_logger import TrackerLogger, configure_logger
 
 
@@ -92,10 +93,9 @@ class KAISERLICH_OT_auto_track_cycle(bpy.types.Operator):
                 scene = context.scene
                 scene.proxy_built = True
                 self._logger.info("[Proxy] build finished")
-                detect_features_in_ui_context(
-                    threshold=1.0,
-                    margin=26,
-                    min_distance=265,
+                detect_features_async(
+                    scene,
+                    self._clip,
                     logger=self._logger,
                 )
                 scene.kaiserlich_tracking_state = 'DETECTING'


### PR DESCRIPTION
## Summary
- invoke asynchronous feature detection after proxy building
- add detailed logging around marker evaluation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68764c78c578832d93927f3de19d4279