### PR TITLE
Fix safe_remove_track operator handling

### DIFF
--- a/modules/util/tracking_utils.py
+++ b/modules/util/tracking_utils.py
@@ -47,11 +47,23 @@ def safe_remove_track(clip, track):
             )
             if area and region:
                 space = area.spaces.active
+                if hasattr(track, "select"):
+                    track.select = True
                 tracks.active = track
                 with context.temp_override(
                     area=area, region=region, space_data=space, clip=clip
                 ):
                     op()
+                # Operator might silently fail to remove the track
+                still_there = (
+                    track in tracks
+                    or (
+                        hasattr(tracks, "get") and tracks.get(getattr(track, "name", ""))
+                        is not None
+                    )
+                )
+                if still_there and hasattr(tracks, "remove"):
+                    tracks.remove(track)
                 return
         except Exception:  # pragma: no cover - fallback
             pass

--- a/tests/test_tracking_utils.py
+++ b/tests/test_tracking_utils.py
@@ -22,6 +22,10 @@ class DummyTracks(list):
         self.removed = None
     def remove(self, track):
         self.removed = track
+        try:
+            super().remove(track)
+        except ValueError:
+            pass
     def get(self, name):
         for t in self:
             if t.name == name:
@@ -33,6 +37,7 @@ class DummyTrack:
     def __init__(self, name="T"):
         self.name = name
         self.markers = []
+        self.select = False
 
 
 class DummyMarker:
@@ -69,7 +74,7 @@ def test_safe_remove_track_operator(monkeypatch):
 
     tracking_utils.safe_remove_track(clip, track)
     assert called.get("op") is True
-    assert clip.tracking.tracks.removed is None
+    assert track not in clip.tracking.tracks
 
 
 def test_safe_remove_track_fallback(monkeypatch):


### PR DESCRIPTION
## Summary
- ensure track is selected before calling Blender operator
- cleanup track if Blender operator fails
- update test mocks to handle selection and track removal

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876fa5933e4832dba9411e176e05dd9