### PR TITLE
Add safeguard for Track Partial at scene boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,3 +237,4 @@ Seit Version 1.121 entfernt dieser Button vorhandene Präfixe, bevor er TRACK_ e
 Seit Version 1.122 wurde der Button "All Cycle" aus dem Panel entfernt.
 Seit Version 1.123 gibt es einen Button 'Track Partial', der ausgew\u00e4hlte Marker blockweise r\u00fcckw\u00e4rts verfolgt und anschlie\u00dfend f\u00fcr eine begrenzte Anzahl von Frames vorw\u00e4rts trackt.
 Seit Version 1.125 bietet das API-Panel einen Button "Select TRACK", der alle aktiven TRACK_-Marker im aktuellen Frame auswählt.
+Seit Version 1.126 bricht der Button "Track Partial" ab, wenn der Playhead am Szenenanfang oder -ende steht.

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Simple Addon",
     "author": "Your Name",
-    "version": (1, 125),
+    "version": (1, 126),
     "blender": (4, 4, 0),
     "location": "View3D > Object",
     "description": "Zeigt eine einfache Meldung an",
@@ -717,6 +717,10 @@ class CLIP_OT_track_partial(bpy.types.Operator):
         original_start = scene.frame_start
         original_end = scene.frame_end
         current = scene.frame_current
+
+        if current == original_start or current == original_end:
+            self.report({'WARNING'}, 'Playhead at scene start or end')
+            return {'CANCELLED'}
 
         if not bpy.ops.clip.track_markers.poll():
             self.report({'WARNING'}, "Tracking nicht m\u00f6glich")


### PR DESCRIPTION
## Summary
- prevent `Track Partial` from running when the playhead is at scene start or end
- bump addon version to 1.126
- document the new behavior in the README

## Testing
- `python -m py_compile __init__.py`

------
https://chatgpt.com/codex/tasks/task_e_687f022792e4832d859a86d122789369