### PR TITLE
Update cleanup threshold algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,3 +294,4 @@ Seit Version 1.175 wird dieser Ablauf modular ausgeführt, sodass die Bereinigun
 Seit Version 1.176 ruft der "Cleanup"-Button nur noch 'Select Error Tracks' und danach 'Delete' auf.
 Seit Version 1.177 wiederholt derselbe Button 'Select Error Tracks' und 'Delete', wobei der Error Threshold auf 90% des jeweils gr\xc3\xb6\xc3\x9ften Fehlers gesetzt wird, bis der Wert unter 10 f\xc3\xa4llt.
 Seit Version 1.178 sucht "Error Marker Select" erst dann erneut nach dem höchsten Error-Wert, wenn im vorigen Durchgang bei 10% Reduktion des Error Threshold mindestens ein Marker gelöscht wurde.
+Seit Version 1.179 zählt der Cleanup ausschließlich TRACK_-Marker, um erfolgreiche Löschdurchgänge zu erkennen, und senkt den Error Threshold weiter um 10 %, solange keine Marker entfernt wurden.

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Simple Addon",
     "author": "Your Name",
-    "version": (1, 178),
+    "version": (1, 179),
     "blender": (4, 4, 0),
     "location": "View3D > Object",
     "description": "Zeigt eine einfache Meldung an",

--- a/functions/core.py
+++ b/functions/core.py
@@ -1968,16 +1968,8 @@ def cleanup_error_tracks(scene, clip, min_value=10):
     max_err = max_track_error(scene, clip)
     threshold = max_err * 0.9
 
-    while True:
+    while threshold >= min_value:
         print(f"[Cleanup] max error {max_err:.3f} -> threshold {threshold:.3f}")
-
-        if threshold < min_value:
-            scene.error_threshold = min_value
-            if bpy.ops.clip.track_cleanup.poll():
-                bpy.ops.clip.track_cleanup()
-            if bpy.ops.clip.delete_selected.poll():
-                bpy.ops.clip.delete_selected()
-            break
 
         scene.error_threshold = threshold
         before = sum(1 for t in clip.tracking.tracks if t.name.startswith("TRACK_"))
@@ -1992,6 +1984,12 @@ def cleanup_error_tracks(scene, clip, min_value=10):
             threshold = max_err * 0.9
         else:
             threshold *= 0.9
+
+    scene.error_threshold = min_value
+    if bpy.ops.clip.track_cleanup.poll():
+        bpy.ops.clip.track_cleanup()
+    if bpy.ops.clip.delete_selected.poll():
+        bpy.ops.clip.delete_selected()
 
 
 class CLIP_OT_track_cleanup(bpy.types.Operator):


### PR DESCRIPTION
## Summary
- refine cleanup operation so error scans are only recomputed after a successful deletion
- bump addon version to 1.178
- document new behaviour in README

## Testing
- `python -m py_compile functions/core.py __init__.py ui/panels.py`

------
https://chatgpt.com/codex/tasks/task_e_68834a3b7250832dba2c0b007f35985e