### PR TITLE
Add Test Track operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ mit "Name New" um. Findet "Low Marker Frame" keinen weiteren Frame, wird
 zuerst "Select NEW" und anschließend "Name Track" ausgeführt.
 Seit Version 1.181 besitzt das API-Unterpanel einen Button "TEST select", der alle Marker mit dem Präfix TEST_ auswählt.
 Seit Version 1.182 gibt es dort zusätzlich einen Button "Test Detect", der Marker erkennt, bis ihre Anzahl im Zielbereich liegt.
+Seit Version 1.183 besitzt dieses Unter-Panel auch einen Button "Test Track", der selektierte Marker bis zum Sequenzende vorwärts verfolgt.
 
 ## License
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Simple Addon",
     "author": "Your Name",
-    "version": (1, 182),
+    "version": (1, 183),
     "blender": (4, 4, 0),
     "location": "View3D > Object",
     "description": "Zeigt eine einfache Meldung an",

--- a/functions/core.py
+++ b/functions/core.py
@@ -2434,6 +2434,44 @@ class CLIP_OT_test_track_backwards(bpy.types.Operator):
         return {'FINISHED'}
 
 
+class CLIP_OT_test_track(bpy.types.Operator):
+    bl_idname = "clip.test_track"
+    bl_label = "Test Track"
+    bl_description = (
+        "Trackt selektierte Marker vorwärts bis zum Sequenzende"
+    )
+
+    def execute(self, context):
+        clip = context.space_data.clip
+        if not clip:
+            self.report({'WARNING'}, "Kein Clip geladen")
+            return {'CANCELLED'}
+
+        if not any(t.select for t in clip.tracking.tracks):
+            self.report({'WARNING'}, "Keine Tracks ausgewählt")
+            return {'CANCELLED'}
+
+        scene = context.scene
+        original_start = scene.frame_start
+        original_end = scene.frame_end
+        current = scene.frame_current
+
+        if not bpy.ops.clip.track_markers.poll():
+            self.report({'WARNING'}, "Tracking nicht möglich")
+            return {'CANCELLED'}
+
+        scene.frame_start = current
+        scene.frame_end = original_end
+        bpy.ops.clip.track_markers(backwards=False, sequence=True)
+
+        scene.frame_start = original_start
+        scene.frame_end = original_end
+        scene.frame_current = current
+
+        self.report({'INFO'}, "Tracking abgeschlossen")
+        return {'FINISHED'}
+
+
 class CLIP_OT_pattern_up(bpy.types.Operator):
     bl_idname = "clip.pattern_up"
     bl_label = "Pattern+"
@@ -2622,6 +2660,7 @@ operator_classes = (
     CLIP_OT_setup_defaults,
     CLIP_OT_track_full,
     CLIP_OT_test_track_backwards,
+    CLIP_OT_test_track,
     CLIP_OT_pattern_up,
     CLIP_OT_pattern_down,
     CLIP_OT_motion_cycle,

--- a/ui/panels.py
+++ b/ui/panels.py
@@ -89,6 +89,7 @@ class CLIP_PT_test_subpanel(bpy.types.Panel):
         
         layout.operator('clip.setup_defaults', text='Test Defaults')
         layout.operator('clip.detect_button', text='Test Detect')
+        layout.operator('clip.test_track', text='Test Track')
         layout.operator('clip.prefix_test', text='TEST Name')
         layout.operator('clip.select_test_tracks', text='TEST select')
 


### PR DESCRIPTION
## Summary
- add a new `clip.test_track` operator
- expose operator in Test subpanel via a new button
- bump addon version to 1.183
- document the new Test Track button

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6883ce1addec832d9a0e711d375ead76