### PR TITLE
Add conditional logic for Track Nr.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,3 +252,4 @@ Seit Version 1.137 gibt es im API-Panel die Buttons "Proxy on" und "Proxy off", 
 Seit Version 1.138 schaltet der Button "Track Nr. 1" zunächst das Proxy aus und aktiviert es erneut direkt vor "Track Partial".
 Seit Version 1.139 wiederholt der Button "Track Nr. 1" den gesamten Ablauf, bis der Szenenendframe erreicht ist.
 Seit Version 1.140 setzen die Buttons "Track Nr. 1" und "Step Track" nach dem "Track Partial" erneut Marker, um l\u00fcckenlose TRACK_-Marker zu erhalten.
+Seit Version 1.141 pr\u00fcft "Track Nr. 1" die Markeranzahl vor dem Umbenennen, aktiviert "Select TRACK" nur bei neuen TRACK_-Markern und f\u00fchrt "Frame Jump" aus, wenn der Playhead nach "Track Partial" zweimal auf demselben Frame verbleibt.


### PR DESCRIPTION
## Summary
- add version 1.141 information to addon
- extend Track Nr. 1 operator with conditional checks for marker count, new tracks, and frame jumps
- document new behaviour in README

## Testing
- `python -m py_compile __init__.py`

------
https://chatgpt.com/codex/tasks/task_e_687fbbb04a90832d9e2fedd4aaa3ba77