### PR TITLE
Fix track lookup in Blender collections

### DIFF
--- a/modules/util/tracking_utils.py
+++ b/modules/util/tracking_utils.py
@@ -7,11 +7,26 @@ import bpy
 
 def _track_exists(tracks, track):
     """Return ``True`` if ``track`` is present in ``tracks``."""
-    if track in tracks:
-        return True
+    try:
+        if track in tracks:
+            return True
+    except TypeError:
+        pass
+
+    name = getattr(track, "name", None)
+    if name is None:
+        return False
+
+    try:
+        if name in tracks:
+            return True
+    except TypeError:
+        pass
+
     if hasattr(tracks, "get"):
-        return tracks.get(getattr(track, "name", "")) is not None
-    return False
+        return tracks.get(name) is not None
+
+    return any(getattr(t, "name", None) == name for t in tracks)
 
 
 def safe_remove_track(clip, track, logger=None):

--- a/tests/test_tracking_utils.py
+++ b/tests/test_tracking_utils.py
@@ -133,3 +133,24 @@ def test_count_markers_in_frame():
     assert tracking_utils.count_markers_in_frame(tracks, 2) == 1
     assert tracking_utils.count_markers_in_frame(tracks, 3) == 1
     assert tracking_utils.count_markers_in_frame(tracks, 4) == 0
+
+
+def test_track_exists_bpy_collection():
+    class DummyBpyTracks:
+        def __init__(self, tracks):
+            self._tracks = {t.name: t for t in tracks}
+
+        def __contains__(self, name):  # expects a track name
+            return name in self._tracks
+
+        def get(self, name):
+            return self._tracks.get(name)
+
+        def __iter__(self):
+            return iter(self._tracks.values())
+
+    t1 = DummyTrack("A")
+    tracks = DummyBpyTracks([t1])
+
+    assert tracking_utils._track_exists(tracks, t1)
+    assert not tracking_utils._track_exists(tracks, DummyTrack("B"))


### PR DESCRIPTION
## Summary
- handle bpy collections in `_track_exists`
- add regression test for `_track_exists`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68779f340e88832db30ab81c589f18c2