### PR TITLE
Implement dynamic tracking marker detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,5 @@ Seit Version 1.11 heißt der Parameter für den Mindestabstand
 `min_distance` und ersetzt das bisherige `detection_distance`.
 Seit Version 1.12 werden die verwendeten Werte für `margin` und `min_distance`
 beim Aufruf von `clip.detect_features()` in der Konsole ausgegeben.
+Seit Version 1.13 gibt es einen Button "Tracking Marker", der eine erweiterte
+Feature-Erkennung mit dynamischen Parametern ausführt.

--- a/developer.md
+++ b/developer.md
@@ -53,3 +53,8 @@
 - Beim Aufruf von `clip.detect_features()` werden die verwendeten Werte für
   `margin` und `min_distance` in der Konsole ausgegeben. Beide Werte sind
   nun ganze Zahlen.
+
+## Version 1.13
+- Neuer Operator `clip.tracking_marker` führt eine dynamische Feature-Erkennung
+  durch und entfernt NEW_-Tracks, die zu nahe an GOOD_-Tracks liegen.
+- Zusätzlicher Button "Tracking Marker" ruft diesen Operator auf.


### PR DESCRIPTION
## Summary
- add new `CLIP_OT_tracking_marker` operator for dynamic feature detection and cleanup
- show a new "Tracking Marker" button in the panel
- bump addon version to 1.13
- document new operator and button in README and developer notes

## Testing
- `python -m py_compile __init__.py`


------
https://chatgpt.com/codex/tasks/task_e_6879392d0ff8832daf48f181666e3a17