### PR TITLE
Add track sequence operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,32 @@ Seit Version 1.41 verfolgt der Track-Button die ausgewählten Marker maximal
 zehn Frames nach vorne und bricht am Endframe ab.
 Seit Version 1.42 führt der Track-Button die TRACK_-Marker bis zu zehn Frames
 rückwärts und danach wieder vorwärts, wobei er Start- und Endframe beachtet.
+Seit Version 1.43 setzt der Track-Button den Frame-Bereich temporär und nutzt
+`sequence=True`, um die Marker bis zu zehn Frames zurück und anschließend
+vorwärts zu verfolgen.
+Seit Version 1.44 verfolgt der Track-Button die TRACK_-Marker in
+Zehnerschritten, bis keine mehr aktiv sind.
+Seit Version 1.45 verwendet der Detect-Button einen minimalen
+`detection_threshold` von 0.0001 statt 0.001.
+Seit Version 1.47 prüft der Track-Button nach jedem Zehnerblock,
+ob noch TRACK_-Marker aktiv sind und beendet das Tracking,
+sobald keine mehr vorhanden sind.
+Seit Version 1.48 erkennt der Track-Button Marker als inaktiv, wenn sie stummgeschaltet sind oder Koordinaten von (0,0) besitzen.
+Seit Version 1.49 gibt der Track-Button nach jedem Tracking-Schritt die Anzahl
+der aktiven Marker aus.
+Seit Version 1.50 arbeitet der Track-Button in 25er-Schritten und pr\u00FCft nach
+jeder Passage von 25 Frames erneut die verbleibenden TRACK_-Marker.
+Seit Version 1.51 passt der Track-Button die Blockgr\xF6\xDFe dynamisch an und
+verteilt den verbleibenden Bereich auf vier Abschnitte.
+Seit Version 1.52 gibt es experimentelle "Live Track"-Operatoren, die per
+Timer laufendes Tracking \xFCberwachen und stoppen, sobald keine TRACK_-Marker
+mehr aktiv sind.
+Seit Version 1.53 f\u00fchrt der neue "Proxy Track"-Button automatisch den Proxy-Befehl aus,
+speichert den aktuellen Frame und verfolgt TRACK_-Marker zehn Frames r\u00fcckw\u00e4rts
+und anschlie\xDFend wieder vorw\u00e4rts.
+Seit Version 1.54 deaktiviert der "Proxy Track"-Button zun\u00e4chst den Proxy,
+speichert den aktuellen Frame, w\u00e4hlt alle TRACK_-Marker aus und verfolgt sie
+zehn Frames r\u00fcckw\u00e4rts. Danach setzt er den Playhead zur\u00fcck und trackt
+vorw\u00e4rts.
+Seit Version 1.55 verwendet der "Proxy Track"-Button beim Rückwärts-Tracking denselben dynamischen Block-Algorithmus wie der Track-Button. Die Marker werden in Abschnitten eines Viertels des verbleibenden Bereichs verfolgt, bis keine aktiven TRACK_-Marker mehr übrig sind. Danach wird der gespeicherte Frame wiederhergestellt und ohne Unterteilung vorwärts getrackt.
+Seit Version 1.56 aktiviert der "Proxy Track"-Button den Proxy, bevor er das Tracking startet.

--- a/developer.md
+++ b/developer.md
@@ -190,3 +190,62 @@
   Der zuvor gespeicherte Frame wird zwischen den Richtungen
   wiederhergestellt.
 
+## Version 1.43
+- `clip.track_sequence` setzt den Frame-Bereich temporär und verwendet
+  `sequence=True`, um die Marker jeweils maximal zehn Frames rückwärts
+  und danach wieder vorwärts zu verfolgen.
+
+## Version 1.44
+- `clip.track_sequence` arbeitet in Schritten von zehn Frames und wiederholt
+  das Tracking, bis keine ausgewählten `TRACK_`-Marker mehr vorhanden sind.
+
+## Version 1.45
+- `clip.detect_button` setzt den minimalen `detection_threshold` nun auf
+  `0.0001` statt `0.001`.
+
+## Version 1.46
+- `clip.track_sequence` gab nach jedem Tracking-Schritt die Anzahl
+  der noch aktiven TRACK_-Marker aus.
+
+## Version 1.47
+- `clip.track_sequence` pr\xFCft am Ende jedes Zehnerblocks, ob noch
+  TRACK_-Marker aktiv sind und beendet das Tracking gegebenenfalls fr\xFChzeitig.
+
+
+## Version 1.48
+- `clip.track_sequence` betrachtet Marker als inaktiv, wenn sie stummgeschaltet sind oder Koordinaten von (0,0) aufweisen.
+
+## Version 1.49
+- `clip.track_sequence` meldet nach jedem Tracking-Schritt die Anzahl der noch
+  aktiven `TRACK_`-Marker.
+
+## Version 1.50
+- `clip.track_sequence` verwendet nun Bl\xF6cke von 25 Frames und pr\xFCft nach
+  jedem dieser Abschnitte erneut, ob noch TRACK_-Marker aktiv sind.
+
+## Version 1.51
+- `clip.track_sequence` berechnet die Blockgr\xF6\xDFe dynamisch, indem der
+  verbleibende Bereich in vier Teile aufgeteilt wird.
+
+## Version 1.52
+- Neue Operatoren `clip.live_track_forward` und `clip.live_track_backward`
+  verwenden einen Timer, um w\u00e4hrend des UI-Trackings zu \u00fcberpr\u00fcfen,
+  ob noch aktive `TRACK_`-Marker vorhanden sind und stoppen das Tracking,
+  sobald keine mehr existieren.
+
+## Version 1.53
+- Neuer Operator `clip.proxy_track` ruft automatisch `clip.panel_button` auf,
+  speichert den aktuellen Frame und verfolgt `TRACK_`-Marker jeweils zehn
+  Frames r\u00fcckw\u00e4rts und danach wieder vorw\u00e4rts zum gespeicherten Frame.
+
+## Version 1.54
+- `clip.proxy_track` deaktiviert zun\u00e4chst den Proxy, merkt sich den
+  aktuellen Frame und w\u00e4hlt alle `TRACK_`-Marker aus. Anschlie\u00dfend werden
+  die Marker zehn Frames r\u00fcckw\u00e4rts getrackt, der Playhead wird
+  wiederhergestellt und das Tracking l\u00e4uft vorw\u00e4rts weiter.
+
+## Version 1.55
+- `clip.proxy_track` nutzt beim Rückwärts-Tracking den dynamischen Block-Algorithmus aus `clip.track_sequence` und wiederholt die Schritte, bis keine TRACK_-Marker mehr aktiv sind. Anschließend wird der gespeicherte Frame wiederhergestellt und ohne Unterteilung vorwärts getrackt.
+
+## Version 1.56
+- `clip.proxy_track` aktiviert nun den Proxy bevor das Tracking beginnt.


### PR DESCRIPTION
## Summary
- bump addon version to 1.33
- add new operator `clip.track_sequence`
- expose new "Track" button in panel
- document changes in README and developer notes

## Testing
- `python -m py_compile __init__.py`

------
https://chatgpt.com/codex/tasks/task_e_687a8955041c832d9fbc584b02ef1107