### PR TITLE
Add console output for detect_features parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -17,10 +17,12 @@ Seit Version 1.7.1 kann derselbe Operator auch ohne erneute Feature-Erkennung au
 Seit Version 1.8 setzt der "Marker"-Button nun einen Clip Marker (Movie Tracking
 Marker) im Clip Editor anstatt eines Timeline Markers.
 Seit Version 1.9 ruft der "Marker"-Button `clip.detect_features()` auf und setzt
-vorher die Parameter `detection_threshold`, `detection_distance` und
+vorher die Parameter `detection_threshold`, `min_distance` und
 `detection_margin`.
 Seit Version 1.10 werden diese Parameter direkt an den Operator
 `clip.detect_features()` übergeben, da sie nicht mehr als
 Eigenschaften von `SpaceClipEditor` verfügbar sind.
 Seit Version 1.11 heißt der Parameter für den Mindestabstand
 `min_distance` und ersetzt das bisherige `detection_distance`.
+Seit Version 1.12 werden die verwendeten Werte für `margin` und `min_distance`
+beim Aufruf von `clip.detect_features()` in der Konsole ausgegeben.

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Simple Addon",
     "author": "Your Name",
-    "version": (1, 11),
+    "version": (1, 12),
     "blender": (4, 4, 0),
     "location": "View3D > Object",
     "description": "Zeigt eine einfache Meldung an",
@@ -73,10 +73,13 @@ class CLIP_OT_marker_button(bpy.types.Operator):
         frame = context.scene.marker_frame
         context.scene.frame_current = frame
 
+        margin = 1
+        min_distance = 120
+        print(f"detect_features: margin={margin}, min_distance={min_distance}")
         bpy.ops.clip.detect_features(
             threshold=0.8,
-            min_distance=120,
-            margin=1,
+            min_distance=min_distance,
+            margin=margin,
         )
         self.report({'INFO'}, f"Features bei Frame {frame} erkannt")
         return {'FINISHED'}
@@ -104,12 +107,15 @@ class CLIP_OT_clean_new_tracks(bpy.types.Operator):
             return {'CANCELLED'}
 
         width, height = clip.size
-        margin = width / 100.0
-        min_distance_px = width / 20.0
+        margin = width // 100
+        min_distance_px = width // 20
 
         threshold = 1.0
 
         if self.detect:
+            print(
+                f"detect_features: margin={margin}, min_distance={min_distance_px}"
+            )
             bpy.ops.clip.detect_features(
                 threshold=threshold,
                 min_distance=min_distance_px,

--- a/developer.md
+++ b/developer.md
@@ -37,7 +37,7 @@
 
 ## Version 1.9
 - Der "Marker"-Button führt nun `clip.detect_features()` aus. Dabei werden
-  `detection_threshold`, `detection_distance` und `detection_margin` gesetzt.
+  `detection_threshold`, `min_distance` und `detection_margin` gesetzt.
 
 ## Version 1.10
 - Die Parameter für `clip.detect_features()` werden nun direkt beim
@@ -48,3 +48,8 @@
 - Der Parameter `detection_distance` wurde durch `min_distance`
   ersetzt, der nun beim Aufruf von `clip.detect_features()`
   verwendet wird.
+
+## Version 1.12
+- Beim Aufruf von `clip.detect_features()` werden die verwendeten Werte für
+  `margin` und `min_distance` in der Konsole ausgegeben. Beide Werte sind
+  nun ganze Zahlen.


### PR DESCRIPTION
## Summary
- log the integer `margin` and `min_distance` values used for `clip.detect_features`
- document the new console output in README and developer notes
- bump addon version to 1.12
- add `.gitignore` for Python bytecode

## Testing
- `python -m py_compile __init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68792e19bf60832d96025447b0389386