### PR TITLE
Implement iterative cleanup threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,10 @@ Seit Version 1.174 löscht "Track Nr. 1" nach jedem Durchlauf zunächst kurze TR
 Seit Version 1.175 wird dieser Ablauf modular ausgeführt, sodass die Bereinigung und der Sprung zum nächsten Start nacheinander erfolgen.
 Seit Version 1.176 ruft der "Cleanup"-Button nur noch 'Select Error Tracks' und danach 'Delete' auf.
 Seit Version 1.177 wiederholt derselbe Button 'Select Error Tracks' und 'Delete', wobei der Error Threshold auf 90% des jeweils größten Fehlers gesetzt wird, bis der Wert unter 10 fällt.
+Seit Version 1.178 setzt der "Cleanup"-Button zunächst den größten gefundenen Fehler in
+"Error Threshold" und löscht TRACK_-Marker iterativ. Dabei verringert er den Threshold
+nach jedem Durchlauf auf 90 % des vorherigen Werts, bis der ursprüngliche
+Schwellwert erreicht ist.
 
 ## License
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Simple Addon",
     "author": "Your Name",
-    "version": (1, 176),
+    "version": (1, 178),
     "blender": (4, 4, 0),
     "location": "View3D > Object",
     "description": "Zeigt eine einfache Meldung an",

--- a/functions/core.py
+++ b/functions/core.py
@@ -1987,25 +1987,31 @@ def max_track_error(scene, clip):
     return max_error
 
 
-def cleanup_error_tracks(scene, clip, min_value=10):
-    """Delete TRACK_ markers iteratively based on error threshold."""
-    while True:
-        max_err = max_track_error(scene, clip)
-        threshold = max_err * 0.9
+def cleanup_error_tracks(scene, clip):
+    """Delete TRACK_ markers while decreasing the error threshold."""
+    original = scene.error_threshold
 
-        if threshold < min_value:
-            scene.error_threshold = min_value
+    max_err = max_track_error(scene, clip)
+    scene.error_threshold = max_err
+    threshold = max_err
+
+    while threshold >= original:
+        while True:
             if bpy.ops.clip.track_cleanup.poll():
                 bpy.ops.clip.track_cleanup()
-            if bpy.ops.clip.delete_selected.poll():
-                bpy.ops.clip.delete_selected()
-            break
+            else:
+                break
 
+            if any(t.select for t in clip.tracking.tracks):
+                if bpy.ops.clip.delete_selected.poll():
+                    bpy.ops.clip.delete_selected()
+            else:
+                break
+
+        threshold *= 0.9
         scene.error_threshold = threshold
-        if bpy.ops.clip.track_cleanup.poll():
-            bpy.ops.clip.track_cleanup()
-        if bpy.ops.clip.delete_selected.poll():
-            bpy.ops.clip.delete_selected()
+
+    scene.error_threshold = original
 
 
 class CLIP_OT_track_cleanup(bpy.types.Operator):


### PR DESCRIPTION
## Summary
- tune cleanup_error_tracks to start from the maximum error and gradually reduce the threshold
- bump addon version to 1.178
- document the new cleanup logic in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6883772e8d68832d815f46dd1ead1260