### PR TITLE
Fix relative import in detect_no_proxy

### DIFF
--- a/modules/detection/detect_no_proxy.py
+++ b/modules/detection/detect_no_proxy.py
@@ -54,7 +54,7 @@ def detect_features_no_proxy(clip, threshold=1.0, margin=None, min_distance=None
     clip.use_proxy = False
     if logger:
         logger.debug("Proxies disabled for detection")
-    from modules.proxy.proxy_wait import log_proxy_status
+    from ..proxy.proxy_wait import log_proxy_status
     log_proxy_status(clip)
     log_proxy_status(clip, logger)
 


### PR DESCRIPTION
## Summary
- ensure detect_no_proxy uses a relative import for `log_proxy_status`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876abead114832d8d2a386c275de8a4