### PR TITLE
Add Tracking Marker workflow operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ Ein Blender-Add-on, das das automatische Tracking von Markern vereinfacht.
 1. Movie Clip Editor öffnen und einen Clip laden.
 2. In der Sidebar den Tab **"Kaiserlich"** wählen.
 3. **Auto Track** drücken. Das Add-on erkennt Features, verfolgt sie und bereinigt neue Marker.
-4. Optional können im Panel weitere Parameter angepasst werden:
+4. **Detect Features** führt nur die Feature-Erkennung aus.
+5. **Tracking Marker** startet den benutzerdefinierten Workflow.
+6. Optional können im Panel weitere Parameter angepasst werden:
    - **Minimale Markeranzahl**
    - **Tracking-Länge**
    - **Fehler-Schwelle**

--- a/__init__.py
+++ b/__init__.py
@@ -14,6 +14,7 @@ from .modules.operators.detect_features_operator import KAISERLICH_OT_detect_fea
 from .modules.operators.cleanup_new_tracks_operator import (
     KAISERLICH_OT_cleanup_new_tracks,
 )
+from .modules.operators.tracking_marker_operator import KAISERLICH_OT_tracking_marker
 from .modules.ui.kaiserlich_panel import (
     KAISERLICH_PT_tracking_tools,
     KAISERLICH_PT_cleanup_tools,
@@ -35,6 +36,7 @@ classes = [
     KAISERLICH_OT_rename_tracks_modal,
     KAISERLICH_OT_detect_features,
     KAISERLICH_OT_cleanup_new_tracks,
+    KAISERLICH_OT_tracking_marker,
     KAISERLICH_PT_tracking_tools,
     KAISERLICH_PT_cleanup_tools,
 ]

--- a/modules/operators/__init__.py
+++ b/modules/operators/__init__.py
@@ -4,10 +4,12 @@ from .tracksycle_operator import KAISERLICH_OT_auto_track_cycle
 from .rename_tracks_modal import KAISERLICH_OT_rename_tracks_modal
 from .detect_features_operator import KAISERLICH_OT_detect_features
 from .cleanup_new_tracks_operator import KAISERLICH_OT_cleanup_new_tracks
+from .tracking_marker_operator import KAISERLICH_OT_tracking_marker
 
 __all__ = [
     "KAISERLICH_OT_auto_track_cycle",
     "KAISERLICH_OT_rename_tracks_modal",
     "KAISERLICH_OT_detect_features",
     "KAISERLICH_OT_cleanup_new_tracks",
+    "KAISERLICH_OT_tracking_marker",
 ]

--- a/modules/operators/tracking_marker_operator.py
+++ b/modules/operators/tracking_marker_operator.py
@@ -1,0 +1,104 @@
+"""Operator implementing custom tracking workflow."""
+
+from __future__ import annotations
+
+import bpy
+
+from ..detection.detect_no_proxy import detect_features_no_proxy
+from ..detection.distance_remove import distance_remove
+from ..util.tracking_utils import hard_remove_new_tracks
+from ..util.tracker_logger import TrackerLogger, configure_logger
+
+
+class KAISERLICH_OT_tracking_marker(bpy.types.Operator):  # type: ignore[misc]
+    """Detect features with iterative threshold adjustment."""
+
+    bl_idname = "kaiserlich.tracking_marker"
+    bl_label = "Tracking Marker"
+    bl_options = {'REGISTER', 'UNDO'}
+
+    attempts: bpy.props.IntProperty(name="Versuche", default=10, min=1)
+
+    def execute(self, context):  # type: ignore[override]
+        space = context.space_data
+        clip = getattr(space, "clip", None)
+        if not clip:
+            self.report({'ERROR'}, "No clip loaded")
+            return {'CANCELLED'}
+
+        scene = context.scene
+        configure_logger(debug=getattr(scene, "debug_output", False))
+        logger = TrackerLogger()
+
+        width, height = clip.size
+        logger.info(f"Auflösung: {width} x {height}")
+
+        margin = width * 0.01
+        dist_px = width * 0.002
+
+        threshold = 1.0
+        expected = getattr(scene, "min_marker_count", 10) * 4
+
+        for _ in range(self.attempts):
+            space.detection_margin = margin
+            space.detection_distance = int(dist_px)
+            space.detection_threshold = threshold
+
+            detect_features_no_proxy(
+                clip,
+                threshold=threshold,
+                margin=margin,
+                min_distance=dist_px,
+                logger=logger,
+            )
+
+            existing_names = {t.name for t in clip.tracking.tracks}
+            idx = 0
+            for track in clip.tracking.tracks:
+                if track.name.startswith(("Track", "Track.", "Track_")):
+                    new_name = f"NEW_{idx:03}"
+                    while new_name in existing_names:
+                        idx += 1
+                        new_name = f"NEW_{idx:03}"
+                    track.name = new_name
+                    track.pattern_size = 50
+                    track.search_size = 100
+                    existing_names.add(new_name)
+                    idx += 1
+
+            good_tracks = [t for t in clip.tracking.tracks if t.name.startswith("GOOD_")]
+            frame = scene.frame_current
+            for good in good_tracks:
+                marker = None
+                if hasattr(good.markers, "find_frame"):
+                    mi = good.markers.find_frame(frame)
+                    if mi != -1:
+                        marker = good.markers[mi]
+                if marker is None:
+                    marker = next(
+                        (m for m in good.markers if getattr(m, "frame", None) == frame),
+                        None,
+                    )
+                if marker:
+                    distance_remove(clip.tracking.tracks, marker.co, dist_px, logger=logger)
+
+            nm = len([t for t in clip.tracking.tracks if t.name.startswith("NEW_")])
+            min_valid = expected * 0.8
+            max_valid = expected * 1.2
+            if min_valid <= nm <= max_valid:
+                for track in clip.tracking.tracks:
+                    if track.name.startswith("NEW_"):
+                        track.name = track.name.replace("NEW_", "TRACK_")
+                logger.info("Detection erfolgreich")
+                return {'FINISHED'}
+
+            threshold = max(round(threshold * ((nm + 0.1) / expected), 5), 0.0001)
+            hard_remove_new_tracks(clip, logger=logger)
+
+        for track in clip.tracking.tracks:
+            if track.name.startswith("NEW_"):
+                track.name = track.name.replace("NEW_", "TRACK_")
+        return {'FINISHED'}
+
+
+__all__ = ["KAISERLICH_OT_tracking_marker"]

--- a/modules/ui/kaiserlich_panel.py
+++ b/modules/ui/kaiserlich_panel.py
@@ -6,6 +6,8 @@ from ..operators.tracksycle_operator import KAISERLICH_OT_auto_track_cycle
 from ..operators.cleanup_new_tracks_operator import (
     KAISERLICH_OT_cleanup_new_tracks,
 )
+from ..operators.detect_features_operator import KAISERLICH_OT_detect_features
+from ..operators.tracking_marker_operator import KAISERLICH_OT_tracking_marker
 
 
 class KAISERLICH_PT_tracking_tools(bpy.types.Panel):
@@ -27,6 +29,12 @@ class KAISERLICH_PT_tracking_tools(bpy.types.Panel):
 
         layout.operator(
             KAISERLICH_OT_auto_track_cycle.bl_idname, text="Auto Track starten"
+        )
+        layout.operator(
+            KAISERLICH_OT_detect_features.bl_idname, text="Detect Features"
+        )
+        layout.operator(
+            KAISERLICH_OT_tracking_marker.bl_idname, text="Tracking Marker"
         )
         layout.prop(scene, "min_marker_count")
         layout.prop(scene, "min_track_length")

--- a/tests/test_tracking_marker_operator.py
+++ b/tests/test_tracking_marker_operator.py
@@ -1,0 +1,89 @@
+import os
+import sys
+from types import SimpleNamespace
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import modules.operators.tracking_marker_operator as marker_op
+
+
+class DummyClip:
+    def __init__(self):
+        self.size = (1000, 1000)
+        self.tracking = SimpleNamespace(tracks=[])
+
+
+class DummyContext:
+    def __init__(self, clip):
+        self.scene = SimpleNamespace(frame_current=1, min_marker_count=5, debug_output=False)
+        self.space_data = SimpleNamespace(clip=clip,
+                                         detection_margin=0,
+                                         detection_distance=0,
+                                         detection_threshold=0)
+
+
+def test_operator_no_clip():
+    op = marker_op.KAISERLICH_OT_tracking_marker()
+    op.report = lambda *a, **k: None
+    context = DummyContext(None)
+    result = op.execute(context)
+    assert result == {'CANCELLED'}
+
+
+def test_operator_adjusts_threshold(monkeypatch):
+    thresholds = []
+    marker_counts = [0, 0, 0]
+
+    def dummy_detect(clip, threshold=1.0, margin=None, min_distance=None, logger=None):
+        thresholds.append(threshold)
+        count = marker_counts.pop(0)
+        clip.tracking.tracks = [SimpleNamespace(name=f"Track{i}", markers=[SimpleNamespace(co=(0,0))]) for i in range(count)]
+        return True
+
+    monkeypatch.setattr(marker_op, "detect_features_no_proxy", dummy_detect)
+    monkeypatch.setattr(marker_op, "distance_remove", lambda *a, **k: None)
+    monkeypatch.setattr(marker_op, "hard_remove_new_tracks", lambda *a, **k: [])
+
+    clip = DummyClip()
+    context = DummyContext(clip)
+
+    op = marker_op.KAISERLICH_OT_tracking_marker()
+    op.report = lambda *a, **k: None
+    op.attempts = 3
+
+    op.execute(context)
+
+    assert len(set(thresholds)) > 1
+    assert thresholds[0] == 1.0
+    assert len(thresholds) == 3
+
+
+def test_distance_filter_uses_current_frame(monkeypatch):
+    captured = {}
+
+    def dummy_detect(clip, threshold=1.0, margin=None, min_distance=None, logger=None):
+        good = SimpleNamespace(
+            name="GOOD_1",
+            markers=[SimpleNamespace(frame=1, co=(1,1)), SimpleNamespace(frame=2, co=(2,2))],
+        )
+        clip.tracking.tracks = [good, SimpleNamespace(name="Track0", markers=[SimpleNamespace(co=(0,0))])]
+        return True
+
+    def dummy_distance(tracks, pos, margin, logger=None):
+        captured['pos'] = pos
+
+    monkeypatch.setattr(marker_op, "detect_features_no_proxy", dummy_detect)
+    monkeypatch.setattr(marker_op, "distance_remove", dummy_distance)
+    monkeypatch.setattr(marker_op, "hard_remove_new_tracks", lambda *a, **k: [])
+
+    clip = DummyClip()
+    context = DummyContext(clip)
+    context.scene.frame_current = 2
+
+    op = marker_op.KAISERLICH_OT_tracking_marker()
+    op.report = lambda *a, **k: None
+    op.attempts = 1
+
+    op.execute(context)
+
+    assert captured.get('pos') == (2,2)


### PR DESCRIPTION
## Summary
- add new operator for a custom feature detection cycle
- expose Detect Features and Tracking Marker operators in the UI
- document new buttons in the README
- include tests for the new workflow operator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687934bbdbb0832dbaad26805b8fee35