### PR TITLE
Remove unused checks attribute

### DIFF
--- a/modules/operators/tracksycle_operator.py
+++ b/modules/operators/tracksycle_operator.py
@@ -118,7 +118,6 @@ class KAISERLICH_OT_auto_track_cycle(bpy.types.Operator):
         self._clip = clip
         self._proxy_paths = [direct_path, alt_path]
         self._logger = logger
-        self._checks = 0
         wm = context.window_manager
         self._timer = wm.event_timer_add(0.5, window=context.window)
         wm.modal_handler_add(self)
@@ -150,7 +149,6 @@ class KAISERLICH_OT_auto_track_cycle(bpy.types.Operator):
 
                 bpy.app.timers.register(check_detection_done)
                 return {'RUNNING_MODAL'}
-            self._checks += 1
         return {'PASS_THROUGH'}
 
     def cancel(self, context):  # type: ignore[override]


### PR DESCRIPTION
## Summary
- remove `_checks` attribute handling from `KAISERLICH_OT_auto_track_cycle`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6876dee7a5dc832d97450809061de90f