### PR TITLE
Add combined Defaults+Test button

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Simple Addon",
     "author": "Your Name",
-    "version": (1, 91),
+    "version": (1, 92),
     "blender": (4, 4, 0),
     "location": "View3D > Object",
     "description": "Zeigt eine einfache Meldung an",
@@ -743,6 +743,20 @@ class CLIP_OT_test_button(bpy.types.Operator):
         return {'FINISHED'}
 
 
+class CLIP_OT_defaults_test(bpy.types.Operator):
+    bl_idname = "clip.defaults_test"
+    bl_label = "Defaults + Test"
+    bl_description = (
+        "Setzt Tracking-Defaults und führt anschließend den Test aus"
+    )
+
+    def execute(self, context):
+        result = bpy.ops.clip.setup_defaults()
+        if result != {'FINISHED'}:
+            return result
+        return bpy.ops.clip.test_button()
+
+
 class CLIP_PT_tracking_panel(bpy.types.Panel):
     bl_space_type = 'CLIP_EDITOR'
     bl_region_type = 'UI'
@@ -765,8 +779,7 @@ class CLIP_PT_button_panel(bpy.types.Panel):
         layout.prop(context.scene, 'marker_frame', text='Marker / Frame')
         layout.prop(context.scene, 'frames_track', text='Frames/Track')
         layout.operator('clip.panel_button')
-        layout.operator('clip.setup_defaults', text='Defaults')
-        layout.operator('clip.test_button', text='Test')
+        layout.operator('clip.defaults_test', text='Defaults + Test')
         layout.operator('clip.all_cycle', text='All Cycle')
 
 classes = (
@@ -779,6 +792,7 @@ classes = (
     CLIP_OT_count_button,
     CLIP_OT_setup_defaults,
     CLIP_OT_test_button,
+    CLIP_OT_defaults_test,
     CLIP_OT_all_cycle,
     CLIP_OT_track_sequence,
     CLIP_OT_tracking_length,

--- a/developer.md
+++ b/developer.md
@@ -391,3 +391,5 @@
 - Der Detect-Button wiederholt die Feature-Erkennung, bis die Zahl neuer Marker
   zwischen 80 % und 120 % von (Marker / Frame) / 3 liegt. Marker außerhalb dieses
   Bereichs werden gelöscht und Threshold, Margin sowie Distance neu berechnet.
+## Version 1.92
+- Neuer Button 'Defaults + Test' vereint das Setzen der Tracking-Defaults mit dem anschlie\xDFenden Testlauf.


### PR DESCRIPTION
## Summary
- bump version to 1.92
- add new operator `clip.defaults_test`
- replace separate "Defaults" and "Test" buttons with new combined button
- register the new operator
- document the change in developer notes

## Testing
- `python -m py_compile __init__.py`

------
https://chatgpt.com/codex/tasks/task_e_687d5102d984832db8f385d8fc9756a3