### PR TITLE
Add button to new panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@ Dieses Verzeichnis enthaelt ein minimales Blender Addon. Kopiere den Ordner `my_
 Das Addon stellt einen simplen Operator bereit, der im Info-Bereich eine Meldung ausgibt.
 
 Seit Version 1.1 gibt es im Clip Editor unter *Track* ein neues Panel mit einem Button. Dieser Button ruft einen Operator auf, der eine Meldung in Blender ausgibt.
+
+Seit Version 1.2 befindet sich der Button in einem eigenen Panel.

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Simple Addon",
     "author": "Your Name",
-    "version": (1, 1),
+    "version": (1, 2),
     "blender": (3, 6, 0),
     "location": "View3D > Object",
     "description": "Zeigt eine einfache Meldung an",
@@ -38,12 +38,24 @@ class CLIP_PT_tracking_panel(bpy.types.Panel):
 
     def draw(self, context):
         layout = self.layout
+        layout.label(text="Addon Informationen")
+
+
+class CLIP_PT_button_panel(bpy.types.Panel):
+    bl_space_type = 'CLIP_EDITOR'
+    bl_region_type = 'UI'
+    bl_category = 'Track'
+    bl_label = 'Button Panel'
+
+    def draw(self, context):
+        layout = self.layout
         layout.operator('clip.panel_button')
 
 classes = (
     OBJECT_OT_simple_operator,
     CLIP_OT_panel_button,
     CLIP_PT_tracking_panel,
+    CLIP_PT_button_panel,
 )
 
 

--- a/developer.md
+++ b/developer.md
@@ -2,3 +2,6 @@
 
 ## Version 1.1
 - Neues Panel im Clip Editor unter *Track* mit einem Button, der den Operator `clip.panel_button` aufruft.
+
+## Version 1.2
+- Der Button befindet sich jetzt in einem eigenen Panel (`CLIP_PT_button_panel`).


### PR DESCRIPTION
## Summary
- bump addon version to 1.2
- move the button to its own Clip Editor panel
- update docs to mention the new panel

## Testing
- `python3 -m py_compile __init__.py`
- `pip install flake8` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68787d5da38c832da10b131b12c4c750