### PR TITLE
Fix Track Nr. 1 cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,3 +255,4 @@ Seit Version 1.140 setzen die Buttons "Track Nr. 1" und "Step Track" nach dem "T
 Seit Version 1.141 bietet das API-Panel einen Button "Short Track", der TRACK_-Marker ausw\u00e4hlt, deren L\u00e4nge unter dem Wert aus "Frames/Track" liegt.
 Seit Version 1.142 l\u00f6st der Button "Track Nr. 1" am Szenenende automatisch "Short Track" und danach "Delete" aus.
 Seit Version 1.143 bietet das API-Panel einen Button "Name GOOD", der alle TRACK_-Marker in GOOD_-Marker umbenennt.
+Seit Version 1.144 führt der Button "Track Nr. 1" nach dem Tracking keine automatische Feature-Erkennung mehr aus.

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Simple Addon",
     "author": "Your Name",
-    "version": (1, 143),
+    "version": (1, 144),
     "blender": (4, 4, 0),
     "location": "View3D > Object",
     "description": "Zeigt eine einfache Meldung an",
@@ -239,10 +239,6 @@ class CLIP_OT_track_nr1(bpy.types.Operator):
         elif self._state == "TRACK":
             if bpy.ops.clip.track_partial.poll():
                 bpy.ops.clip.track_partial()
-            self._state = "REDETECT"
-
-        elif self._state == "REDETECT":
-            bpy.ops.clip.all_detect()
             self._state = "NEXT"
 
         elif self._state == "NEXT":


### PR DESCRIPTION
## Summary
- remove the redundant post-tracking detection step in `CLIP_OT_track_nr1`
- update the addon version and changelog

## Testing
- `python -m py_compile __init__.py`

------
https://chatgpt.com/codex/tasks/task_e_687fdad5ab3c832d866d880c05efc957