### PR TITLE
Add warning alias for TrackerLogger

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ from modules.util.tracker_logger import TrackerLogger, configure_logger
 
 configure_logger(debug=True, log_file="tracksycle.log")
 logger = TrackerLogger()
-logger.info(), logger.warn(), logger.error(), logger.debug()
+logger.info(), logger.warning(), logger.error(), logger.debug()
 ```
 
 ---

--- a/modules/operators/rename_tracks_modal.py
+++ b/modules/operators/rename_tracks_modal.py
@@ -62,7 +62,7 @@ class KAISERLICH_OT_rename_tracks_modal(bpy.types.Operator):
                     track.name = new_name
                 except RuntimeError as exc:
                     if self._logger:
-                        self._logger.warn(f"Failed to rename track {track.name} -> {new_name}: {exc}")
+                        self._logger.warning(f"Failed to rename track {track.name} -> {new_name}: {exc}")
             self._index += 1
         return {'PASS_THROUGH'}
 

--- a/modules/proxy/proxy_wait.py
+++ b/modules/proxy/proxy_wait.py
@@ -145,7 +145,7 @@ def remove_existing_proxies(clip, logger=None):
                 f"[Tracksycle] WARNUNG: Proxy-Datei {abs_dir} ist gesperrt und kann nicht gelöscht werden."
             )
             if logger:
-                logger.warn(message)
+                logger.warning(message)
             else:
                 print(message)
         else:
@@ -155,7 +155,7 @@ def remove_existing_proxies(clip, logger=None):
                     logger.info(f"Proxy directory removed: {abs_dir}")
             except Exception as exc:  # pylint: disable=broad-except
                 if logger:
-                    logger.warn(f"Failed to remove proxy directory: {exc}")
+                    logger.warning(f"Failed to remove proxy directory: {exc}")
     else:
         if logger:
             logger.debug("Proxy directory does not exist")
@@ -222,7 +222,7 @@ def create_proxy_and_wait(clip, timeout=300, logger=None):
     log_proxy_status(clip, logger)
     if not clip.proxy.directory:
         if logger:
-            logger.warn("Proxy directory was not set; using default '//proxies'")
+            logger.warning("Proxy directory was not set; using default '//proxies'")
         clip.proxy.directory = "//proxies"
 
     directory = bpy.path.abspath(clip.proxy.directory)
@@ -348,7 +348,7 @@ def create_proxy_and_wait_async(clip, callback=None, timeout=300, logger=None):
     log_proxy_status(clip, logger)
     if not clip.proxy.directory:
         if logger:
-            logger.warn("Proxy directory was not set; using default '//proxies'")
+            logger.warning("Proxy directory was not set; using default '//proxies'")
         clip.proxy.directory = "//proxies"
 
     directory = bpy.path.abspath(clip.proxy.directory)

--- a/modules/util/tracker_logger.py
+++ b/modules/util/tracker_logger.py
@@ -54,6 +54,9 @@ class TrackerLogger:
     def warn(self, msg):
         self._logger.warning(msg)
 
+    def warning(self, msg):
+        self._logger.warning(msg)
+
     def error(self, msg):
         self._logger.error(msg)
 

--- a/tests/test_tracker_logger.py
+++ b/tests/test_tracker_logger.py
@@ -16,10 +16,12 @@ def test_tracker_logger_methods(caplog):
     with caplog.at_level(logger.level):
         tlogger.info('info')
         tlogger.warn('warn')
+        tlogger.warning('warning')
         tlogger.error('error')
         tlogger.debug('debug')
     assert 'info' in caplog.text
     assert 'warn' in caplog.text
+    assert 'warning' in caplog.text
     assert 'error' in caplog.text
     assert 'debug' in caplog.text
 


### PR DESCRIPTION
## Summary
- extend `TrackerLogger` with `warning` method
- switch internal `logger.warn` usage to `logger.warning`
- update documentation to reflect new method
- test both `warn` and `warning` methods

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876c6c9cbb4832d942590708dbb005c