### PR TITLE
Fix proxy directory attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,5 @@ Seit Version 1.1 gibt es im Clip Editor unter *Track* ein neues Panel mit einem 
 Seit Version 1.2 befindet sich der Button in einem eigenen Panel.
 Seit Version 1.3 liegt dieses Panel in einem separaten Tab "Addon" im Clip Editor.
 Seit Version 1.4 baut der Button Proxys mit 50 % Gr\u00f6\u00dfe und einer Qualit\u00e4t von 50 im benutzerdefinierten Verzeichnis `//proxies`.
+Seit Version 1.4.1 wird für Blender 4.4 das Attribut `clip.proxy.use_proxy_custom_directory` verwendet.
 Seit Version 1.5 entfernt der Button vorhandene Proxy-Verzeichnisse, bevor neue Proxys erstellt werden.

--- a/__init__.py
+++ b/__init__.py
@@ -40,7 +40,10 @@ class CLIP_OT_panel_button(bpy.types.Operator):
         # Proxy mit Qualität 50 erzeugen
         clip.proxy.quality = 50
 
-        clip.proxy.use_custom_directory = True
+        if hasattr(clip.proxy, "use_proxy_custom_directory"):
+            clip.proxy.use_proxy_custom_directory = True
+        else:
+            clip.proxy.use_custom_directory = True
         clip.proxy.directory = "//proxies"
 
         # absoluten Pfad zum Proxy-Verzeichnis auflösen

--- a/developer.md
+++ b/developer.md
@@ -12,5 +12,8 @@
 ## Version 1.4
 - Der Operator `clip.panel_button` baut jetzt 50%-Proxys mit Qualit\u00e4t 50 im Ordner `//proxies`.
 
+## Version 1.4.1
+- `clip.proxy.use_custom_directory` ersetzt durch `clip.proxy.use_proxy_custom_directory` (API-Anpassung ab Blender 4.4).
+
 ## Version 1.5
 - Vor dem Proxy-Bau wird das Proxy-Verzeichnis (falls vorhanden) gel\u00f6scht, bevor neue Proxys erstellt werden.


### PR DESCRIPTION
## Summary
- fix deprecated `clip.proxy.use_custom_directory` by switching to `clip.proxy.use_proxy_custom_directory`
- document API update in `developer.md`
- mention update for Blender 4.4 in `README.md`

## Testing
- `python -m py_compile __init__.py`

------
https://chatgpt.com/codex/tasks/task_e_687886f72374832d92d45b4b37761540