### PR TITLE
Improve track removal fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,9 @@ REVIEW / LOOP
 
 > **Hinweis:** Direktes Entfernen über `clip.tracking.tracks.remove()` wird ab Blender 4.4+ nicht mehr unterstützt. Verwende `safe_remove_track` oder `bpy.ops.clip.track_remove()`.
 
+### ⚠️ Hinweise zur Track‑Entfernung
+Als letzte Rückfallebene sucht `hard_remove_new_tracks` nach dem Track auch in `bpy.context.space_data.clip` und `bpy.data.movieclips`. Wird er dort gefunden, erfolgt ein Entfernungsversuch mit Attributprüfung und entsprechender Logging-Meldung.
+
 ---
 
 ## 🔧 Debug-Logging

--- a/modules/util/tracking_utils.py
+++ b/modules/util/tracking_utils.py
@@ -150,6 +150,47 @@ def hard_remove_new_tracks(clip, logger=None):
 
         ref_clip = getattr(track, "id_data", clip)
         ref_tracks = getattr(getattr(ref_clip, "tracking", None), "tracks", None)
+
+        if ref_tracks is None:
+            context_clip = getattr(getattr(bpy.context, "space_data", None), "clip", None)
+            data_movieclips = getattr(bpy.data, "movieclips", None)
+            movieclip_iter = []
+            if data_movieclips is not None:
+                if hasattr(data_movieclips, "values"):
+                    movieclip_iter = data_movieclips.values()
+                else:
+                    movieclip_iter = data_movieclips
+            fallback_sources = [
+                (context_clip, "context clip"),
+            ] + [(mc, "bpy.data.movieclips") for mc in movieclip_iter]
+
+            removed_via_fallback = False
+            for candidate_clip, label in fallback_sources:
+                candidate_tracks = getattr(getattr(candidate_clip, "tracking", None), "tracks", None)
+                if candidate_tracks and hasattr(candidate_tracks, "remove"):
+                    target = None
+                    if hasattr(candidate_tracks, "get"):
+                        target = candidate_tracks.get(track.name)
+                    if target is None:
+                        for t in candidate_tracks:
+                            if getattr(t, "name", None) == getattr(track, "name", None):
+                                target = t
+                                break
+                    if target is not None:
+                        try:
+                            candidate_tracks.remove(target)
+                            if logger:
+                                logger.info(f"Removed NEW_ track via {label} fallback: {track.name}")
+                            removed_via_fallback = True
+                            break
+                        except Exception as exc:  # pragma: no cover - fallback
+                            if logger:
+                                logger.warning(f"{label} fallback removal failed for {track.name}: {exc}")
+                            break
+
+            if removed_via_fallback:
+                continue
+
         if ref_tracks and getattr(track, "name", None) in ref_tracks:
             try:
                 ref_tracks.remove(ref_tracks.get(track.name))

--- a/tests/test_tracking_utils.py
+++ b/tests/test_tracking_utils.py
@@ -230,3 +230,43 @@ def test_hard_remove_returns_failed(monkeypatch):
     result = tracking_utils.hard_remove_new_tracks(clip)
 
     assert result == ["NEW_001"]
+
+
+def test_hard_remove_context_and_data_fallback(monkeypatch):
+    clip = DummyClip()
+    clip.name = "C1"
+    t1 = DummyTrack("NEW_CTX")
+    clip.tracking.tracks.append(t1)
+
+    monkeypatch.setattr(tracking_utils, "safe_remove_track", lambda *_a, **_k: False)
+    t1.id_data = SimpleNamespace(tracking=SimpleNamespace())
+
+    import bpy
+    bpy.context = _setup_context(clip, with_area=False)
+    bpy.context.space_data = SimpleNamespace(clip=clip)
+    bpy.data = SimpleNamespace(movieclips={"C1": clip})
+
+    result = tracking_utils.hard_remove_new_tracks(clip)
+
+    assert clip.tracking.tracks == []
+    assert result == []
+
+
+def test_hard_remove_data_fallback_only(monkeypatch):
+    clip = DummyClip()
+    clip.name = "C2"
+    t1 = DummyTrack("NEW_DATA")
+    clip.tracking.tracks.append(t1)
+
+    monkeypatch.setattr(tracking_utils, "safe_remove_track", lambda *_a, **_k: False)
+    t1.id_data = SimpleNamespace(tracking=SimpleNamespace())
+
+    import bpy
+    bpy.context = _setup_context(clip, with_area=False)
+    bpy.context.space_data = SimpleNamespace(clip=None)
+    bpy.data = SimpleNamespace(movieclips={"C2": clip})
+
+    result = tracking_utils.hard_remove_new_tracks(clip)
+
+    assert clip.tracking.tracks == []
+    assert result == []


### PR DESCRIPTION
## Summary
- support searching for tracks in the current context clip and `bpy.data.movieclips` when the normal reference list is unavailable
- ensure safe fallback removal with logging
- test the new search paths
- document this ultimate fallback

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68780223d6d4832d87325383f30e463a