### PR TITLE
Run cleanup before low marker frame

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,3 +288,5 @@ Seit Version 1.169 bietet das API-Panel einen Button "Select NEW", der alle Mark
 Seit Version 1.170 wählt "Track Nr. 1" vor dem Umbenennen alle NEW_-Marker aus.
 Seit Version 1.171 löscht der "Cleanup"-Button nach "Select Short Tracks" direkt die ausgewählten Marker.
 Seit Version 1.172 ruft derselbe Button danach "Select Error Tracks" und erneut "Delete" auf.
+Seit Version 1.173 setzt "Track Nr. 1" nach jedem Durchlauf den Playhead mit "Low Marker Frame" auf den nächsten Frame mit zu wenigen Markern. Der Zyklus endet, wenn kein solcher Frame mehr gefunden wird.
+Seit Version 1.174 löscht "Track Nr. 1" nach jedem Durchlauf zunächst kurze TRACK_-Marker mit "Select Short Tracks" und "Delete" und springt danach mit "Low Marker Frame" zum nächsten Start.

--- a/README.md
+++ b/README.md
@@ -290,3 +290,4 @@ Seit Version 1.171 löscht der "Cleanup"-Button nach "Select Short Tracks" direk
 Seit Version 1.172 ruft derselbe Button danach "Select Error Tracks" und erneut "Delete" auf.
 Seit Version 1.173 setzt "Track Nr. 1" nach jedem Durchlauf den Playhead mit "Low Marker Frame" auf den nächsten Frame mit zu wenigen Markern. Der Zyklus endet, wenn kein solcher Frame mehr gefunden wird.
 Seit Version 1.174 löscht "Track Nr. 1" nach jedem Durchlauf zunächst kurze TRACK_-Marker mit "Select Short Tracks" und "Delete" und springt danach mit "Low Marker Frame" zum nächsten Start.
+Seit Version 1.175 wird dieser Ablauf modular ausgeführt, sodass die Bereinigung und der Sprung zum nächsten Start nacheinander erfolgen.

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Simple Addon",
     "author": "Your Name",
-    "version": (1, 172),
+    "version": (1, 174),
     "blender": (4, 4, 0),
     "location": "View3D > Object",
     "description": "Zeigt eine einfache Meldung an",

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Simple Addon",
     "author": "Your Name",
-    "version": (1, 174),
+    "version": (1, 175),
     "blender": (4, 4, 0),
     "location": "View3D > Object",
     "description": "Zeigt eine einfache Meldung an",

--- a/functions/core.py
+++ b/functions/core.py
@@ -258,16 +258,36 @@ class CLIP_OT_track_nr1(bpy.types.Operator):
         )
         return "DECIDE"
     def step_decide(self, context):
-        """Evaluate progress and continue or finish."""
+        """Evaluate progress and continue or finish using Low Marker Frame."""
         scene = context.scene
+        clip = context.space_data.clip
         print(
             f"[Track Nr.1] decide end {self._end} tracked {self._tracked} threshold {scene.frames_track}"
         )
-        if self._tracked > scene.frames_track or self._end < scene.frame_end:
-            next_start = min(self._start + scene.frames_track, scene.frame_end)
-            scene.frame_current = next_start
-            print(f"[Track Nr.1] next start {scene.frame_current}")
+
+        if not clip:
+            return "RENAME"
+
+        print("[Track Nr.1] select_short_tracks")
+        if bpy.ops.clip.select_short_tracks.poll():
+            bpy.ops.clip.select_short_tracks()
+        else:
+            print("[Track Nr.1] select_short_tracks nicht verfügbar")
+
+        print("[Track Nr.1] delete_selected")
+        if bpy.ops.clip.delete_selected.poll():
+            bpy.ops.clip.delete_selected()
+        else:
+            print("[Track Nr.1] delete_selected nicht verfügbar")
+
+        current = scene.frame_current
+        threshold = scene.marker_frame
+        frame, count = find_low_marker_frame(clip, threshold)
+        if frame is not None and frame != current:
+            scene.frame_current = frame
+            print(f"[Track Nr.1] next low frame {frame} ({count} markers)")
             return "DETECT"
+
         print("[Track Nr.1] finish cycle")
         return "RENAME"
 

--- a/functions/core.py
+++ b/functions/core.py
@@ -256,15 +256,11 @@ class CLIP_OT_track_nr1(bpy.types.Operator):
         print(
             f"[Track Nr.1] start {self._start} end {self._end} tracked {self._tracked}"
         )
-        return "DECIDE"
-    def step_decide(self, context):
-        """Evaluate progress and continue or finish using Low Marker Frame."""
-        scene = context.scene
-        clip = context.space_data.clip
-        print(
-            f"[Track Nr.1] decide end {self._end} tracked {self._tracked} threshold {scene.frames_track}"
-        )
+        return "CLEANUP"
 
+    def step_cleanup(self, context):
+        """Remove short tracks before searching the next frame."""
+        clip = context.space_data.clip
         if not clip:
             return "RENAME"
 
@@ -279,6 +275,17 @@ class CLIP_OT_track_nr1(bpy.types.Operator):
             bpy.ops.clip.delete_selected()
         else:
             print("[Track Nr.1] delete_selected nicht verfügbar")
+
+        return "JUMP"
+
+    def step_jump(self, context):
+        """Use Low Marker Frame to continue or finish the cycle."""
+        scene = context.scene
+        clip = context.space_data.clip
+
+        print(
+            f"[Track Nr.1] decide end {self._end} tracked {self._tracked} threshold {scene.frames_track}"
+        )
 
         current = scene.frame_current
         threshold = scene.marker_frame


### PR DESCRIPTION
## Summary
- Track Nr.1 deletes short tracks before jumping to the next low marker frame
- bump addon version to 1.174
- document the new behaviour

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6882e1b3d138832d8126705fa790460d