### PR TITLE
Improve logging around marker removal

### DIFF
--- a/tests/test_tracking_utils.py
+++ b/tests/test_tracking_utils.py
@@ -74,6 +74,9 @@ class DummyLogger:
     def debug(self, msg):
         pass
 
+    def info(self, msg):
+        pass
+
 
 def test_safe_remove_track_operator(monkeypatch):
     called = {}


### PR DESCRIPTION
## Summary
- add detailed logs inside `safe_remove_track`
- report removed track names in `hard_remove_new_tracks`
- show which tracks were deleted during async detection retries
- update tests for new logger usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68785de1ceb0832dabf027309ce21028