### PR TITLE
Improve detection override handling

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -258,6 +258,12 @@ def detect_features_no_proxy(clip, threshold=1.0, margin=None,
                              min_distance=None, logger=None):
     clip.proxy.build_50 = False
     clip.use_proxy = False
+    # Werte im SpaceClipEditor setzen, damit Blender konsistent arbeitet
+    space = get_clip_editor_override().get("space_data")
+    if space:
+        space.detection_threshold = threshold
+        space.detection_distance = min_distance
+        space.detection_margin = margin
     bpy.ops.clip.detect_features(
         threshold=threshold,
         margin=margin,

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Ein Blender-Add-on, das das automatische Tracking von Markern vereinfacht.
    - **Tracking-Länge**
    - **Fehler-Schwelle**
    - **Debug Output aktivieren**
+   - **Detection-Einstellungen des Clip Editors** (Threshold, Distance, Margin)
 
 ## Bekannte Einschränkungen
 - Blender **4.0** oder neuer erforderlich.

--- a/tests/test_detect_no_proxy.py
+++ b/tests/test_detect_no_proxy.py
@@ -27,8 +27,10 @@ def _setup_context(areas, called):
         def __exit__(self, exc_type, exc_val, exc_tb):
             return False
 
+    screen = SimpleNamespace(areas=areas)
     return SimpleNamespace(
-        screen=SimpleNamespace(areas=areas),
+        window=SimpleNamespace(screen=screen),
+        screen=screen,
         scene="scene",
         temp_override=lambda **kw: DummyOverride(**kw),
     )
@@ -36,7 +38,13 @@ def _setup_context(areas, called):
 
 def test_detect_features_no_proxy_ui_context(monkeypatch):
     called = {}
-    areas = [SimpleNamespace(type="CLIP_EDITOR", regions=[SimpleNamespace(type="WINDOW")])]
+    areas = [
+        SimpleNamespace(
+            type="CLIP_EDITOR",
+            regions=[SimpleNamespace(type="WINDOW")],
+            spaces=SimpleNamespace(active=SimpleNamespace(type="CLIP_EDITOR")),
+        )
+    ]
     import bpy
     bpy.context = _setup_context(areas, called)
 
@@ -58,8 +66,10 @@ def test_detect_features_no_proxy_ui_context(monkeypatch):
     assert called["min_distance"] == 5
     assert called["args"] == ()
     assert called["override"]["clip"] is clip
+    assert called["override"]["window"] == bpy.context.window
     assert called["override"]["area"] is areas[0]
     assert called["override"]["region"] is areas[0].regions[0]
+    assert called["override"]["space_data"] is areas[0].spaces.active
     assert called["override"]["scene"] == "scene"
 
 


### PR DESCRIPTION
## Summary
- keep detection parameters in sync with Clip Editor settings via `get_clip_editor_override`
- update developer notes and README
- adjust tests for new override keys

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878d7e72b84832db207c6b1c28decb2