### PR TITLE
Add Heavy Track operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ zuerst "Select NEW" und anschließend "Name Track" ausgeführt.
 Seit Version 1.181 besitzt das API-Unterpanel einen Button "TEST select", der alle Marker mit dem Präfix TEST_ auswählt.
 Seit Version 1.182 gibt es dort zusätzlich einen Button "Test Detect", der Marker erkennt, bis ihre Anzahl im Zielbereich liegt.
 Seit Version 1.183 besitzt dieses Unter-Panel auch einen Button "Test Track", der selektierte Marker bis zum Sequenzende vorwärts verfolgt.
+Seit Version 1.184 gibt es im "Stufen"-Panel einen neuen Button "Heavy Track", der automatisch verschiedene Tracking-Einstellungen testet und die besten Werte übernimmt.
 
 ## License
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Simple Addon",
     "author": "Your Name",
-    "version": (1, 183),
+    "version": (1, 184),
     "blender": (4, 4, 0),
     "location": "View3D > Object",
     "description": "Zeigt eine einfache Meldung an",

--- a/functions/core.py
+++ b/functions/core.py
@@ -2168,6 +2168,43 @@ class CLIP_OT_cleanup(bpy.types.Operator):
         return {'FINISHED'}
 
 
+class CLIP_OT_heavy_track(bpy.types.Operator):
+    bl_idname = "clip.heavy_track"
+    bl_label = "Heavy Track"
+    bl_description = (
+        "Sucht den nächsten Low Marker Frame und testet verschiedene "
+        "Tracking-Einstellungen"
+    )
+
+    def execute(self, context):
+        clip = context.space_data.clip
+        if not clip:
+            self.report({'WARNING'}, "Kein Clip geladen")
+            return {'CANCELLED'}
+
+        scene = context.scene
+        threshold = scene.marker_frame
+        frame, _ = find_low_marker_frame(clip, threshold)
+        if frame is None:
+            self.report({'INFO'}, "Kein Frame mit zu wenigen Markern gefunden")
+            return {'FINISHED'}
+
+        scene.frame_current = frame
+
+        bpy.ops.clip.setup_defaults(silent=True)
+        bpy.ops.clip.defaults_detect()
+        bpy.ops.clip.motion_detect()
+        bpy.ops.clip.channel_detect()
+        bpy.ops.clip.apply_detect_settings()
+
+        settings = clip.tracking.settings
+        settings.default_search_size = settings.default_pattern_size * 2
+        settings.default_margin = settings.default_pattern_size * 2
+
+        self.report({'INFO'}, "Heavy Track abgeschlossen")
+        return {'FINISHED'}
+
+
 class CLIP_OT_step_track(bpy.types.Operator):
     bl_idname = "clip.step_track"
     bl_label = "Step Track"
@@ -2687,5 +2724,6 @@ operator_classes = (
     CLIP_OT_camera_solve,
     CLIP_OT_track_cleanup,
     CLIP_OT_cleanup,
+    CLIP_OT_heavy_track,
 )
 

--- a/ui/panels.py
+++ b/ui/panels.py
@@ -35,6 +35,7 @@ class CLIP_PT_stufen_panel(bpy.types.Panel):
         layout.operator('clip.panel_button', text='Proxy')
         layout.operator('clip.track_nr1', text='Track Nr. 1')
         layout.operator('clip.cleanup', text='Cleanup')
+        layout.operator('clip.heavy_track', text='Heavy Track')
 
 
 class CLIP_PT_test_panel(bpy.types.Panel):


### PR DESCRIPTION
## Summary
- add `Heavy Track` operator to run extended tracking tests
- expose new button in the Stufen panel
- register the operator in the addon
- bump addon version to 1.184
- document the new feature in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6883d44558d0832d93df704135f71fb7