### PR TITLE
Add error threshold setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,3 +262,4 @@ Seit Version 1.147 ruft der Button "Track Nr. 1" zu Beginn automatisch "Defaults
 Seit Version 1.148 besitzt das API-Panel die Buttons "Marker Position" und "GOOD Marker Position". Sie geben die Pixelkoordinaten der Marker in ausgewählten Tracks beziehungsweise aller GOOD_-Marker im aktuellen Frame aus.
 Seit Version 1.149 gibt der Button "Marker Position" die Pixelkoordinaten aller Marker in den selektierten Tracks aus.
 Seit Version 1.150 bietet das API-Panel einen Button "Kamera solve", der den Camera Solver ausführt.
+Seit Version 1.151 enthält das Final-Panel ein Eingabefeld "Error Threshold" mit dem Standardwert 2.

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Simple Addon",
     "author": "Your Name",
-    "version": (1, 150),
+    "version": (1, 151),
     "blender": (4, 4, 0),
     "location": "View3D > Object",
     "description": "Zeigt eine einfache Meldung an",
@@ -38,6 +38,11 @@ def register():
         description="Gespeicherter Threshold-Wert",
         default=1.0,
     )
+    bpy.types.Scene.error_threshold = FloatProperty(
+        name="Error Threshold",
+        description="Fehlergrenze für Operationen",
+        default=2.0,
+    )
     for cls in classes:
         bpy.utils.register_class(cls)
 
@@ -53,6 +58,8 @@ def unregister():
         del bpy.types.Scene.nm_count
     if hasattr(bpy.types.Scene, "threshold_value"):
         del bpy.types.Scene.threshold_value
+    if hasattr(bpy.types.Scene, "error_threshold"):
+        del bpy.types.Scene.error_threshold
 
 
 if __name__ == "__main__":

--- a/ui/panels.py
+++ b/ui/panels.py
@@ -21,6 +21,7 @@ class CLIP_PT_final_panel(bpy.types.Panel):
         layout = self.layout
         layout.prop(context.scene, 'marker_frame', text='Marker/Frame')
         layout.prop(context.scene, 'frames_track', text='Frames/Track')
+        layout.prop(context.scene, 'error_threshold', text='Error Threshold')
 
 
 class CLIP_PT_stufen_panel(bpy.types.Panel):


### PR DESCRIPTION
## Summary
- add version bump to 1.151
- add `error_threshold` property and expose it in the Final panel
- document new feature in README

## Testing
- `python -m py_compile __init__.py ui/panels.py functions/core.py`

------
https://chatgpt.com/codex/tasks/task_e_6880d2172dac832d9a6f71856037de62