### PR TITLE
Implement safe_remove_track helper

### DIFF
--- a/modules/detection/distance_remove.py
+++ b/modules/detection/distance_remove.py
@@ -2,6 +2,7 @@
 
 import bpy
 from mathutils import Vector
+from ..util.tracking_utils import safe_remove_track
 
 
 def distance_remove(tracks, good_marker, margin):
@@ -15,5 +16,6 @@ def distance_remove(tracks, good_marker, margin):
         if (Vector(pos) - good_pos).length < margin:
             safe_track = tracks.get(track.name) if hasattr(tracks, "get") else track
             if safe_track:
-                tracks.remove(safe_track)
+                clip = getattr(tracks, "id_data", None)
+                safe_remove_track(clip, safe_track)
 

--- a/modules/operators/tracksycle_operator.py
+++ b/modules/operators/tracksycle_operator.py
@@ -8,6 +8,7 @@ from ..detection.find_frame_with_few_tracking_markers import (
     find_frame_with_few_tracking_markers,
 )
 from ..detection.detect_no_proxy import detect_features_no_proxy
+from ..util.tracking_utils import safe_remove_track
 
 
 class KAISERLICH_OT_auto_track_cycle(bpy.types.Operator):
@@ -52,9 +53,7 @@ class KAISERLICH_OT_auto_track_cycle(bpy.types.Operator):
                     f"\u26A0 Zu wenige Marker in Frame {frame}. L\u00f6sche Tracks und versuche erneut."
                 )
                 for track in list(clip.tracking.tracks):
-                    safe_track = clip.tracking.tracks.get(track.name)
-                    if safe_track:
-                        clip.tracking.tracks.remove(safe_track)
+                    safe_remove_track(clip, track)
                 return 0.5
 
             logger.info("\U0001F389 Gen\u00fcgend Marker erkannt \u2013 fertig.")

--- a/modules/util/tracking_utils.py
+++ b/modules/util/tracking_utils.py
@@ -1,0 +1,61 @@
+"""Utility helpers for Blender tracking."""
+
+from __future__ import annotations
+
+import bpy
+
+
+def safe_remove_track(clip, track):
+    """Safely remove ``track`` from ``clip``.
+
+    Tries to call :func:`bpy.ops.clip.track_remove` in a Clip Editor UI
+    context. If the operator cannot be executed, falls back to directly
+    removing the track from ``clip.tracking.tracks``.
+    """
+    tracks = None
+
+    if clip is not None and hasattr(clip, "tracking"):
+        tracks = clip.tracking.tracks
+    elif hasattr(clip, "remove") and hasattr(clip, "active"):
+        tracks = clip
+    
+    if tracks is None and hasattr(track, "id_data"):
+        parent = track.id_data
+        if hasattr(parent, "tracking"):
+            tracks = parent.tracking.tracks
+            clip = parent
+
+    if tracks is None:
+        return
+
+    try:
+        op = bpy.ops.clip.track_remove
+    except AttributeError:
+        op = None
+
+    if op is not None:
+        try:
+            context = bpy.context
+            area = next(
+                (a for a in context.screen.areas if a.type == "CLIP_EDITOR"),
+                None,
+            )
+            region = (
+                next((r for r in area.regions if r.type == "WINDOW"), None)
+                if area
+                else None
+            )
+            if area and region:
+                space = area.spaces.active
+                tracks.active = track
+                with context.temp_override(
+                    area=area, region=region, space_data=space, clip=clip
+                ):
+                    op()
+                return
+        except Exception:  # pragma: no cover - fallback
+            pass
+
+    safe_track = tracks.get(track.name) if hasattr(tracks, "get") else track
+    if safe_track and hasattr(tracks, "remove"):
+        tracks.remove(safe_track)

--- a/tests/test_distance_remove.py
+++ b/tests/test_distance_remove.py
@@ -38,10 +38,20 @@ class DummyTracks(list):
         del self[idx]
         self.removed = True
 
-def test_distance_remove_empty_markers():
+def test_distance_remove_empty_markers(monkeypatch):
     tracks = DummyTracks([DummyTrack(), DummyTrack([DummyMarker((0, 0))])])
+    called = {}
+
+    def dummy_safe_remove(clip, track):
+        called['track'] = track
+        tracks.remove(track)
+
+    monkeypatch.setattr(distance_remove, 'safe_remove_track', dummy_safe_remove)
+
     distance_remove.distance_remove(tracks, (0, 0), 1.0)
-    # The track with markers should be removed; the empty one remains
+
+    # The track with markers should be removed via safe_remove_track
+    assert called.get('track') is not None
     assert getattr(tracks, 'removed', False)
     assert len(tracks) == 1
 

--- a/tests/test_tracking_utils.py
+++ b/tests/test_tracking_utils.py
@@ -1,0 +1,87 @@
+import os, sys
+from types import SimpleNamespace
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from modules.util import tracking_utils
+
+
+class DummyOverride:
+    def __init__(self, **kw):
+        self.kw = kw
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return False
+
+
+class DummyTracks(list):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.active = None
+        self.removed = None
+    def remove(self, track):
+        self.removed = track
+    def get(self, name):
+        for t in self:
+            if t.name == name:
+                return t
+        return None
+
+
+class DummyTrack:
+    def __init__(self, name="T"):
+        self.name = name
+        self.markers = []
+
+
+class DummyClip:
+    def __init__(self):
+        self.tracking = SimpleNamespace(tracks=DummyTracks())
+
+
+def _setup_context(clip, with_area=True):
+    if with_area:
+        areas = [SimpleNamespace(type="CLIP_EDITOR", regions=[SimpleNamespace(type="WINDOW")], spaces=SimpleNamespace(active=SimpleNamespace(type="CLIP_EDITOR")))]
+    else:
+        areas = []
+    return SimpleNamespace(
+        screen=SimpleNamespace(areas=areas),
+        temp_override=lambda **kw: DummyOverride(**kw),
+    )
+
+
+def test_safe_remove_track_operator(monkeypatch):
+    called = {}
+    clip = DummyClip()
+    track = DummyTrack()
+    clip.tracking.tracks.append(track)
+    track.id_data = clip
+
+    import bpy
+    bpy.ops.clip.track_remove = lambda: called.setdefault("op", True)
+    bpy.context = _setup_context(clip, with_area=True)
+
+    tracking_utils.safe_remove_track(clip, track)
+    assert called.get("op") is True
+    assert clip.tracking.tracks.removed is None
+
+
+def test_safe_remove_track_fallback(monkeypatch):
+    called = {}
+    clip = DummyClip()
+    track = DummyTrack()
+    clip.tracking.tracks.append(track)
+    track.id_data = clip
+
+    import bpy
+    bpy.ops.clip.track_remove = lambda: called.setdefault("op", True)
+    bpy.context = _setup_context(clip, with_area=False)
+
+    def dummy_remove(t):
+        called["removed"] = True
+    clip.tracking.tracks.remove = dummy_remove
+
+    tracking_utils.safe_remove_track(clip, track)
+    assert called.get("op") is None
+    assert called.get("removed") is True


### PR DESCRIPTION
## Summary
- add `safe_remove_track` utility for robust track removal
- use `safe_remove_track` in `tracksycle_operator` and `distance_remove`
- create unit tests for new helper
- update existing tests to use the helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876d9fe6ad0832db20ba307ff214478