### PR TITLE
Add Name GOOD call at end of Track Nr.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,3 +256,4 @@ Seit Version 1.141 bietet das API-Panel einen Button "Short Track", der TRACK_-M
 Seit Version 1.142 l\u00f6st der Button "Track Nr. 1" am Szenenende automatisch "Short Track" und danach "Delete" aus.
 Seit Version 1.143 bietet das API-Panel einen Button "Name GOOD", der alle TRACK_-Marker in GOOD_-Marker umbenennt.
 Seit Version 1.144 führt der Button "Track Nr. 1" nach dem Tracking keine automatische Feature-Erkennung mehr aus.
+Seit Version 1.145 l\u00f6st der Button "Track Nr. 1" am Ende automatisch "Name GOOD" aus.

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Simple Addon",
     "author": "Your Name",
-    "version": (1, 144),
+    "version": (1, 145),
     "blender": (4, 4, 0),
     "location": "View3D > Object",
     "description": "Zeigt eine einfache Meldung an",
@@ -249,6 +249,8 @@ class CLIP_OT_track_nr1(bpy.types.Operator):
                     bpy.ops.clip.short_track()
                 if bpy.ops.clip.delete_selected.poll():
                     bpy.ops.clip.delete_selected()
+                if bpy.ops.clip.prefix_good.poll():
+                    bpy.ops.clip.prefix_good()
                 return self.cancel(context)
             self._state = "DETECT"
 


### PR DESCRIPTION
## Summary
- trigger the Name GOOD operator when `Track Nr. 1` finishes
- bump addon version to 1.145
- document this new behaviour in the README

## Testing
- `python -m py_compile __init__.py`

------
https://chatgpt.com/codex/tasks/task_e_687fe025105c832d81a60452e6a59ded