### PR TITLE
Remove duplicate tracking marker operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,5 +26,5 @@ Seit Version 1.11 heißt der Parameter für den Mindestabstand
 `min_distance` und ersetzt das bisherige `detection_distance`.
 Seit Version 1.12 werden die verwendeten Werte für `margin` und `min_distance`
 beim Aufruf von `clip.detect_features()` in der Konsole ausgegeben.
-Seit Version 1.13 gibt es einen Button "Tracking Marker", der eine erweiterte
-Feature-Erkennung mit dynamischen Parametern ausführt.
+Seit Version 1.13 führt der "Marker"-Button eine erweiterte
+Feature-Erkennung mit dynamischen Parametern aus.

--- a/developer.md
+++ b/developer.md
@@ -55,6 +55,5 @@
   nun ganze Zahlen.
 
 ## Version 1.13
-- Neuer Operator `clip.tracking_marker` führt eine dynamische Feature-Erkennung
-  durch und entfernt NEW_-Tracks, die zu nahe an GOOD_-Tracks liegen.
-- Zusätzlicher Button "Tracking Marker" ruft diesen Operator auf.
+- Der "Marker"-Button führt jetzt eine dynamische Feature-Erkennung durch und
+  entfernt NEW_-Tracks, die zu nahe an GOOD_-Tracks liegen.


### PR DESCRIPTION
## Summary
- remove the `CLIP_OT_tracking_marker` operator and its button
- integrate dynamic tracking logic into the existing marker button
- update docs to reflect the change

## Testing
- `python -m py_compile __init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68793e6c0af0832da21535e5cdb0ca62