### PR TITLE
Update Track Nr.1 to trigger Defaults once

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,3 +258,4 @@ Seit Version 1.143 bietet das API-Panel einen Button "Name GOOD", der alle TRACK
 Seit Version 1.144 führt der Button "Track Nr. 1" nach dem Tracking keine automatische Feature-Erkennung mehr aus.
 Seit Version 1.145 l\u00f6st der Button "Track Nr. 1" am Ende automatisch "Name GOOD" aus.
 Seit Version 1.146 bietet das API-Panel einen Button "Low Marker Frame", der zum ersten Frame springt, in dem weniger Marker aktiv sind als im Feld "Marker / Frame" angegeben.
+Seit Version 1.147 ruft der Button "Track Nr. 1" zu Beginn automatisch "Defaults" auf.

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Simple Addon",
     "author": "Your Name",
-    "version": (1, 146),
+    "version": (1, 147),
     "blender": (4, 4, 0),
     "location": "View3D > Object",
     "description": "Zeigt eine einfache Meldung an",
@@ -213,6 +213,8 @@ class CLIP_OT_track_nr1(bpy.types.Operator):
         scene = context.scene
 
         if self._state == "INIT":
+            if bpy.ops.clip.api_defaults.poll():
+                bpy.ops.clip.api_defaults()
             if bpy.ops.clip.proxy_off.poll():
                 bpy.ops.clip.proxy_off()
             self._state = "DETECT"


### PR DESCRIPTION
## Summary
- call `clip.api_defaults` when `Track Nr. 1` starts
- bump addon version to 1.147
- document new behaviour in README

## Testing
- `python -m py_compile __init__.py`


------
https://chatgpt.com/codex/tasks/task_e_687ff1a71a2c832d8d482e22798c24f9