### PR TITLE
Add block-based reverse tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,3 +235,4 @@ Seit Version 1.119 bietet das API-Panel einen Button "Name New", der selektierte
 Seit Version 1.120 bietet das API-Panel einen Button "Name Track", der selektierte Tracks mit dem Präfix TRACK_ versieht.
 Seit Version 1.121 entfernt dieser Button vorhandene Präfixe, bevor er TRACK_ einfügt.
 Seit Version 1.122 wurde der Button "All Cycle" aus dem Panel entfernt.
+Seit Version 1.123 gibt es einen Button 'Track Partial', der ausgew\u00e4hlte Marker blockweise r\u00fcckw\u00e4rts verfolgt und anschlie\u00dfend f\u00fcr eine begrenzte Anzahl von Frames vorw\u00e4rts trackt.


### PR DESCRIPTION
## Summary
- refine `CLIP_OT_track_partial` to track backwards in blocks before tracking forward
- document the new `Track Partial` button in the README

## Testing
- `python -m py_compile __init__.py`


------
https://chatgpt.com/codex/tasks/task_e_687ef218841c832db8409eea1af6614f