### PR TITLE
Add combined button without proxy

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -15,6 +15,9 @@ from .modules.operators.cleanup_new_tracks_operator import (
     KAISERLICH_OT_cleanup_new_tracks,
 )
 from .modules.operators.tracking_marker_operator import KAISERLICH_OT_tracking_marker
+from .modules.operators.combine_actions_operator import (
+    KAISERLICH_OT_run_all_except_proxy,
+)
 from .modules.ui.kaiserlich_panel import (
     KAISERLICH_PT_tracking_tools,
     KAISERLICH_PT_cleanup_tools,
@@ -37,6 +40,7 @@ classes = [
     KAISERLICH_OT_detect_features,
     KAISERLICH_OT_cleanup_new_tracks,
     KAISERLICH_OT_tracking_marker,
+    KAISERLICH_OT_run_all_except_proxy,
     KAISERLICH_PT_tracking_tools,
     KAISERLICH_PT_cleanup_tools,
 ]

--- a/modules/operators/__init__.py
+++ b/modules/operators/__init__.py
@@ -5,6 +5,7 @@ from .rename_tracks_modal import KAISERLICH_OT_rename_tracks_modal
 from .detect_features_operator import KAISERLICH_OT_detect_features
 from .cleanup_new_tracks_operator import KAISERLICH_OT_cleanup_new_tracks
 from .tracking_marker_operator import KAISERLICH_OT_tracking_marker
+from .combine_actions_operator import KAISERLICH_OT_run_all_except_proxy
 
 __all__ = [
     "KAISERLICH_OT_auto_track_cycle",
@@ -12,4 +13,5 @@ __all__ = [
     "KAISERLICH_OT_detect_features",
     "KAISERLICH_OT_cleanup_new_tracks",
     "KAISERLICH_OT_tracking_marker",
+    "KAISERLICH_OT_run_all_except_proxy",
 ]

--- a/modules/operators/combine_actions_operator.py
+++ b/modules/operators/combine_actions_operator.py
@@ -1,0 +1,22 @@
+"""Operator to run multiple actions without the proxy step."""
+
+from __future__ import annotations
+
+import bpy
+
+
+class KAISERLICH_OT_run_all_except_proxy(bpy.types.Operator):  # type: ignore[misc]
+    """Execute all Kaiserlich actions except the proxy builder."""
+
+    bl_idname = "kaiserlich.run_all_except_proxy"
+    bl_label = "Run All Except Proxy"
+    bl_options = {'REGISTER', 'UNDO'}
+
+    def execute(self, context):  # type: ignore[override]
+        bpy.ops.kaiserlich.detect_features()
+        bpy.ops.kaiserlich.tracking_marker()
+        bpy.ops.kaiserlich.cleanup_new_tracks()
+        return {'FINISHED'}
+
+
+__all__ = ["KAISERLICH_OT_run_all_except_proxy"]

--- a/modules/ui/kaiserlich_panel.py
+++ b/modules/ui/kaiserlich_panel.py
@@ -8,6 +8,7 @@ from ..operators.cleanup_new_tracks_operator import (
 )
 from ..operators.detect_features_operator import KAISERLICH_OT_detect_features
 from ..operators.tracking_marker_operator import KAISERLICH_OT_tracking_marker
+from ..operators.combine_actions_operator import KAISERLICH_OT_run_all_except_proxy
 
 
 class KAISERLICH_PT_tracking_tools(bpy.types.Panel):
@@ -35,6 +36,10 @@ class KAISERLICH_PT_tracking_tools(bpy.types.Panel):
         )
         layout.operator(
             KAISERLICH_OT_tracking_marker.bl_idname, text="Tracking Marker"
+        )
+        layout.operator(
+            KAISERLICH_OT_run_all_except_proxy.bl_idname,
+            text="Alles außer Proxy",
         )
         layout.prop(scene, "min_marker_count")
         layout.prop(scene, "min_track_length")


### PR DESCRIPTION
## Summary
- add a new operator `KAISERLICH_OT_run_all_except_proxy`
- export and register the operator
- expose it in the Kaiserlich UI panel

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a7c17cc10832db16ec655f6ed9772