### PR TITLE
Modularize Track Nr.1

### DIFF
--- a/functions/core.py
+++ b/functions/core.py
@@ -193,9 +193,9 @@ class CLIP_OT_track_nr1(bpy.types.Operator):
         return "DETECT"
 
     def step_detect(self, context):
-        """Run auto detection with repeated attempts."""
-        if bpy.ops.clip.detect_button.poll():
-            bpy.ops.clip.detect_button()
+        """Run auto detection using the all_detect operator."""
+        if bpy.ops.clip.all_detect.poll():
+            bpy.ops.clip.all_detect()
         return "PREFIX"
 
     def step_prefix(self, context):


### PR DESCRIPTION
## Summary
- break down Track Nr.1 modal operator into step methods
- keep state transitions but manage them in dedicated functions

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688094aa3644832db0fcd6ead395223a