### PR TITLE
Add operator to clean duplicate tracks

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ Seit Version 1.4.1 wird nur `clip.proxy.directory` gesetzt. Das Attribut `clip.p
 Seit Version 1.5 entfernt der Button vorhandene Proxy-Verzeichnisse, bevor neue Proxys erstellt werden.
 Seit Version 1.6 gibt es ein Eingabefeld "Marker / Frame" und einen zus\u00e4tzlichen "Marker"-Button, der einen Timeline Marker setzt.
 Seit Version 1.7 bietet das Panel einen Button "Clean NEW Tracks", der neu erkannte Tracks l\u00f6scht, wenn sie zu nah an bestehenden GOOD_ Tracks liegen.
+Seit Version 1.7.1 kann derselbe Operator auch ohne erneute Feature-Erkennung ausgef\u00fchrt werden.

--- a/developer.md
+++ b/developer.md
@@ -25,3 +25,8 @@
 ## Version 1.7
 - Neuer Operator `clip.clean_new_tracks` entfernt `NEW_`-Tracks, die im aktuellen
   Frame näher als die berechnete Pixel-Distanz zu `GOOD_`-Tracks liegen.
+
+## Version 1.7.1
+- `clip.clean_new_tracks` besitzt jetzt eine Option `detect`, um die Feature-
+  Erkennung wahlweise zu überspringen.
+- Fehler beim Löschen von Tracks werden abgefangen.


### PR DESCRIPTION
## Summary
- add `clean_new_tracks` operator to remove NEW_ tracks close to GOOD_ tracks
- document new operator in developer notes and README

## Testing
- `python -m py_compile __init__.py`


------
https://chatgpt.com/codex/tasks/task_e_6878baca00d4832d88fb8d39eda93ee7