### PR TITLE
Fix marker to use clip operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,5 @@ Seit Version 1.5 entfernt der Button vorhandene Proxy-Verzeichnisse, bevor neue 
 Seit Version 1.6 gibt es ein Eingabefeld "Marker / Frame" und einen zus\u00e4tzlichen "Marker"-Button, der einen Timeline Marker setzt.
 Seit Version 1.7 bietet das Panel einen Button "Clean NEW Tracks", der neu erkannte Tracks l\u00f6scht, wenn sie zu nah an bestehenden GOOD_ Tracks liegen.
 Seit Version 1.7.1 kann derselbe Operator auch ohne erneute Feature-Erkennung ausgef\u00fchrt werden.
+Seit Version 1.8 setzt der "Marker"-Button nun einen Clip Marker (Movie Tracking
+Marker) im Clip Editor anstatt eines Timeline Markers.

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Simple Addon",
     "author": "Your Name",
-    "version": (1, 7),
+    "version": (1, 8),
     "blender": (4, 4, 0),
     "location": "View3D > Object",
     "description": "Zeigt eine einfache Meldung an",
@@ -65,12 +65,14 @@ class CLIP_OT_panel_button(bpy.types.Operator):
 class CLIP_OT_marker_button(bpy.types.Operator):
     bl_idname = "clip.marker_button"
     bl_label = "Marker"
-    bl_description = "Setzt einen Timeline Marker an der angegebenen Frame-Nummer"
+    bl_description = (
+        "Setzt einen Clip Marker (Movie Tracking Marker) am angegebenen Frame"
+    )
 
     def execute(self, context):
         frame = context.scene.marker_frame
         context.scene.frame_current = frame
-        bpy.ops.marker.add()
+        bpy.ops.clip.add_marker()
         self.report({'INFO'}, f"Marker bei Frame {frame} gesetzt")
         return {'FINISHED'}
 

--- a/developer.md
+++ b/developer.md
@@ -30,3 +30,7 @@
 - `clip.clean_new_tracks` besitzt jetzt eine Option `detect`, um die Feature-
   Erkennung wahlweise zu überspringen.
 - Fehler beim Löschen von Tracks werden abgefangen.
+
+## Version 1.8
+- Der "Marker"-Button setzt nun einen Clip Marker (Movie Tracking Marker) im
+  Clip Editor statt eines Timeline Markers.


### PR DESCRIPTION
## Summary
- update version to 1.8
- use `bpy.ops.clip.add_marker()` instead of timeline markers
- document change in developer and user documentation

## Testing
- `python -m py_compile __init__.py`


------
https://chatgpt.com/codex/tasks/task_e_6878c8c92a00832db1c06a685222a462