### PR TITLE
Trigger Track Partial from Track Nr. 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,3 +245,4 @@ Seit Version 1.130 protokolliert "Track Partial" Markeranzahl und Tracking-Berei
 Seit Version 1.131 befindet sich unter dem Proxy ein Button "Track Nr. 1", der den Detect-Button auslöst.
 Seit Version 1.132 gibt es im API-Panel einen Button "Frame jump", der den Playhead um "Frames/Track" nach vorne bewegt.
 Seit Version 1.133 löst der Button "Track Nr. 1" nach dem Detect-Schritt zusätzlich "Select TRACK" aus.
+Seit Version 1.134 löst der Button "Track Nr. 1" im Anschluss "Track Partial" aus.

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Simple Addon",
     "author": "Your Name",
-    "version": (1, 133),
+    "version": (1, 134),
     "blender": (4, 4, 0),
     "location": "View3D > Object",
     "description": "Zeigt eine einfache Meldung an",
@@ -156,6 +156,8 @@ class CLIP_OT_track_nr1(bpy.types.Operator):
             bpy.ops.clip.prefix_track()
         if bpy.ops.clip.select_active_tracks.poll():
             bpy.ops.clip.select_active_tracks()
+        if bpy.ops.clip.track_partial.poll():
+            bpy.ops.clip.track_partial()
         return {'FINISHED'}
 
 


### PR DESCRIPTION
## Summary
- run Track Partial automatically after Track Nr. 1 finishes
- bump addon version to 1.134 and document the change

## Testing
- `python -m py_compile __init__.py`

------
https://chatgpt.com/codex/tasks/task_e_687f98782e90832d82cafbeab7c6450a