### PR TITLE
Update Track Nr.1 behavior with proxy toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,3 +249,4 @@ Seit Version 1.134 löst der Button "Track Nr. 1" im Anschluss "Track Partial" a
 Seit Version 1.135 löst der Button "Track Nr. 1" am Ende "Frame Jump" aus.
 Seit Version 1.136 bietet das API-Panel einen Button "Defaults", der Pattern Size 50, Search Size 100, Motion Model "Loc", Keyframe-Matching, Prepass, Normalize, alle RGB-Kanäle, Gewicht 1, Mindestkorrelation 0.9 und Margin 100 einstellt.
 Seit Version 1.137 gibt es im API-Panel die Buttons "Proxy on" und "Proxy off", die das Proxy aktivieren bzw. deaktivieren.
+Seit Version 1.138 schaltet der Button "Track Nr. 1" zunächst das Proxy aus und aktiviert es erneut direkt vor "Track Partial".

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Simple Addon",
     "author": "Your Name",
-    "version": (1, 137),
+    "version": (1, 138),
     "blender": (4, 4, 0),
     "location": "View3D > Object",
     "description": "Zeigt eine einfache Meldung an",
@@ -183,13 +183,23 @@ class CLIP_OT_track_nr1(bpy.types.Operator):
     bl_description = "Löst den Detect-Button aus"
 
     def execute(self, context):
+        if bpy.ops.clip.proxy_off.poll():
+            bpy.ops.clip.proxy_off()
+
         bpy.ops.clip.all_detect()
+
         if bpy.ops.clip.prefix_track.poll():
             bpy.ops.clip.prefix_track()
+
         if bpy.ops.clip.select_active_tracks.poll():
             bpy.ops.clip.select_active_tracks()
+
+        if bpy.ops.clip.proxy_on.poll():
+            bpy.ops.clip.proxy_on()
+
         if bpy.ops.clip.track_partial.poll():
             bpy.ops.clip.track_partial()
+
         if bpy.ops.clip.frame_jump_custom.poll():
             bpy.ops.clip.frame_jump_custom()
         return {'FINISHED'}


### PR DESCRIPTION
## Summary
- update addon version to 1.138
- make `Track Nr. 1` toggle proxy off at start and back on before running `Track Partial`
- document the new behaviour in README

## Testing
- `python -m py_compile __init__.py`

------
https://chatgpt.com/codex/tasks/task_e_687f9f9d905c832db3cc3dff04fb13ac