### PR TITLE
Improve marker workflow documentation and utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,14 @@ Der Operator `KAISERLICH_OT_auto_track_cycle` durchläuft automatisch folgende S
 
 1. Entfernen vorhandener Proxy-Dateien und Erzeugen eines neuen 50%-Proxys.
 2. Feature-Erkennung mit dynamisch angepasstem Threshold, bis die Markeranzahl im Bereich von 80‑120 % von `min_marker_count * 4` liegt.
-3. Bereinigung und Umbenennung der Marker zu `TRACK_*`.
+3. Neu gesetzte Marker erhalten zunächst das Präfix `NEW_`. Marker, die zu nah
+   an vorhandenen `GOOD_*`-Markern liegen, werden gelöscht. Liegt die Anzahl der
+   verbleibenden `NEW_*`-Marker im gültigen Bereich, werden sie in `TRACK_*`
+   umbenannt; andernfalls werden alle `NEW_*`-Marker entfernt und die Erkennung
+   erneut gestartet (siehe `detect_features_async`). Die Funktion
+   `hard_remove_new_tracks` kann dabei genutzt werden, um zuverlässig alle
+   `NEW_*`-Tracks zu löschen. Anschließend können die verbleibenden Marker mit
+   `rename_new_to_track` in `TRACK_*` umbenannt werden.
 4. Bidirektionales Tracking aller Marker.
 5. Löschen zu kurzer Tracks basierend auf `min_track_length`.
 6. Optionales Nachjustieren von Motion Model und Pattern Size, falls zu wenige Marker vorhanden sind.

--- a/modules/detection/async_detection.py
+++ b/modules/detection/async_detection.py
@@ -88,7 +88,7 @@ def detect_features_async(scene, clip, logger=None, attempts=10):
                 pos = good.markers[0].co
             except (AttributeError, IndexError):
                 continue
-            distance_remove(clip.tracking.tracks, pos, margin_dist)
+            distance_remove(clip.tracking.tracks, pos, margin_dist, logger=logger)
 
         if logger:
             logger.debug("Starting marker count check")

--- a/modules/detection/distance_remove.py
+++ b/modules/detection/distance_remove.py
@@ -4,8 +4,8 @@ from mathutils import Vector
 from ..util.tracking_utils import safe_remove_track
 
 
-def distance_remove(tracks, good_marker, margin):
-    """Remove tracks within a margin of a given marker."""
+def distance_remove(tracks, good_marker, margin, logger=None):
+    """Remove tracks within ``margin`` distance of ``good_marker``."""
     good_pos = Vector(good_marker)
     for track in list(tracks):
         if not getattr(track, "name", "").startswith("NEW_"):
@@ -14,9 +14,12 @@ def distance_remove(tracks, good_marker, margin):
             pos = track.markers[0].co
         except (AttributeError, IndexError):
             continue
-        if (Vector(pos) - good_pos).length < margin:
+        dist = (Vector(pos) - good_pos).length
+        if dist < margin:
             safe_track = tracks.get(track.name) if hasattr(tracks, "get") else track
             if safe_track:
                 clip = getattr(tracks, "id_data", None)
-                safe_remove_track(clip, safe_track)
+                if logger:
+                    logger.info(f"Entferne {track.name} mit Distanz {dist:.3f}")
+                safe_remove_track(clip, safe_track, logger=logger)
 

--- a/modules/proxy/proxy_wait.py
+++ b/modules/proxy/proxy_wait.py
@@ -20,17 +20,17 @@ def _get_clip_editor_override(ctx=None):
     screen = getattr(ctx.window, "screen", None)
     if screen:
         for area in screen.areas:
-                if area.type == "CLIP_EDITOR":
-                    override["area"] = area
-                    for region in area.regions:
-                        if region.type == "WINDOW":
-                            override["region"] = region
-                            break
-                    for space in area.spaces:
-                        if space.type == "CLIP_EDITOR":
-                            override["space_data"] = space
-                            break
-                    break
+            if area.type == "CLIP_EDITOR":
+                override["area"] = area
+                for region in area.regions:
+                    if region.type == "WINDOW":
+                        override["region"] = region
+                        break
+                for space in area.spaces:
+                    if space.type == "CLIP_EDITOR":
+                        override["space_data"] = space
+                        break
+                break
     return override
 
 

--- a/modules/util/__init__.py
+++ b/modules/util/__init__.py
@@ -1,1 +1,15 @@
-# Miscellaneous utilities
+"""Utility exports for Kaiserlich Tracksycle."""
+
+from .tracking_utils import (
+    safe_remove_track,
+    count_markers_in_frame,
+    hard_remove_new_tracks,
+    rename_new_to_track,
+)
+
+__all__ = [
+    "safe_remove_track",
+    "count_markers_in_frame",
+    "hard_remove_new_tracks",
+    "rename_new_to_track",
+]

--- a/tests/test_distance_remove.py
+++ b/tests/test_distance_remove.py
@@ -45,7 +45,7 @@ def test_distance_remove_empty_markers(monkeypatch):
     tracks = DummyTracks([DummyTrack(), DummyTrack([DummyMarker((0, 0))])])
     called = {}
 
-    def dummy_safe_remove(clip, track):
+    def dummy_safe_remove(clip, track, logger=None):
         called['track'] = track
         tracks.remove(track)
 
@@ -57,4 +57,27 @@ def test_distance_remove_empty_markers(monkeypatch):
     assert called.get('track') is not None
     assert getattr(tracks, 'removed', False)
     assert len(tracks) == 1
+
+
+class DummyLogger:
+    def __init__(self):
+        self.infos = []
+
+    def info(self, msg):
+        self.infos.append(msg)
+
+
+def test_distance_remove_logs(monkeypatch):
+    tracks = DummyTracks([DummyTrack([DummyMarker((0, 0))])])
+
+    def dummy_safe_remove(clip, track, logger=None):
+        tracks.remove(track)
+
+    monkeypatch.setattr(distance_remove, 'safe_remove_track', dummy_safe_remove)
+
+    logger = DummyLogger()
+    distance_remove.distance_remove(tracks, (0, 0), 1.0, logger=logger)
+
+    assert len(logger.infos) == 1
+    assert len(tracks) == 0
 

--- a/tests/test_tracking_utils.py
+++ b/tests/test_tracking_utils.py
@@ -155,3 +155,55 @@ def test_track_exists_bpy_collection():
 
     assert tracking_utils._track_exists(tracks, t1)
     assert not tracking_utils._track_exists(tracks, DummyTrack("B"))
+
+
+def test_hard_remove_new_tracks(monkeypatch):
+    clip = DummyClip()
+    clip.tracking.tracks.extend([
+        DummyTrack("NEW_001"),
+        DummyTrack("KEEP"),
+        DummyTrack("NEW_002"),
+    ])
+
+    def dummy_safe_remove(_clip, track, logger=None):
+        clip.tracking.tracks.remove(track)
+        return True
+
+    monkeypatch.setattr(tracking_utils, "safe_remove_track", dummy_safe_remove)
+
+    tracking_utils.hard_remove_new_tracks(clip)
+
+    names = [t.name for t in clip.tracking.tracks]
+    assert names == ["KEEP"]
+
+
+def test_hard_remove_new_tracks_empty(monkeypatch):
+    clip = DummyClip()
+    t1 = DummyTrack("NEW_001")
+    t1.markers = []
+    t2 = DummyTrack("NEW_002")
+    t2.markers = []
+    clip.tracking.tracks.extend([t1, t2])
+
+    def dummy_safe_remove(_clip, track, logger=None):
+        # simulate failure: do not remove t1
+        return track is not t1
+
+    monkeypatch.setattr(tracking_utils, "safe_remove_track", dummy_safe_remove)
+
+    tracking_utils.hard_remove_new_tracks(clip)
+
+    assert clip.tracking.tracks == []
+
+
+def test_rename_new_to_track(monkeypatch):
+    clip = DummyClip()
+    clip.tracking.tracks.extend([
+        DummyTrack("NEW_001"),
+        DummyTrack("NEW_002"),
+    ])
+
+    tracking_utils.rename_new_to_track(clip)
+
+    names = [t.name for t in clip.tracking.tracks]
+    assert names == ["TRACK_000", "TRACK_001"]


### PR DESCRIPTION
## Summary
- document `NEW_` cleanup workflow in README, mention helper
- add `hard_remove_new_tracks` helper and export it
- add `rename_new_to_track` helper and export it
- allow optional logging in `distance_remove`
- pass logger through `detect_features_async`
- fix indentation in `_get_clip_editor_override`
- test cleanup helpers and logging behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6877bf349998832db5d37e4af52d0bd1