### PR TITLE
Remove coordinate check from Select TRACK

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1311,7 +1311,6 @@ class CLIP_OT_select_active_tracks(bpy.types.Operator):
             active = (
                 marker
                 and not marker.mute
-                and marker.co.length_squared != 0.0
             )
             if track.name.startswith("TRACK_") and active:
                 track.select = True


### PR DESCRIPTION
## Summary
- loosen track selection criteria by dropping the coordinate check

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f94a0d9e4832dab64577e2ac80afc