### PR TITLE
Add Cleanup button

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,3 +264,5 @@ Seit Version 1.149 gibt der Button "Marker Position" die Pixelkoordinaten aller 
 Seit Version 1.150 bietet das API-Panel einen Button "Kamera solve", der den Camera Solver ausführt.
 Seit Version 1.151 enthält das Final-Panel ein Eingabefeld "Error Threshold" mit dem Standardwert 2.
 Seit Version 1.152 besitzt das API-Panel einen Button "Track Cleanup", der GOOD_-Tracks anhand ihrer Positionen löscht.
+Seit Version 1.153 verfügt das Stufen-Panel über einen Button "Cleanup", der
+"Short Track" und danach "Track Cleanup" ausführt.

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Simple Addon",
     "author": "Your Name",
-    "version": (1, 152),
+    "version": (1, 153),
     "blender": (4, 4, 0),
     "location": "View3D > Object",
     "description": "Zeigt eine einfache Meldung an",

--- a/functions/core.py
+++ b/functions/core.py
@@ -1721,6 +1721,21 @@ class CLIP_OT_track_cleanup(bpy.types.Operator):
         return {'FINISHED'}
 
 
+class CLIP_OT_cleanup(bpy.types.Operator):
+    bl_idname = "clip.cleanup"
+    bl_label = "Cleanup"
+    bl_description = (
+        "F\u00fchrt Short Track und Track Cleanup nacheinander aus"
+    )
+
+    def execute(self, context):
+        if bpy.ops.clip.short_track.poll():
+            bpy.ops.clip.short_track()
+        if bpy.ops.clip.track_cleanup.poll():
+            bpy.ops.clip.track_cleanup()
+        return {'FINISHED'}
+
+
 class CLIP_OT_step_track(bpy.types.Operator):
     bl_idname = "clip.step_track"
     bl_label = "Step Track"
@@ -2153,5 +2168,6 @@ operator_classes = (
     CLIP_OT_good_marker_position,
     CLIP_OT_camera_solve,
     CLIP_OT_track_cleanup,
+    CLIP_OT_cleanup,
 )
 

--- a/ui/panels.py
+++ b/ui/panels.py
@@ -34,6 +34,7 @@ class CLIP_PT_stufen_panel(bpy.types.Panel):
         layout = self.layout
         layout.operator('clip.panel_button', text='Proxy')
         layout.operator('clip.track_nr1', text='Track Nr. 1')
+        layout.operator('clip.cleanup', text='Cleanup')
 
 
 class CLIP_PT_test_panel(bpy.types.Panel):


### PR DESCRIPTION
## Summary
- increment version to 1.153
- add new operator `clip.cleanup` to run Short Track and Track Cleanup
- expose new Cleanup button in Stufen panel
- document new feature in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688115e61310832dae27a4499e46efda