### PR TITLE
Revert CLI logging and print only frames

### DIFF
--- a/debug_cli.py
+++ b/debug_cli.py
@@ -21,14 +21,15 @@ from modules.util.tracker_logger import configure_logger
 
 
 def cycle_models(steps: int) -> None:
-    """Cycle through motion models and print them."""
+    """Cycle through motion models without console output."""
     for _ in range(steps):
-        model = motion_model.next_model()
-        print(model)
+        motion_model.next_model()
 
 
 def show_track_length(frames):
-    """Display the length of a dummy track."""
+    """Print only the frame list and return the track length."""
+    FN = frames
+    print(FN)
     class DummyMarker:
         def __init__(self, frame):
             self.frame = frame
@@ -39,7 +40,7 @@ def show_track_length(frames):
 
     track = DummyTrack(frames)
     length = get_track_length(track)
-    print(f"Track length: {length}")
+    return length
 
 
 def main(argv=None):


### PR DESCRIPTION
## Summary
- revert previous logging commit
- update CLI to avoid extra console output
- print only frame numbers and return the track length

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687d1996b180832d86a2d2d92d3f3e69