### PR TITLE
Update Cleanup button behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,3 +286,4 @@ Seit Version 1.167 springt der Playhead nach jedem Durchlauf um "Frames/Track" n
 Seit Version 1.168 prüft "Cycle Detect" nun auch den Abstand zu vorhandenen NEW_-Markern, sodass neu erkannte Marker ebenfalls ausreichend Abstand zu ihnen einhalten müssen.
 Seit Version 1.169 bietet das API-Panel einen Button "Select NEW", der alle Marker mit dem Präfix NEW_ auswählt.
 Seit Version 1.170 wählt "Track Nr. 1" vor dem Umbenennen alle NEW_-Marker aus.
+Seit Version 1.171 löscht der "Cleanup"-Button nach "Select Short Tracks" direkt die ausgewählten Marker.

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Simple Addon",
     "author": "Your Name",
-    "version": (1, 169),
+    "version": (1, 171),
     "blender": (4, 4, 0),
     "location": "View3D > Object",
     "description": "Zeigt eine einfache Meldung an",

--- a/functions/core.py
+++ b/functions/core.py
@@ -2008,7 +2008,7 @@ class CLIP_OT_cleanup(bpy.types.Operator):
     bl_idname = "clip.cleanup"
     bl_label = "Cleanup"
     bl_description = (
-        "Ruft 'Select Short Tracks', 'Select Error Tracks' und danach 'Delete' auf"
+        "Ruft 'Select Short Tracks' und danach 'Delete' auf"
     )
 
     def execute(self, context):
@@ -2017,12 +2017,6 @@ class CLIP_OT_cleanup(bpy.types.Operator):
             bpy.ops.clip.select_short_tracks()
         else:
             print("[Cleanup] select_short_tracks nicht verf\u00fcgbar")
-
-        print("[Cleanup] track_cleanup")
-        if bpy.ops.clip.track_cleanup.poll():
-            bpy.ops.clip.track_cleanup()
-        else:
-            print("[Cleanup] track_cleanup nicht verf\u00fcgbar")
 
         print("[Cleanup] delete_selected")
         if bpy.ops.clip.delete_selected.poll():


### PR DESCRIPTION
## Summary
- streamline Cleanup workflow by removing Select Error Tracks step
- bump addon version to 1.171
- document new Cleanup behaviour

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6882d09eb3c0832d8637ff2919a40f5a