### PR TITLE
Add Auto Detect CH operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,4 +222,4 @@ Seit Version 1.106 sucht "Auto Detect" nun sechsmal in einem Block nach einem ho
 Seit Version 1.107 sucht "Auto Detect" nur noch in Zweierblöcken nach einem höheren Endframe und speichert das Ergebnis nur, wenn es besser ist. Der Zyklus endet, sobald der nächste Track früher stoppt als der bereits gespeicherte Endframe.
 Seit Version 1.108 sucht "Auto Detect" wieder in Viererblöcken nach einem höheren Endframe. Der Vorgang endet, wenn der nächste Track früher stoppt als der gespeicherte Endframe.
 Seit Version 1.109 gibt "Auto Detect" am Ende den gespeicherten Endframe und dessen Einstellungen in der Konsole aus.
-Seit Version 1.110 testet ein neuer Button "Auto Detect CH" verschiedene RGB-Kombinationen, speichert das beste Ergebnis und gibt es in der Konsole aus.
+Seit Version 1.110 testet ein neuer Button "Auto Detect CH" verschiedene RGB-Kombinationen, speichert das beste Ergebnis und gibt Pattern Size, Motion Model sowie die Farbkanäle in der Konsole aus.

--- a/__init__.py
+++ b/__init__.py
@@ -481,7 +481,10 @@ class CLIP_OT_motion_detect(bpy.types.Operator):
 
         print(
             "Auto Detect MM gespeichert: ",
-            f"end_frame={TEST_END_FRAME}, motion_model={best_model}"
+            f"end_frame={TEST_END_FRAME}, ",
+            f"pattern_size={TEST_SETTINGS.get('pattern_size')}, ",
+            f"motion_model={best_model}, ",
+            f"channels={TEST_SETTINGS.get('channels_active')}"
         )
 
         self.report({'INFO'}, "Auto Detect MM abgeschlossen")
@@ -551,7 +554,10 @@ class CLIP_OT_channel_detect(bpy.types.Operator):
 
         print(
             "Auto Detect CH gespeichert: ",
-            f"end_frame={TEST_END_FRAME}, channels={best_channels}"
+            f"end_frame={TEST_END_FRAME}, ",
+            f"pattern_size={TEST_SETTINGS.get('pattern_size')}, ",
+            f"motion_model={TEST_SETTINGS.get('motion_model')}, ",
+            f"channels={best_channels}"
         )
 
         self.report({'INFO'}, "Auto Detect CH abgeschlossen")


### PR DESCRIPTION
## Summary
- add channel combinations constant
- implement `CLIP_OT_channel_detect` to test RGB channels combinations
- expose new button in test panel
- register new class
- document Auto Detect CH in README

## Testing
- `python -m py_compile __init__.py`


------
https://chatgpt.com/codex/tasks/task_e_687e68198ec4832d894df6608ddf1a6a