### PR TITLE
Move button panel to its own tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@ Das Addon stellt einen simplen Operator bereit, der im Info-Bereich eine Meldung
 Seit Version 1.1 gibt es im Clip Editor unter *Track* ein neues Panel mit einem Button. Dieser Button ruft einen Operator auf, der eine Meldung in Blender ausgibt.
 
 Seit Version 1.2 befindet sich der Button in einem eigenen Panel.
+Seit Version 1.3 liegt dieses Panel in einem separaten Tab "Addon" im Clip Editor.

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Simple Addon",
     "author": "Your Name",
-    "version": (1, 2),
+    "version": (1, 3),
     "blender": (3, 6, 0),
     "location": "View3D > Object",
     "description": "Zeigt eine einfache Meldung an",
@@ -44,7 +44,7 @@ class CLIP_PT_tracking_panel(bpy.types.Panel):
 class CLIP_PT_button_panel(bpy.types.Panel):
     bl_space_type = 'CLIP_EDITOR'
     bl_region_type = 'UI'
-    bl_category = 'Track'
+    bl_category = 'Addon'
     bl_label = 'Button Panel'
 
     def draw(self, context):

--- a/developer.md
+++ b/developer.md
@@ -5,3 +5,6 @@
 
 ## Version 1.2
 - Der Button befindet sich jetzt in einem eigenen Panel (`CLIP_PT_button_panel`).
+
+## Version 1.3
+- Das Button-Panel liegt nun im separaten Tab `Addon`.


### PR DESCRIPTION
## Summary
- bump addon version to 1.3
- show button panel in its own UI tab
- update README and developer notes for the new tab location

## Testing
- `python -m py_compile __init__.py`

------
https://chatgpt.com/codex/tasks/task_e_68787e896db0832db69dcee657cef977