### PR TITLE
Add Test Defaults Button

### DIFF
--- a/functions/core.py
+++ b/functions/core.py
@@ -2280,9 +2280,11 @@ class CLIP_OT_setup_defaults(bpy.types.Operator):
         settings.use_default_green_channel = True
         settings.use_default_blue_channel = True
 
-        # Mindestkorrelation und Margin für neue Tracks setzen
-        settings.default_correlation_min = 0.85
+        settings.default_weight = 1.0
+        settings.default_correlation_min = 0.9
         settings.default_margin = 10
+        if hasattr(settings, 'use_default_mask'):
+            settings.use_default_mask = False
 
 
 

--- a/ui/panels.py
+++ b/ui/panels.py
@@ -89,6 +89,7 @@ class CLIP_PT_test_subpanel(bpy.types.Panel):
 
         layout.operator('clip.prefix_test', text='TEST Name')
         layout.operator('clip.select_test_tracks', text='TEST select')
+        layout.operator('clip.setup_defaults', text='Test Defaults')
 
 panel_classes = (
     CLIP_PT_tracking_panel,


### PR DESCRIPTION
## Summary
- add a *Test Defaults* button in the **Test** subpanel
- extend `setup_defaults` operator with weight, correlation, margin and mask settings

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6883c81aa830832d96e5801e41a17d32