### PR TITLE
Add Short delet operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,3 +252,4 @@ Seit Version 1.137 gibt es im API-Panel die Buttons "Proxy on" und "Proxy off", 
 Seit Version 1.138 schaltet der Button "Track Nr. 1" zunächst das Proxy aus und aktiviert es erneut direkt vor "Track Partial".
 Seit Version 1.139 wiederholt der Button "Track Nr. 1" den gesamten Ablauf, bis der Szenenendframe erreicht ist.
 Seit Version 1.140 setzen die Buttons "Track Nr. 1" und "Step Track" nach dem "Track Partial" erneut Marker, um l\u00fcckenlose TRACK_-Marker zu erhalten.
+Seit Version 1.141 bietet das API-Panel einen Button "Short delet", der TRACK_-Marker ausw\u00e4hlt, deren L\u00e4nge unter dem Wert aus "Frames/Track" liegt.


### PR DESCRIPTION
## Summary
- add Short delet operator to select short TRACK_ markers
- expose Short delet via API panel
- document the new button
- bump version to 1.141

## Testing
- `python3 -m py_compile __init__.py`

------
https://chatgpt.com/codex/tasks/task_e_687fcf7c39c4832d999584ed202120bd