### PR TITLE
Add Name New button

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,3 +231,4 @@ Seit Version 1.115 gibt dieser Button zus\u00e4tzliche Konsolenausgaben zum Thre
 Seit Version 1.116 berechnet der Button Margin und Min Distance logarithmisch aus dem Threshold.
 Seit Version 1.117 findet im Detect-Button keine automatische Umbenennung der Marker mehr statt.
 Seit Version 1.118 bleiben neu erkannte Marker nach dem Detect-Button ausgewählt.
+Seit Version 1.119 bietet das API-Panel einen Button "Name New", der selektierte Tracks mit dem Präfix NEW_ versieht.

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Simple Addon",
     "author": "Your Name",
-    "version": (1, 118),
+    "version": (1, 119),
     "blender": (4, 4, 0),
     "location": "View3D > Object",
     "description": "Zeigt eine einfache Meldung an",
@@ -1528,6 +1528,7 @@ class CLIP_PT_test_panel(bpy.types.Panel):
         layout.operator('clip.all_detect', text='Detect')
         layout.operator('clip.track_bidirectional', text='Track')
         layout.operator('clip.count_button', text='Count')
+        layout.operator('clip.prefix_new', text='Name New')
         layout.operator('clip.delete_selected', text='Delete')
         layout.operator('clip.pattern_up', text='Pattern+')
         layout.operator('clip.pattern_down', text='Pattern-')


### PR DESCRIPTION
## Summary
- bump version to 1.119
- add 'Name New' button in API panel to prefix selected tracks with NEW_
- document new button in the changelog

## Testing
- `python -m py_compile __init__.py`


------
https://chatgpt.com/codex/tasks/task_e_687ec95b3794832db5f3a8be5b12edcc