### PR TITLE
Implement last end frame tracking for Auto Detect

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,3 +211,5 @@ Tracking in der Konsole aus.
 Seit Version 1.101 gibt "Auto Detect" am Ende die Anzahl der getrackten Frames
 sowie Pattern Size, Motion Model, Pattern Match und die aktiven RGB-Kanäle in
 der Konsole aus.
+Seit Version 1.102 stoppt die Schleife, wenn der nächste Track einen
+früheren Endframe liefert als das bisher beste Ergebnis.

--- a/developer.md
+++ b/developer.md
@@ -421,3 +421,6 @@
 - Am Ende gibt "Auto Detect" die Anzahl der getrackten Frames sowie
   Pattern Size, Motion Model, Pattern Match und die aktiven RGB-Kanäle in der
   Konsole aus.
+## Version 1.102
+- Die Auto-Detect-Schleife beendet sich, wenn der n\u00e4chste Track fr\u00fcher
+  endet als das bislang beste Ergebnis.


### PR DESCRIPTION
## Summary
- track last end frame globally as `LAST_TRACK_END`
- update `CLIP_OT_track_full` to record `LAST_TRACK_END`
- refine auto-detect loop to compare against previous best end frame
- document new behaviour

## Testing
- `python -m py_compile __init__.py`

------
https://chatgpt.com/codex/tasks/task_e_687e23667200832d82f5a2248c8785bc