### PR TITLE
Add Test Track backwards operator

### DIFF
--- a/ui/panels.py
+++ b/ui/panels.py
@@ -94,6 +94,7 @@ class CLIP_PT_test_subpanel(bpy.types.Panel):
         layout.operator('clip.detect_button', text='Test Detect')
         layout.operator('clip.prefix_test', text='Name Test')
         layout.operator('clip.track_full', text='Track Test')
+        layout.operator('clip.test_track_backwards', text='Test Track backwards')
         layout.operator('clip.test_button', text='Test')
 
 panel_classes = (


### PR DESCRIPTION
## Summary
- add a new operator `CLIP_OT_test_track_backwards` to track all `TEST_` trackers back to the scene start
- include new operator in the UI Test panel
- register operator in `operator_classes`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68839c56ec14832da088d100d45462ee