### PR TITLE
Implement Defaults button in API panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,3 +247,4 @@ Seit Version 1.132 gibt es im API-Panel einen Button "Frame jump", der den Playh
 Seit Version 1.133 löst der Button "Track Nr. 1" nach dem Detect-Schritt zusätzlich "Select TRACK" aus.
 Seit Version 1.134 löst der Button "Track Nr. 1" im Anschluss "Track Partial" aus.
 Seit Version 1.135 löst der Button "Track Nr. 1" am Ende "Frame Jump" aus.
+Seit Version 1.136 bietet das API-Panel einen Button "Defaults", der Pattern Size 50, Search Size 100, Motion Model "Loc", Keyframe-Matching, Prepass, Normalize, alle RGB-Kanäle, Gewicht 1, Mindestkorrelation 0.9 und Margin 100 einstellt.

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Simple Addon",
     "author": "Your Name",
-    "version": (1, 135),
+    "version": (1, 136),
     "blender": (4, 4, 0),
     "location": "View3D > Object",
     "description": "Zeigt eine einfache Meldung an",
@@ -1366,6 +1366,37 @@ class CLIP_OT_frame_jump(bpy.types.Operator):
         return {'FINISHED'}
 
 
+class CLIP_OT_api_defaults(bpy.types.Operator):
+    bl_idname = "clip.api_defaults"
+    bl_label = "Defaults"
+    bl_description = (
+        "Setzt Standardwerte f\u00fcr Pattern, Suche, Motion Model und mehr"
+    )
+
+    def execute(self, context):
+        clip = context.space_data.clip
+        if not clip:
+            self.report({'WARNING'}, "Kein Clip geladen")
+            return {'CANCELLED'}
+
+        settings = clip.tracking.settings
+        settings.default_pattern_size = 50
+        settings.default_search_size = 100
+        settings.default_motion_model = 'Loc'
+        settings.default_pattern_match = 'KEYFRAME'
+        settings.use_default_brute = True
+        settings.use_default_normalization = True
+        settings.use_default_red_channel = True
+        settings.use_default_green_channel = True
+        settings.use_default_blue_channel = True
+        settings.default_weight = 1.0
+        settings.default_correlation_min = 0.9
+        settings.default_margin = 100
+
+        self.report({'INFO'}, "Tracking-Defaults gesetzt")
+        return {'FINISHED'}
+
+
 class CLIP_OT_setup_defaults(bpy.types.Operator):
     bl_idname = "clip.setup_defaults"
     bl_label = "Test Defaults"
@@ -1707,6 +1738,7 @@ class CLIP_PT_test_panel(bpy.types.Panel):
     def draw(self, context):
         layout = self.layout
         layout.operator('clip.all_detect', text='Detect')
+        layout.operator('clip.api_defaults', text='Defaults')
         layout.operator('clip.track_bidirectional', text='Track')
         layout.operator('clip.track_partial', text='Track Partial')
         layout.operator('clip.count_button', text='Count')
@@ -1757,6 +1789,7 @@ classes = (
     CLIP_OT_distance_button,
     CLIP_OT_delete_selected,
     CLIP_OT_count_button,
+    CLIP_OT_api_defaults,
     CLIP_OT_defaults_detect,
     CLIP_OT_motion_detect,
     CLIP_OT_channel_detect,


### PR DESCRIPTION
## Summary
- add `Defaults` operator to apply standard tracking settings
- expose the new operator in the API panel
- register new operator and bump addon version
- document the new Defaults button in README

## Testing
- `python -m py_compile __init__.py`

------
https://chatgpt.com/codex/tasks/task_e_687f9ba8de40832da77b15d05cda0628