### PR TITLE
Add Select TRACK step to Track Nr.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,3 +244,4 @@ Seit Version 1.129 verschiebt der Button "Track Partial" den Playhead einen Fram
 Seit Version 1.130 protokolliert "Track Partial" Markeranzahl und Tracking-Bereich in der Konsole und listet neu erkannte Marker mit Position auf.
 Seit Version 1.131 befindet sich unter dem Proxy ein Button "Track Nr. 1", der den Detect-Button auslöst.
 Seit Version 1.132 gibt es im API-Panel einen Button "Frame jump", der den Playhead um "Frames/Track" nach vorne bewegt.
+Seit Version 1.133 löst der Button "Track Nr. 1" nach dem Detect-Schritt zusätzlich "Select TRACK" aus.

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Simple Addon",
     "author": "Your Name",
-    "version": (1, 132),
+    "version": (1, 133),
     "blender": (4, 4, 0),
     "location": "View3D > Object",
     "description": "Zeigt eine einfache Meldung an",
@@ -154,6 +154,8 @@ class CLIP_OT_track_nr1(bpy.types.Operator):
         bpy.ops.clip.all_detect()
         if bpy.ops.clip.prefix_track.poll():
             bpy.ops.clip.prefix_track()
+        if bpy.ops.clip.select_active_tracks.poll():
+            bpy.ops.clip.select_active_tracks()
         return {'FINISHED'}
 
 


### PR DESCRIPTION
## Summary
- trigger the Select TRACK operator at the end of the Track Nr.1 operator
- bump addon version to 1.133
- document new behavior in README

## Testing
- `python -m py_compile __init__.py`

------
https://chatgpt.com/codex/tasks/task_e_687f93278714832d8d22e9d73b44e3fa