### PR TITLE
Add motion tracking panel with button

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 Dieses Verzeichnis enthaelt ein minimales Blender Addon. Kopiere den Ordner `my_blender_addon` in deinen Blender Addons-Ordner und aktiviere das Addon in den Einstellungen.
 
 Das Addon stellt einen simplen Operator bereit, der im Info-Bereich eine Meldung ausgibt.
+
+Seit Version 1.1 gibt es im Clip Editor unter *Track* ein neues Panel mit einem Button. Dieser Button ruft einen Operator auf, der eine Meldung in Blender ausgibt.

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Simple Addon",
     "author": "Your Name",
-    "version": (1, 0),
+    "version": (1, 1),
     "blender": (3, 6, 0),
     "location": "View3D > Object",
     "description": "Zeigt eine einfache Meldung an",
@@ -19,11 +19,41 @@ class OBJECT_OT_simple_operator(bpy.types.Operator):
         self.report({'INFO'}, "Hello World from Addon")
         return {'FINISHED'}
 
+
+class CLIP_OT_panel_button(bpy.types.Operator):
+    bl_idname = "clip.panel_button"
+    bl_label = "Panel Button"
+    bl_description = "Gibt eine Meldung im Clip Editor aus"
+
+    def execute(self, context):
+        self.report({'INFO'}, "Button im Clip Editor gedr\u00fcckt")
+        return {'FINISHED'}
+
+
+class CLIP_PT_tracking_panel(bpy.types.Panel):
+    bl_space_type = 'CLIP_EDITOR'
+    bl_region_type = 'UI'
+    bl_category = 'Track'
+    bl_label = 'Addon Panel'
+
+    def draw(self, context):
+        layout = self.layout
+        layout.operator('clip.panel_button')
+
+classes = (
+    OBJECT_OT_simple_operator,
+    CLIP_OT_panel_button,
+    CLIP_PT_tracking_panel,
+)
+
+
 def register():
-    bpy.utils.register_class(OBJECT_OT_simple_operator)
+    for cls in classes:
+        bpy.utils.register_class(cls)
 
 def unregister():
-    bpy.utils.unregister_class(OBJECT_OT_simple_operator)
+    for cls in reversed(classes):
+        bpy.utils.unregister_class(cls)
 
 if __name__ == "__main__":
     register()

--- a/developer.md
+++ b/developer.md
@@ -1,0 +1,4 @@
+# Entwicklerhinweise
+
+## Version 1.1
+- Neues Panel im Clip Editor unter *Track* mit einem Button, der den Operator `clip.panel_button` aufruft.


### PR DESCRIPTION
## Summary
- add a simple panel in the Clip Editor with a button
- implement operator for panel button
- register operator and panel
- document the new panel in README and developer docs

## Testing
- `python -m py_compile __init__.py`

------
https://chatgpt.com/codex/tasks/task_e_68787b6c67a4832d9b751f79229684d7