### PR TITLE
Add defensive track removal checks

### DIFF
--- a/modules/detection/distance_remove.py
+++ b/modules/detection/distance_remove.py
@@ -13,5 +13,7 @@ def distance_remove(tracks, good_marker, margin):
         except (AttributeError, IndexError):
             continue
         if (Vector(pos) - good_pos).length < margin:
-            tracks.remove(track)
+            safe_track = tracks.get(track.name) if hasattr(tracks, "get") else track
+            if safe_track:
+                tracks.remove(safe_track)
 

--- a/modules/operators/tracksycle_operator.py
+++ b/modules/operators/tracksycle_operator.py
@@ -52,7 +52,9 @@ class KAISERLICH_OT_auto_track_cycle(bpy.types.Operator):
                     f"\u26A0 Zu wenige Marker in Frame {frame}. L\u00f6sche Tracks und versuche erneut."
                 )
                 for track in list(clip.tracking.tracks):
-                    clip.tracking.tracks.remove(track)
+                    safe_track = clip.tracking.tracks.get(track.name)
+                    if safe_track:
+                        clip.tracking.tracks.remove(safe_track)
                 return 0.5
 
             logger.info("\U0001F389 Gen\u00fcgend Marker erkannt \u2013 fertig.")


### PR DESCRIPTION
## Summary
- avoid AttributeError by verifying track membership before calling `remove`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876d00d3740832db9f8bf649a806969