### PR TITLE
Remove redundant proxy status log

### DIFF
--- a/modules/detection/detect_no_proxy.py
+++ b/modules/detection/detect_no_proxy.py
@@ -54,7 +54,6 @@ def detect_features_no_proxy(clip, threshold=1.0, margin=None, min_distance=None
     clip.use_proxy = False
     if logger:
         logger.debug("Proxies disabled for detection")
-    log_proxy_status(clip)
     log_proxy_status(clip, logger)
 
     before = len(clip.tracking.tracks)


### PR DESCRIPTION
## Summary
- update proxy logging in `detect_features_no_proxy` to use logger only

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876e670d9d0832d8cafee38f95f4e1c