### PR TITLE
Implement valid range check for async detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ def unregister():
 Der Operator `KAISERLICH_OT_auto_track_cycle` durchläuft automatisch folgende Schritte:
 
 1. Entfernen vorhandener Proxy-Dateien und Erzeugen eines neuen 50%-Proxys.
-2. Feature-Erkennung mit dynamisch angepasstem Threshold, bis mindestens `min_marker_count` Marker gefunden sind.
+2. Feature-Erkennung mit dynamisch angepasstem Threshold, bis die Markeranzahl im Bereich von 80‑120 % von `min_marker_count * 4` liegt.
 3. Bereinigung und Umbenennung der Marker zu `TRACK_*`.
 4. Bidirektionales Tracking aller Marker.
 5. Löschen zu kurzer Tracks basierend auf `min_track_length`.
@@ -317,6 +317,7 @@ threshold = round(threshold, 5)
 Dabei ist:
 
 * `expected = min_marker_count * 4`
+* Der Detection-Loop endet, sobald `marker_count` zwischen `expected * 0.8` und `expected * 1.2` liegt.
 * `threshold_start = 1.0`
 * `0.0001` = untere Grenze zur Vermeidung von Null/Negativwerten
 

--- a/modules/detection/async_detection.py
+++ b/modules/detection/async_detection.py
@@ -65,14 +65,17 @@ def detect_features_async(scene, clip, logger=None, attempts=10):
         marker_count = count_markers_in_frame(
             clip.tracking.tracks, scene.frame_current
         )
+        min_marker_count = getattr(scene, "min_marker_count", 10)
+        min_plus = min_marker_count * 4
+        min_valid = min_plus * 0.8
+        max_valid = min_plus * 1.2
         if logger:
             logger.debug(f"Markers detected: {marker_count}")
             logger.debug(
-                f"Evaluating: marker_count={marker_count}, "
-                f"min_marker_count={getattr(scene, 'min_marker_count', 10)}, "
-                f"attempt={state['attempt']}, attempts={attempts}"
+                f"Evaluating: marker_count={marker_count}, min_marker_count={min_marker_count}, "
+                f"min_valid={min_valid}, max_valid={max_valid}, attempt={state['attempt']}, attempts={attempts}"
             )
-        if marker_count >= getattr(scene, "min_marker_count", 10) or state["attempt"] >= attempts:
+        if (min_valid < marker_count < max_valid) or state["attempt"] >= attempts:
             if logger:
                 logger.info(
                     f"Detection finished after {state['attempt'] + 1} attempts with {marker_count} markers"
@@ -80,7 +83,7 @@ def detect_features_async(scene, clip, logger=None, attempts=10):
             if hasattr(scene, "kaiserlich_feature_detection_done"):
                 scene.kaiserlich_feature_detection_done = True
             return None
-        if marker_count < getattr(scene, "min_marker_count", 10):
+        if marker_count < min_marker_count:
             if logger:
                 logger.debug("Removing existing tracks before retrying")
             for track in list(clip.tracking.tracks):

--- a/tests/test_async_detection.py
+++ b/tests/test_async_detection.py
@@ -55,3 +55,44 @@ def test_async_detection_adjusts_threshold_and_limits_attempts(monkeypatch):
     assert len(set(thresholds)) > 1  # threshold adjusted over attempts
     assert thresholds[0] == 1.0
     assert iterations == len(thresholds)
+
+
+def test_async_detection_stops_when_count_in_range(monkeypatch):
+    thresholds = []
+    marker_counts = [0, 17]
+
+    def dummy_detect(clip, threshold=1.0, margin=None, min_distance=None, logger=None):
+        thresholds.append(threshold)
+        return True
+
+    def dummy_count(tracks, frame):
+        return marker_counts.pop(0)
+
+    monkeypatch.setattr(async_detection, "detect_features_no_proxy", dummy_detect)
+    monkeypatch.setattr(async_detection, "count_markers_in_frame", dummy_count)
+    monkeypatch.setattr(async_detection, "safe_remove_track", lambda *a, **k: None)
+
+    step_holder = {}
+
+    def dummy_register(fn, first_interval=0.0):
+        step_holder["fn"] = fn
+
+    import bpy  # provided by conftest
+
+    bpy.app = SimpleNamespace(timers=SimpleNamespace(register=dummy_register))
+
+    scene = SimpleNamespace(frame_current=1, min_marker_count=5)
+    clip = DummyClip()
+
+    async_detection.detect_features_async(scene, clip, attempts=5)
+    step = step_holder["fn"]
+
+    iterations = 1
+    result = step()
+    while result is not None:
+        iterations += 1
+        result = step()
+
+    assert iterations == 2  # stop once marker count enters valid range
+    assert thresholds[0] == 1.0
+    assert iterations == len(thresholds)


### PR DESCRIPTION
## Summary
- use a valid marker range in `async_detection._step`
- update async detection tests for the new range logic
- document the detection range rule in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876fe9f8388832d88c6c790aaa97720