### PR TITLE
Enhance track cleanup robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,12 @@ from modules.util.tracking_utils import hard_remove_new_tracks
 hard_remove_new_tracks(clip, logger=logger)
 ```
 
+> **Warnung:** `clip.tracking.tracks.remove()` ist ab Blender 4.4+ unsicher.
+> `hard_remove_new_tracks` nutzt daher immer `safe_remove_track` und greift
+> im Notfall über `track.id_data.tracking.tracks.get(name)` auf die Referenz
+> zu. Ein abschließendes `bpy.context.view_layer.update()` sorgt für die
+> Aktualisierung des UI-Zustands.
+
 Dieser Schritt sollte vor jedem erneuten Aufruf von `detect_features_async()` stehen.
 
 ## 🧩 Kernstellen der Blender-Kommunikation

--- a/modules/util/tracking_utils.py
+++ b/modules/util/tracking_utils.py
@@ -128,28 +128,61 @@ def count_markers_in_frame(tracks, frame):
 
 
 def hard_remove_new_tracks(clip, logger=None):
-    """Remove all tracks of ``clip`` whose names start with ``NEW_``."""
+    """Robustly remove all tracks starting with ``NEW_``.
+
+    Returns a list of track names that could not be removed.
+    """
 
     if not getattr(clip, "tracking", None):
-        return
+        return ["clip has no tracking data"]
 
     tracks = clip.tracking.tracks
-    new_tracks = [t for t in list(tracks) if getattr(t, "name", "").startswith("NEW_")]
+    all_tracks = list(tracks)
+    failed = []
 
-    for track in new_tracks:
-        safe_remove_track(clip, track, logger=logger)
+    for track in all_tracks:
+        if not getattr(track, "name", "").startswith("NEW_"):
+            continue
 
-    # remove any leftover empty tracks
-    for track in list(tracks):
-        if (
-            getattr(track, "name", "").startswith("NEW_")
-            and not getattr(track, "markers", [])
-        ):
+        removed = safe_remove_track(clip, track, logger=logger)
+        if removed:
+            continue
+
+        ref_clip = getattr(track, "id_data", clip)
+        ref_tracks = getattr(getattr(ref_clip, "tracking", None), "tracks", None)
+        if ref_tracks and getattr(track, "name", None) in ref_tracks:
             try:
-                tracks.remove(track)
+                ref_tracks.remove(ref_tracks.get(track.name))
                 if logger:
-                    logger.info(f"Track {track.name} force removed")
+                    logger.info(f"Force removed track by id_data: {track.name}")
+                continue
             except Exception as exc:  # pragma: no cover - fallback
                 if logger:
-                    logger.warning(f"Track {track.name} could not be removed: {exc}")
+                    logger.warning(f"Fallback removal failed for {track.name}: {exc}")
+
+        for t in ref_tracks or []:
+            if getattr(t, "name", None) == getattr(track, "name", None):
+                try:
+                    ref_tracks.remove(t)
+                    if logger:
+                        logger.info(f"Removed NEW_ track by name match: {track.name}")
+                    break
+                except Exception as exc:  # pragma: no cover - fallback
+                    if logger:
+                        logger.warning(f"Could not remove {track.name} by name match: {exc}")
+                        failed.append(track.name)
+                else:
+                    break
+        else:
+            failed.append(track.name)
+
+    try:  # ensure view layer refresh
+        bpy.context.view_layer.update()
+    except Exception:  # pragma: no cover - update might not be available in tests
+        pass
+
+    if failed and logger:
+        logger.warning(f"{len(failed)} NEW_ tracks could not be removed: {failed}")
+
+    return failed
 

--- a/tests/test_tracking_utils.py
+++ b/tests/test_tracking_utils.py
@@ -171,10 +171,11 @@ def test_hard_remove_new_tracks(monkeypatch):
 
     monkeypatch.setattr(tracking_utils, "safe_remove_track", dummy_safe_remove)
 
-    tracking_utils.hard_remove_new_tracks(clip)
+    result = tracking_utils.hard_remove_new_tracks(clip)
 
     names = [t.name for t in clip.tracking.tracks]
     assert names == ["KEEP"]
+    assert result == []
 
 
 def test_hard_remove_new_tracks_empty(monkeypatch):
@@ -187,10 +188,45 @@ def test_hard_remove_new_tracks_empty(monkeypatch):
 
     def dummy_safe_remove(_clip, track, logger=None):
         # simulate failure: do not remove t1
-        return track is not t1
+        if track is not t1:
+            clip.tracking.tracks.remove(track)
+            return True
+        return False
 
     monkeypatch.setattr(tracking_utils, "safe_remove_track", dummy_safe_remove)
 
-    tracking_utils.hard_remove_new_tracks(clip)
+    result = tracking_utils.hard_remove_new_tracks(clip)
 
     assert clip.tracking.tracks == []
+    assert result == []
+
+
+def test_hard_remove_fallback_by_name(monkeypatch):
+    clip = DummyClip()
+    t1 = DummyTrack("NEW_001")
+    clip.tracking.tracks.append(t1)
+
+    monkeypatch.setattr(tracking_utils, "safe_remove_track", lambda *_a, **_k: False)
+    clip.tracking.tracks.get = lambda name: None
+
+    result = tracking_utils.hard_remove_new_tracks(clip)
+
+    assert clip.tracking.tracks == []
+    assert result == []
+
+
+def test_hard_remove_returns_failed(monkeypatch):
+    clip = DummyClip()
+    t1 = DummyTrack("NEW_001")
+    clip.tracking.tracks.append(t1)
+
+    monkeypatch.setattr(tracking_utils, "safe_remove_track", lambda *_a, **_k: False)
+
+    def fail_remove(track):
+        raise RuntimeError("fail")
+
+    clip.tracking.tracks.remove = fail_remove
+
+    result = tracking_utils.hard_remove_new_tracks(clip)
+
+    assert result == ["NEW_001"]


### PR DESCRIPTION
## Summary
- make `hard_remove_new_tracks` more resilient by using additional fallbacks and returning failed names
- warn in README about unsafe `tracks.remove` usage and document view layer update
- expand tests for new removal behavior and failing scenarios

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877e369b87c832d8cdc34ab74cff58d