### PR TITLE
Disable proxy before running feature detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,5 @@ zur Berechnung des erwarteten Bereichs. Liegt die Anzahl der NEW_-Tracks
 innerhalb dieses Bereichs, werden sie in TRACK_-Tracks umbenannt und die
 Auswahl wird aufgehoben.
 Der Standardwert des Feldes beträgt nun 20.
+Seit Version 1.24 deaktiviert der "Detect"-Button zunächst den Proxy.
+Seit Version 1.25 gibt der "Count"-Button den NM-Wert in der Konsole aus.

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Simple Addon",
     "author": "Your Name",
-    "version": (1, 23),
+    "version": (1, 25),
     "blender": (4, 4, 0),
     "location": "View3D > Object",
     "description": "Zeigt eine einfache Meldung an",
@@ -74,6 +74,8 @@ class CLIP_OT_detect_button(bpy.types.Operator):
         if not clip:
             self.report({'WARNING'}, "Kein Clip geladen")
             return {'CANCELLED'}
+
+        clip.use_proxy = False
 
         width, height = clip.size
         print(f"Auflösung: {width} x {height}")
@@ -218,6 +220,7 @@ class CLIP_OT_count_button(bpy.types.Operator):
         print(f"Anzahl der Tracking Marker mit Präfix '{prefix}': {count}")
 
         context.scene.nm_count = count
+        print(f"NM Wert: {context.scene.nm_count}")
 
         mframe = context.scene.marker_frame
         track_plus = mframe * 4

--- a/developer.md
+++ b/developer.md
@@ -104,3 +104,11 @@
   diesem Bereich, werden sie in `TRACK_` umbenannt, die Auswahl wird
   aufgehoben und `Scene.nm_count` zurückgesetzt. Das Feld besitzt nun einen
   Standardwert von 20.
+
+## Version 1.24
+- `clip.detect_button` deaktiviert nun zuerst den Proxy, bevor die
+  Feature-Erkennung gestartet wird.
+
+## Version 1.25
+- `clip.count_button` gibt den aktuellen Wert von `Scene.nm_count` in der
+  Konsole aus.


### PR DESCRIPTION
## Summary
- bump addon version to 1.25
- print Scene.nm_count to console in the count button
- document the new NM output in README and developer notes

## Testing
- `python3 -m py_compile __init__.py`


------
https://chatgpt.com/codex/tasks/task_e_6879e9bf5c9c832d86c161ab1d06ba5f