### PR TITLE
Add TEST select button

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ Konsole aus.
 Seit Version 1.180 benennt "Track Nr. 1" nach jedem "Cycle Detect" die Marker
 mit "Name New" um. Findet "Low Marker Frame" keinen weiteren Frame, wird
 zuerst "Select NEW" und anschließend "Name Track" ausgeführt.
+Seit Version 1.181 besitzt das API-Unterpanel einen Button "TEST select", der alle Marker mit dem Präfix TEST_ auswählt.
 
 ## License
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Simple Addon",
     "author": "Your Name",
-    "version": (1, 179),
+    "version": (1, 181),
     "blender": (4, 4, 0),
     "location": "View3D > Object",
     "description": "Zeigt eine einfache Meldung an",

--- a/functions/core.py
+++ b/functions/core.py
@@ -1784,6 +1784,23 @@ class CLIP_OT_select_new_tracks(bpy.types.Operator):
         return {'FINISHED'}
 
 
+class CLIP_OT_select_test_tracks(bpy.types.Operator):
+    bl_idname = "clip.select_test_tracks"
+    bl_label = "Select TEST"
+    bl_description = "Selektiert alle TEST_-Marker"
+
+    def execute(self, context):
+        clip = context.space_data.clip
+        if not clip:
+            self.report({'WARNING'}, "Kein Clip geladen")
+            return {'CANCELLED'}
+
+        select_tracks_by_prefix(clip, "TEST_")
+        count = sum(1 for t in clip.tracking.tracks if t.select)
+        self.report({'INFO'}, f"{count} TEST_-Marker ausgewählt")
+        return {'FINISHED'}
+
+
 class CLIP_OT_marker_position(bpy.types.Operator):
     bl_idname = "clip.marker_position"
     bl_label = "Marker Position"
@@ -2623,6 +2640,7 @@ operator_classes = (
     CLIP_OT_low_marker_frame,
     CLIP_OT_select_active_tracks,
     CLIP_OT_select_new_tracks,
+    CLIP_OT_select_test_tracks,
     CLIP_OT_marker_position,
     CLIP_OT_good_marker_position,
     CLIP_OT_camera_solve,

--- a/ui/panels.py
+++ b/ui/panels.py
@@ -88,6 +88,7 @@ class CLIP_PT_test_subpanel(bpy.types.Panel):
         layout = self.layout
 
         layout.operator('clip.prefix_test', text='TEST Name')
+        layout.operator('clip.select_test_tracks', text='TEST select')
 
 panel_classes = (
     CLIP_PT_tracking_panel,


### PR DESCRIPTION
## Summary
- bump version to 1.181
- add operator to select tracks with prefix `TEST_`
- expose new operator in API subpanel
- document the new button in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883c5eb7f60832db6c0077911a88f4b