### PR TITLE
Enhance track cleanup logging

### DIFF
--- a/modules/detection/async_detection.py
+++ b/modules/detection/async_detection.py
@@ -130,11 +130,14 @@ def detect_features_async(scene, clip, logger=None, attempts=10):
             return None
         if logger:
             logger.debug("Removing existing tracks before retrying")
+        before_names = [t.name for t in clip.tracking.tracks if t.name.startswith("NEW_")]
         failed = hard_remove_new_tracks(clip, logger=logger)
-        remaining = len([t for t in clip.tracking.tracks if t.name.startswith("NEW_")])
-        removed_count = marker_count - remaining
+        after_names = [t.name for t in clip.tracking.tracks if t.name.startswith("NEW_")]
+        removed_names = [n for n in before_names if n not in after_names]
+        remaining = len(after_names)
+        removed_count = len(removed_names)
         if logger:
-            logger.info(f"Removed {removed_count} NEW_ tracks")
+            logger.info(f"Removed {removed_count} NEW_ tracks: {removed_names}")
             logger.debug(f"Remaining NEW_ tracks after removal: {remaining}")
         if remaining:
             if logger:

--- a/tests/test_tracking_utils.py
+++ b/tests/test_tracking_utils.py
@@ -74,6 +74,9 @@ class DummyLogger:
     def debug(self, msg):
         pass
 
+    def info(self, msg):
+        pass
+
 
 def test_safe_remove_track_operator(monkeypatch):
     called = {}


### PR DESCRIPTION
## Summary
- add detailed logging in async detection when removing tracks
- improve safe_remove_track with logging about operator usage and success
- track removed track names in hard_remove_new_tracks
- extend DummyLogger with info method to satisfy new logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68786a26570c832d8a76be3af74e827e