### PR TITLE
Add Step Track button

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,3 +237,7 @@ Seit Version 1.121 entfernt dieser Button vorhandene Präfixe, bevor er TRACK_ e
 Seit Version 1.122 wurde der Button "All Cycle" aus dem Panel entfernt.
 Seit Version 1.123 gibt es einen Button 'Track Partial', der ausgew\u00e4hlte Marker blockweise r\u00fcckw\u00e4rts verfolgt und anschlie\u00dfend f\u00fcr eine begrenzte Anzahl von Frames vorw\u00e4rts trackt.
 Seit Version 1.125 bietet das API-Panel einen Button "Select TRACK", der alle aktiven TRACK_-Marker im aktuellen Frame auswählt.
+Seit Version 1.126 besitzt das Stufen-Panel einen "Step Track"-Button, der Detect,
+Name Track, Select TRACK und Track Partial kombiniert und den Playhead um die
+eingestellte Frames/Track-Anzahl weitersetzt, bis das Ende der Sequenz erreicht
+ist.

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Simple Addon",
     "author": "Your Name",
-    "version": (1, 125),
+    "version": (1, 126),
     "blender": (4, 4, 0),
     "location": "View3D > Object",
     "description": "Zeigt eine einfache Meldung an",
@@ -1312,6 +1312,42 @@ class CLIP_OT_select_active_tracks(bpy.types.Operator):
         return {'FINISHED'}
 
 
+class CLIP_OT_step_track(bpy.types.Operator):
+    bl_idname = "clip.step_track"
+    bl_label = "Step Track"
+    bl_description = (
+        "Führt Detect, Name Track, Select TRACK und Track Partial aus "
+        "und springt anschließend um 'Frames/Track' vor"
+    )
+
+    def execute(self, context):
+        clip = context.space_data.clip
+        if not clip:
+            self.report({'WARNING'}, "Kein Clip geladen")
+            return {'CANCELLED'}
+
+        scene = context.scene
+        step = scene.frames_track
+        end_frame = scene.frame_end
+
+        while scene.frame_current <= end_frame:
+            if bpy.ops.clip.all_detect.poll():
+                bpy.ops.clip.all_detect()
+            if bpy.ops.clip.prefix_track.poll():
+                bpy.ops.clip.prefix_track()
+            if bpy.ops.clip.select_active_tracks.poll():
+                bpy.ops.clip.select_active_tracks()
+            if bpy.ops.clip.track_partial.poll():
+                bpy.ops.clip.track_partial()
+
+            next_frame = scene.frame_current + step
+            if next_frame > end_frame:
+                break
+            scene.frame_current = next_frame
+
+        return {'FINISHED'}
+
+
 class CLIP_OT_setup_defaults(bpy.types.Operator):
     bl_idname = "clip.setup_defaults"
     bl_label = "Test Defaults"
@@ -1641,6 +1677,7 @@ class CLIP_PT_stufen_panel(bpy.types.Panel):
     def draw(self, context):
         layout = self.layout
         layout.operator('clip.panel_button', text='Proxy')
+        layout.operator('clip.step_track', text='Step Track')
 
 
 class CLIP_PT_test_panel(bpy.types.Panel):
@@ -1706,6 +1743,7 @@ classes = (
     CLIP_OT_apply_settings,
     CLIP_OT_track_bidirectional,
     CLIP_OT_track_partial,
+    CLIP_OT_step_track,
     CLIP_OT_setup_defaults,
     CLIP_OT_track_full,
     CLIP_OT_pattern_up,


### PR DESCRIPTION
## Summary
- add new operator `CLIP_OT_step_track` that sequentially runs Detect, Name Track, Select TRACK and Track Partial and moves the playhead by the Frames/Track value until the sequence end
- expose the new operator in the Stufen panel below the Proxy button
- bump addon version to 1.126 and document new feature in the README

## Testing
- `python -m py_compile __init__.py`


------
https://chatgpt.com/codex/tasks/task_e_687ef987815c832db3aeaab4204f2628