### PR TITLE
Add Detail Track cycle operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,8 @@ Konsole aus.
 Seit Version 1.180 benennt "Track Nr. 1" nach jedem "Cycle Detect" die Marker
 mit "Name New" um. Findet "Low Marker Frame" keinen weiteren Frame, wird
 zuerst "Select NEW" und anschließend "Name Track" ausgeführt.
+Seit Version 1.181 bietet das Stufen-Panel einen Button "Detail Track", der
+einen erweiterten Test-Zyklus mit automatischem Tracking startet.
 
 ## License
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Simple Addon",
     "author": "Your Name",
-    "version": (1, 179),
+    "version": (1, 181),
     "blender": (4, 4, 0),
     "location": "View3D > Object",
     "description": "Zeigt eine einfache Meldung an",

--- a/ui/panels.py
+++ b/ui/panels.py
@@ -35,6 +35,7 @@ class CLIP_PT_stufen_panel(bpy.types.Panel):
         layout.operator('clip.panel_button', text='Proxy')
         layout.operator('clip.track_nr1', text='Track Nr. 1')
         layout.operator('clip.cleanup', text='Cleanup')
+        layout.operator('clip.optimized_test_cycle', text='Detail Track')
 
 
 class CLIP_PT_test_panel(bpy.types.Panel):


### PR DESCRIPTION
## Summary
- add optimized test cycle operator
- add button to run the cycle from the Stufen panel
- bump addon version
- document new button in README

## Testing
- `python -m py_compile functions/core.py ui/panels.py __init__.py`

------
https://chatgpt.com/codex/tasks/task_e_6883b0e2102c832db4c0ec6f8fce3295