### PR TITLE
Add helper to place markers and track

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,3 +261,4 @@ Seit Version 1.146 bietet das API-Panel einen Button "Low Marker Frame", der zum
 Seit Version 1.147 ruft der Button "Track Nr. 1" zu Beginn automatisch "Defaults" auf.
 Seit Version 1.148 besitzt das API-Panel die Buttons "Marker Position" und "GOOD Marker Position". Sie geben die Pixelkoordinaten der Marker in ausgewählten Tracks beziehungsweise aller GOOD_-Marker im aktuellen Frame aus.
 Seit Version 1.149 gibt der Button "Marker Position" die Pixelkoordinaten aller Marker in den selektierten Tracks aus.
+Seit Version 1.150 bietet das Addon die Funktion `place_and_track_markers`, die Marker blockweise setzt, rückwärts trackt und kurz vorwärts weiterverfolgt.

--- a/functions/core.py
+++ b/functions/core.py
@@ -93,7 +93,32 @@ def cycle_motion_model(settings, clip, reset_size=True):
     if reset_size:
         base = pattern_base(clip)
         settings.default_pattern_size = clamp_pattern_size(base, clip)
+
         settings.default_search_size = settings.default_pattern_size * 2
+
+
+def place_and_track_markers(track, clip, scene, step=30, forward_margin=10):
+    """Place markers at intervals and track backwards then slightly forwards."""
+
+    tracking = clip.tracking
+    tracking_object = tracking.objects.active
+
+    current_frame = scene.frame_end
+    start = scene.frame_start
+
+    while current_frame >= start:
+        track.markers.insert(current_frame, co=(0.5, 0.5))
+
+        bpy.ops.clip.track_markers('INVOKE_DEFAULT', backwards=True)
+
+        scene.frame_current = current_frame
+        for _ in range(forward_margin):
+            scene.frame_current += 1
+            if scene.frame_current > scene.frame_end:
+                break
+            bpy.ops.clip.track_markers('INVOKE_DEFAULT', backwards=False)
+
+        current_frame -= step
 
 class OBJECT_OT_simple_operator(bpy.types.Operator):
     bl_idname = "object.simple_operator"


### PR DESCRIPTION
## Summary
- add `place_and_track_markers` helper function to automate placing markers
- document the new helper in the changelog

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688090d79354832db8d00b7ace9c1d2e