### PR TITLE
Fix detect_features parameter usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,6 @@ Marker) im Clip Editor anstatt eines Timeline Markers.
 Seit Version 1.9 ruft der "Marker"-Button `clip.detect_features()` auf und setzt
 vorher die Parameter `detection_threshold`, `detection_distance` und
 `detection_margin`.
+Seit Version 1.10 werden diese Parameter direkt an den Operator
+`clip.detect_features()` übergeben, da sie nicht mehr als
+Eigenschaften von `SpaceClipEditor` verfügbar sind.

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Simple Addon",
     "author": "Your Name",
-    "version": (1, 9),
+    "version": (1, 10),
     "blender": (4, 4, 0),
     "location": "View3D > Object",
     "description": "Zeigt eine einfache Meldung an",
@@ -73,12 +73,11 @@ class CLIP_OT_marker_button(bpy.types.Operator):
         frame = context.scene.marker_frame
         context.scene.frame_current = frame
 
-        space = context.space_data
-        space.detection_threshold = 0.8
-        space.detection_distance = 120
-        space.detection_margin = 1
-
-        bpy.ops.clip.detect_features()
+        bpy.ops.clip.detect_features(
+            threshold=0.8,
+            distance=120,
+            margin=1,
+        )
         self.report({'INFO'}, f"Features bei Frame {frame} erkannt")
         return {'FINISHED'}
 
@@ -108,12 +107,14 @@ class CLIP_OT_clean_new_tracks(bpy.types.Operator):
         margin = width / 100.0
         distance_px = width / 20.0
 
-        space.detection_margin = margin
-        space.detection_distance = distance_px
-        space.detection_threshold = 1.0
+        threshold = 1.0
 
         if self.detect:
-            bpy.ops.clip.detect_features()
+            bpy.ops.clip.detect_features(
+                threshold=threshold,
+                distance=distance_px,
+                margin=margin,
+            )
 
             for track in clip.tracking.tracks:
                 if track.select and not track.name.startswith("NEW_"):

--- a/developer.md
+++ b/developer.md
@@ -38,3 +38,8 @@
 ## Version 1.9
 - Der "Marker"-Button führt nun `clip.detect_features()` aus. Dabei werden
   `detection_threshold`, `detection_distance` und `detection_margin` gesetzt.
+
+## Version 1.10
+- Die Parameter für `clip.detect_features()` werden nun direkt beim
+  Operatoraufruf übergeben, da die entsprechenden Eigenschaften im
+  `SpaceClipEditor` nicht mehr existieren.


### PR DESCRIPTION
## Summary
- bump version to 1.10
- use parameters with `clip.detect_features` instead of removed properties
- document the change in README and developer notes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68791a0c4310832db803aed3bbf98205