### PR TITLE
Add Marker button and frame input

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ Seit Version 1.3 liegt dieses Panel in einem separaten Tab "Addon" im Clip Edito
 Seit Version 1.4 baut der Button Proxys mit 50 % Gr\u00f6\u00dfe und einer Qualit\u00e4t von 50 im benutzerdefinierten Verzeichnis `//proxies`.
 Seit Version 1.4.1 wird nur `clip.proxy.directory` gesetzt. Das Attribut `clip.proxy.use_proxy_custom_directory` entfällt.
 Seit Version 1.5 entfernt der Button vorhandene Proxy-Verzeichnisse, bevor neue Proxys erstellt werden.
+Seit Version 1.6 gibt es ein Eingabefeld "Marker / Frame" und einen zus\u00e4tzlichen "Marker"-Button, der einen Timeline Marker setzt.

--- a/__init__.py
+++ b/__init__.py
@@ -11,6 +11,7 @@ bl_info = {
 import bpy
 import os
 import shutil
+from bpy.props import IntProperty
 
 class OBJECT_OT_simple_operator(bpy.types.Operator):
     bl_idname = "object.simple_operator"
@@ -24,7 +25,7 @@ class OBJECT_OT_simple_operator(bpy.types.Operator):
 
 class CLIP_OT_panel_button(bpy.types.Operator):
     bl_idname = "clip.panel_button"
-    bl_label = "Panel Button"
+    bl_label = "Proxy"
     bl_description = "Erstellt Proxy-Dateien mit 50% Gr\u00f6\u00dfe"
 
     def execute(self, context):
@@ -61,6 +62,19 @@ class CLIP_OT_panel_button(bpy.types.Operator):
         return {'FINISHED'}
 
 
+class CLIP_OT_marker_button(bpy.types.Operator):
+    bl_idname = "clip.marker_button"
+    bl_label = "Marker"
+    bl_description = "Setzt einen Timeline Marker an der angegebenen Frame-Nummer"
+
+    def execute(self, context):
+        frame = context.scene.marker_frame
+        context.scene.frame_current = frame
+        bpy.ops.marker.add()
+        self.report({'INFO'}, f"Marker bei Frame {frame} gesetzt")
+        return {'FINISHED'}
+
+
 class CLIP_PT_tracking_panel(bpy.types.Panel):
     bl_space_type = 'CLIP_EDITOR'
     bl_region_type = 'UI'
@@ -80,23 +94,32 @@ class CLIP_PT_button_panel(bpy.types.Panel):
 
     def draw(self, context):
         layout = self.layout
+        layout.prop(context.scene, 'marker_frame', text='Marker / Frame')
+        layout.operator('clip.marker_button')
         layout.operator('clip.panel_button')
 
 classes = (
     OBJECT_OT_simple_operator,
     CLIP_OT_panel_button,
+    CLIP_OT_marker_button,
     CLIP_PT_tracking_panel,
     CLIP_PT_button_panel,
 )
 
 
 def register():
+    bpy.types.Scene.marker_frame = IntProperty(
+        name="Marker / Frame",
+        description="Frame f\u00fcr neuen Timeline Marker",
+        default=1,
+    )
     for cls in classes:
         bpy.utils.register_class(cls)
 
 def unregister():
     for cls in reversed(classes):
         bpy.utils.unregister_class(cls)
+    del bpy.types.Scene.marker_frame
 
 if __name__ == "__main__":
     register()

--- a/developer.md
+++ b/developer.md
@@ -17,3 +17,7 @@
 
 ## Version 1.5
 - Vor dem Proxy-Bau wird das Proxy-Verzeichnis (falls vorhanden) gel\u00f6scht, bevor neue Proxys erstellt werden.
+
+## Version 1.6
+- Neues Eingabefeld "Marker / Frame" oberhalb des Panels
+- Neuer Button "Marker", der einen Timeline Marker am angegebenen Frame setzt.


### PR DESCRIPTION
## Summary
- add new `Marker` button operator using Blender API `marker.add`
- display input field "Marker / Frame" for frame selection
- track updates in docs

## Testing
- `python3 -m py_compile __init__.py`


------
https://chatgpt.com/codex/tasks/task_e_6878a4859610832d908cc168cef9c026