### PR TITLE
Add proxy toggle buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,3 +248,4 @@ Seit Version 1.133 löst der Button "Track Nr. 1" nach dem Detect-Schritt zusät
 Seit Version 1.134 löst der Button "Track Nr. 1" im Anschluss "Track Partial" aus.
 Seit Version 1.135 löst der Button "Track Nr. 1" am Ende "Frame Jump" aus.
 Seit Version 1.136 bietet das API-Panel einen Button "Defaults", der Pattern Size 50, Search Size 100, Motion Model "Loc", Keyframe-Matching, Prepass, Normalize, alle RGB-Kanäle, Gewicht 1, Mindestkorrelation 0.9 und Margin 100 einstellt.
+Seit Version 1.137 gibt es im API-Panel die Buttons "Proxy on" und "Proxy off", die das Proxy aktivieren bzw. deaktivieren.

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Simple Addon",
     "author": "Your Name",
-    "version": (1, 136),
+    "version": (1, 137),
     "blender": (4, 4, 0),
     "location": "View3D > Object",
     "description": "Zeigt eine einfache Meldung an",
@@ -142,6 +142,38 @@ class CLIP_OT_panel_button(bpy.types.Operator):
         bpy.ops.clip.rebuild_proxy()
 
         self.report({'INFO'}, "Proxy auf 50% erstellt")
+        return {'FINISHED'}
+
+
+class CLIP_OT_proxy_on(bpy.types.Operator):
+    bl_idname = "clip.proxy_on"
+    bl_label = "Proxy on"
+    bl_description = "Aktiviert das Proxy"
+
+    def execute(self, context):
+        clip = context.space_data.clip
+        if not clip:
+            self.report({'WARNING'}, "Kein Clip geladen")
+            return {'CANCELLED'}
+
+        clip.use_proxy = True
+        self.report({'INFO'}, "Proxy aktiviert")
+        return {'FINISHED'}
+
+
+class CLIP_OT_proxy_off(bpy.types.Operator):
+    bl_idname = "clip.proxy_off"
+    bl_label = "Proxy off"
+    bl_description = "Deaktiviert das Proxy"
+
+    def execute(self, context):
+        clip = context.space_data.clip
+        if not clip:
+            self.report({'WARNING'}, "Kein Clip geladen")
+            return {'CANCELLED'}
+
+        clip.use_proxy = False
+        self.report({'INFO'}, "Proxy deaktiviert")
         return {'FINISHED'}
 
 
@@ -1739,6 +1771,8 @@ class CLIP_PT_test_panel(bpy.types.Panel):
         layout = self.layout
         layout.operator('clip.all_detect', text='Detect')
         layout.operator('clip.api_defaults', text='Defaults')
+        layout.operator('clip.proxy_on', text='Proxy on')
+        layout.operator('clip.proxy_off', text='Proxy off')
         layout.operator('clip.track_bidirectional', text='Track')
         layout.operator('clip.track_partial', text='Track Partial')
         layout.operator('clip.count_button', text='Count')
@@ -1781,6 +1815,8 @@ class CLIP_PT_test_subpanel(bpy.types.Panel):
 classes = (
     OBJECT_OT_simple_operator,
     CLIP_OT_panel_button,
+    CLIP_OT_proxy_on,
+    CLIP_OT_proxy_off,
     CLIP_OT_track_nr1,
     CLIP_OT_detect_button,
     CLIP_OT_prefix_new,


### PR DESCRIPTION
## Summary
- add Proxy on/off operators to activate or deactivate proxy
- expose new buttons in API panel
- document Proxy buttons in README
- bump version to 1.137

## Testing
- `python3 -m py_compile __init__.py`

------
https://chatgpt.com/codex/tasks/task_e_687f9db4535c832d933ca53dfcb7b4da