### PR TITLE
Add Test Detect button

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ Seit Version 1.180 benennt "Track Nr. 1" nach jedem "Cycle Detect" die Marker
 mit "Name New" um. Findet "Low Marker Frame" keinen weiteren Frame, wird
 zuerst "Select NEW" und anschließend "Name Track" ausgeführt.
 Seit Version 1.181 besitzt das API-Unterpanel einen Button "TEST select", der alle Marker mit dem Präfix TEST_ auswählt.
+Seit Version 1.182 gibt es dort zusätzlich einen Button "Test Detect", der Marker erkennt, bis ihre Anzahl im Zielbereich liegt.
 
 ## License
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Simple Addon",
     "author": "Your Name",
-    "version": (1, 181),
+    "version": (1, 182),
     "blender": (4, 4, 0),
     "location": "View3D > Object",
     "description": "Zeigt eine einfache Meldung an",

--- a/ui/panels.py
+++ b/ui/panels.py
@@ -88,6 +88,7 @@ class CLIP_PT_test_subpanel(bpy.types.Panel):
         layout = self.layout
         
         layout.operator('clip.setup_defaults', text='Test Defaults')
+        layout.operator('clip.detect_button', text='Test Detect')
         layout.operator('clip.prefix_test', text='TEST Name')
         layout.operator('clip.select_test_tracks', text='TEST select')
 


### PR DESCRIPTION
## Summary
- bump version to 1.182
- add Test Detect button in the Test subpanel
- document new button in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6883cbe4f458832daaab7910bbdc69a0