### PR TITLE
Remove All Cycle button

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,3 +234,4 @@ Seit Version 1.118 bleiben neu erkannte Marker nach dem Detect-Button ausgewähl
 Seit Version 1.119 bietet das API-Panel einen Button "Name New", der selektierte Tracks mit dem Präfix NEW_ versieht.
 Seit Version 1.120 bietet das API-Panel einen Button "Name Track", der selektierte Tracks mit dem Präfix TRACK_ versieht.
 Seit Version 1.121 entfernt dieser Button vorhandene Präfixe, bevor er TRACK_ einfügt.
+Seit Version 1.122 wurde der Button "All Cycle" aus dem Panel entfernt.

--- a/__init__.py
+++ b/__init__.py
@@ -1554,7 +1554,6 @@ class CLIP_PT_stufen_panel(bpy.types.Panel):
     def draw(self, context):
         layout = self.layout
         layout.operator('clip.panel_button', text='Proxy')
-        layout.operator('clip.all_cycle', text='All Cycle')
 
 
 class CLIP_PT_test_panel(bpy.types.Panel):


### PR DESCRIPTION
## Summary
- remove the "All Cycle" button from the Stufen panel
- document this removal in the README

## Testing
- `python -m py_compile __init__.py`


------
https://chatgpt.com/codex/tasks/task_e_687eefe6c7a0832d869ca3d17ae06198