### PR TITLE
Fix proxy state for auto detect operations

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -963,6 +963,8 @@ def _auto_detect_mm(self, context):
 
         select_tracks_by_prefix(clip, "TEST_")
         if bpy.ops.clip.track_markers.poll():
+            # Proxy aktivieren für das Tracking
+            clip.use_proxy = True
             bpy.ops.clip.track_markers(backwards=False, sequence=True)
             end_frame = scene.frame_current
             if best_end is None or end_frame > best_end:
@@ -1134,6 +1136,9 @@ class CLIP_OT_track_full(bpy.types.Operator):
         if not clip:
             self.report({'WARNING'}, "Kein Clip geladen")
             return {'CANCELLED'}
+
+        # Proxy aktivieren für das Tracking
+        clip.use_proxy = True
 
         scene = context.scene
         start = scene.frame_current


### PR DESCRIPTION
## Summary
- ensure proxy usage is enabled before tracking markers in `track_full`
- enable proxy before tracking markers in `_auto_detect_mm`

## Testing
- `python -m py_compile __init__.py`

------
https://chatgpt.com/codex/tasks/task_e_687ea08a1d98832d9505993e3155e0c8