### PR TITLE
Extend Track Nr.1 operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,3 +246,4 @@ Seit Version 1.131 befindet sich unter dem Proxy ein Button "Track Nr. 1", der d
 Seit Version 1.132 gibt es im API-Panel einen Button "Frame jump", der den Playhead um "Frames/Track" nach vorne bewegt.
 Seit Version 1.133 löst der Button "Track Nr. 1" nach dem Detect-Schritt zusätzlich "Select TRACK" aus.
 Seit Version 1.134 löst der Button "Track Nr. 1" im Anschluss "Track Partial" aus.
+Seit Version 1.135 löst der Button "Track Nr. 1" am Ende "Frame Jump" aus.

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Simple Addon",
     "author": "Your Name",
-    "version": (1, 134),
+    "version": (1, 135),
     "blender": (4, 4, 0),
     "location": "View3D > Object",
     "description": "Zeigt eine einfache Meldung an",
@@ -158,6 +158,8 @@ class CLIP_OT_track_nr1(bpy.types.Operator):
             bpy.ops.clip.select_active_tracks()
         if bpy.ops.clip.track_partial.poll():
             bpy.ops.clip.track_partial()
+        if bpy.ops.clip.frame_jump_custom.poll():
+            bpy.ops.clip.frame_jump_custom()
         return {'FINISHED'}
 
 


### PR DESCRIPTION
## Summary
- bump addon version to 1.135
- call the Frame Jump operator from Track Nr.1
- document the new behaviour in the README

## Testing
- `python -m py_compile __init__.py`

------
https://chatgpt.com/codex/tasks/task_e_687f99b3b01c832da9256121139ddd22