### PR TITLE
Fix All Cycle detect call

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -776,7 +776,7 @@ class CLIP_OT_all_cycle(bpy.types.Operator):
             return self.cancel(context)
 
         if self._state == 'DETECT':
-            bpy.ops.clip.detect_button()
+            bpy.ops.clip.all_detect()
             bpy.ops.clip.prefix_new()
             bpy.ops.clip.distance_button()
             bpy.ops.clip.delete_selected()


### PR DESCRIPTION
## Summary
- swap to `clip.all_detect` in CLIP_OT_all_cycle modal

## Testing
- `python -m py_compile __init__.py`
- run register/unregister with bpy stub

------
https://chatgpt.com/codex/tasks/task_e_687ed7470720832d95fdf29fb281bc67