### PR TITLE
Implement new error track selection formula

### DIFF
--- a/functions/core.py
+++ b/functions/core.py
@@ -2036,16 +2036,6 @@ class CLIP_OT_track_cleanup(bpy.types.Operator):
         g_quarter = scene.error_threshold * 4
         g_eighth = scene.error_threshold * 2
 
-        print(
-            f"[Select Error Tracks] G_global = ET * 6 = {scene.error_threshold} * 6 = {g_global}"
-        )
-        print(
-            f"[Select Error Tracks] G_quarter = ET * 4 = {scene.error_threshold} * 4 = {g_quarter}"
-        )
-        print(
-            f"[Select Error Tracks] G_eighth = ET * 2 = {scene.error_threshold} * 2 = {g_eighth}"
-        )
-
         selected_tracks = set()
 
         def analyze(tracks_info, g, label):
@@ -2065,9 +2055,6 @@ class CLIP_OT_track_cleanup(bpy.types.Operator):
                 print(f"[{label}] {track.name}: ETX={etx:.3f}, ETY={ety:.3f}")
 
                 if abs(etx) > g or abs(ety) > g:
-                    print(
-                        f"[{label}] {track.name} selected because |ETX|={abs(etx):.3f} or |ETY|={abs(ety):.3f} > G={g:.3f}"
-                    )
                     track.select = True
                     selected_tracks.add(track)
 

--- a/functions/core.py
+++ b/functions/core.py
@@ -1992,7 +1992,6 @@ def cleanup_error_tracks(scene, clip, min_value=10):
     while True:
         max_err = max_track_error(scene, clip)
         threshold = max_err * 0.9
-        print(f"[Cleanup] max error {max_err:.3f} -> threshold {threshold:.3f}")
 
         if threshold < min_value:
             scene.error_threshold = min_value

--- a/functions/core.py
+++ b/functions/core.py
@@ -2054,27 +2054,15 @@ class CLIP_OT_track_cleanup(bpy.types.Operator):
 
             xvg = sum(t["xv"] for t in tracks_info) / len(tracks_info)
             yvg = sum(t["yv"] for t in tracks_info) / len(tracks_info)
-            print(
-                f"[{label}] XVG = (Sum XV / AM) = ({sum(t['xv'] for t in tracks_info):.3f} / {len(tracks_info)}) = {xvg:.3f}"
-            )
-            print(
-                f"[{label}] YVG = (Sum YV / AM) = ({sum(t['yv'] for t in tracks_info):.3f} / {len(tracks_info)}) = {yvg:.3f}"
-            )
 
             for info in tracks_info:
                 track = info["track"]
                 xv = info["xv"]
                 yv = info["yv"]
-                xv1 = info["xv1"]
-                xv2 = info["xv2"]
-                yv1 = info["yv1"]
-                yv2 = info["yv2"]
                 etx = xvg - xv
                 ety = yvg - yv
 
-                print(
-                    f"[{label}] {track.name}: XV1={xv1:.3f}, XV2={xv2:.3f}, YV1={yv1:.3f}, YV2={yv2:.3f}, XV={xv1:.3f}+{xv2:.3f}={xv:.3f}, YV={yv1:.3f}+{yv2:.3f}={yv:.3f}; ETX={xvg:.3f}-{xv:.3f}={etx:.3f}, ETY={yvg:.3f}-{yv:.3f}={ety:.3f}"
-                )
+                print(f"[{label}] {track.name}: ETX={etx:.3f}, ETY={ety:.3f}")
 
                 if abs(etx) > g or abs(ety) > g:
                     print(


### PR DESCRIPTION
## Summary
- update `max_track_error` to use new ETX/ETY formula
- revise `CLIP_OT_track_cleanup` to compute error via XV/YV

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6883649e2c3c832db922285ba78de891