### PR TITLE
Move cleanup button to separate UI panel

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -14,7 +14,10 @@ from .modules.operators.detect_features_operator import KAISERLICH_OT_detect_fea
 from .modules.operators.cleanup_new_tracks_operator import (
     KAISERLICH_OT_cleanup_new_tracks,
 )
-from .modules.ui.kaiserlich_panel import KAISERLICH_PT_tracking_tools
+from .modules.ui.kaiserlich_panel import (
+    KAISERLICH_PT_tracking_tools,
+    KAISERLICH_PT_cleanup_tools,
+)
 
 
 bl_info = {
@@ -33,6 +36,7 @@ classes = [
     KAISERLICH_OT_detect_features,
     KAISERLICH_OT_cleanup_new_tracks,
     KAISERLICH_PT_tracking_tools,
+    KAISERLICH_PT_cleanup_tools,
 ]
 
 

--- a/modules/ui/__init__.py
+++ b/modules/ui/__init__.py
@@ -1,5 +1,11 @@
 """UI components for the Kaiserlich Tracksycle addon."""
 
-from .kaiserlich_panel import KAISERLICH_PT_tracking_tools
+from .kaiserlich_panel import (
+    KAISERLICH_PT_tracking_tools,
+    KAISERLICH_PT_cleanup_tools,
+)
 
-__all__ = ["KAISERLICH_PT_tracking_tools"]
+__all__ = [
+    "KAISERLICH_PT_tracking_tools",
+    "KAISERLICH_PT_cleanup_tools",
+]

--- a/modules/ui/kaiserlich_panel.py
+++ b/modules/ui/kaiserlich_panel.py
@@ -3,7 +3,9 @@
 import bpy
 
 from ..operators.tracksycle_operator import KAISERLICH_OT_auto_track_cycle
-from ..operators.cleanup_new_tracks_operator import KAISERLICH_OT_cleanup_new_tracks
+from ..operators.cleanup_new_tracks_operator import (
+    KAISERLICH_OT_cleanup_new_tracks,
+)
 
 
 class KAISERLICH_PT_tracking_tools(bpy.types.Panel):
@@ -26,13 +28,34 @@ class KAISERLICH_PT_tracking_tools(bpy.types.Panel):
         layout.operator(
             KAISERLICH_OT_auto_track_cycle.bl_idname, text="Auto Track starten"
         )
-        layout.operator(
-            KAISERLICH_OT_cleanup_new_tracks.bl_idname, text="Cleanup NEW Tracks"
-        )
         layout.prop(scene, "min_marker_count")
         layout.prop(scene, "min_track_length")
         layout.prop(scene, "error_threshold")
         layout.prop(scene, "debug_output")
 
-__all__ = ["KAISERLICH_PT_tracking_tools"]
+
+class KAISERLICH_PT_cleanup_tools(bpy.types.Panel):
+    """UI panel hosting cleanup utilities."""
+
+    bl_label = "Kaiserlich Cleanup"
+    bl_space_type = 'CLIP_EDITOR'
+    bl_region_type = 'UI'
+    bl_category = "Kaiserlich"
+
+    @classmethod
+    def poll(cls, context):
+        space = context.space_data
+        return space and space.type == 'CLIP_EDITOR' and space.clip is not None
+
+    def draw(self, context):
+        layout = self.layout
+
+        layout.operator(
+            KAISERLICH_OT_cleanup_new_tracks.bl_idname, text="Cleanup NEW Tracks"
+        )
+
+__all__ = [
+    "KAISERLICH_PT_tracking_tools",
+    "KAISERLICH_PT_cleanup_tools",
+]
 


### PR DESCRIPTION
## Summary
- split the cleanup operator into its own panel
- update module exports and register the new panel

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68787c75f6a0832da3cc34b6340223f3