### PR TITLE
Add detail panel and test automation operators

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -9,7 +9,7 @@ bl_info = {
 }
 
 import bpy
-from bpy.props import IntProperty, FloatProperty
+from bpy.props import IntProperty, FloatProperty, StringProperty
 
 from .functions import core as functions
 from .ui import panels
@@ -43,6 +43,11 @@ def register():
         description="Fehlergrenze für Operationen",
         default=2.0,
     )
+    bpy.types.Scene.test_value = StringProperty(
+        name="Test Value",
+        description="Speichert Werte aus Testoperationen",
+        default="",
+    )
     for cls in classes:
         bpy.utils.register_class(cls)
 
@@ -60,6 +65,8 @@ def unregister():
         del bpy.types.Scene.threshold_value
     if hasattr(bpy.types.Scene, "error_threshold"):
         del bpy.types.Scene.error_threshold
+    if hasattr(bpy.types.Scene, "test_value"):
+        del bpy.types.Scene.test_value
 
 
 if __name__ == "__main__":

--- a/__init__.py
+++ b/__init__.py
@@ -38,6 +38,11 @@ def register():
         description="Gespeicherter Threshold-Wert",
         default=1.0,
     )
+    bpy.types.Scene.test_value = IntProperty(
+        name="Test Value",
+        description="Ergebniswert aus Testfunktionen",
+        default=0,
+    )
     bpy.types.Scene.error_threshold = FloatProperty(
         name="Error Threshold",
         description="Fehlergrenze für Operationen",
@@ -58,6 +63,8 @@ def unregister():
         del bpy.types.Scene.nm_count
     if hasattr(bpy.types.Scene, "threshold_value"):
         del bpy.types.Scene.threshold_value
+    if hasattr(bpy.types.Scene, "test_value"):
+        del bpy.types.Scene.test_value
     if hasattr(bpy.types.Scene, "error_threshold"):
         del bpy.types.Scene.error_threshold
 

--- a/__init__.py
+++ b/__init__.py
@@ -9,7 +9,7 @@ bl_info = {
 }
 
 import bpy
-from bpy.props import IntProperty, FloatProperty, StringProperty
+from bpy.props import IntProperty, FloatProperty
 
 from .functions import core as functions
 from .ui import panels
@@ -43,11 +43,6 @@ def register():
         description="Fehlergrenze für Operationen",
         default=2.0,
     )
-    bpy.types.Scene.test_value = StringProperty(
-        name="Test Value",
-        description="Speichert Werte aus Testoperationen",
-        default="",
-    )
     for cls in classes:
         bpy.utils.register_class(cls)
 
@@ -65,8 +60,6 @@ def unregister():
         del bpy.types.Scene.threshold_value
     if hasattr(bpy.types.Scene, "error_threshold"):
         del bpy.types.Scene.error_threshold
-    if hasattr(bpy.types.Scene, "test_value"):
-        del bpy.types.Scene.test_value
 
 
 if __name__ == "__main__":

--- a/functions/core.py
+++ b/functions/core.py
@@ -2682,9 +2682,10 @@ class CLIP_OT_test_pattern(bpy.types.Operator):
             end = _run_test_cycle(context, pattern_size=current)
             if end is None:
                 break
-            if end > best_end:
-                best_end = end
-                best_size = current
+            if end >= best_end:
+                if end > best_end:
+                    best_end = end
+                    best_size = current
                 next_size = min(int(current * 1.1), max_size)
                 if next_size == current or next_size > max_size:
                     break

--- a/functions/core.py
+++ b/functions/core.py
@@ -1666,13 +1666,12 @@ def _Test_detect_mm(self, context):
 def _run_test_cycle(context, pattern_size=None, motion_model=None, channels=None):
     """Run Detect, Track and Delete sequence four times.
 
+    Each cycle begins with ``Test Defaults`` to mirror manual testing.
     Returns the highest frame reached during tracking.
     """
     clip = context.space_data.clip
     if not clip:
         return None
-
-    bpy.ops.clip.setup_defaults()
 
     settings = clip.tracking.settings
     if pattern_size is not None:
@@ -1689,6 +1688,7 @@ def _run_test_cycle(context, pattern_size=None, motion_model=None, channels=None
 
     best_end = None
     for _ in range(4):
+        bpy.ops.clip.setup_defaults()
         bpy.ops.clip.detect_button()
         if bpy.ops.clip.track_full.poll():
             bpy.ops.clip.track_full(silent=True)

--- a/functions/core.py
+++ b/functions/core.py
@@ -1666,7 +1666,6 @@ def _Test_detect_mm(self, context):
 def _run_test_cycle(context, pattern_size=None, motion_model=None, channels=None):
     """Run Detect, Track and Delete sequence four times.
 
-    Each cycle begins with ``Test Defaults`` to mirror manual testing.
     Returns the highest frame reached during tracking.
     """
     clip = context.space_data.clip
@@ -1688,7 +1687,6 @@ def _run_test_cycle(context, pattern_size=None, motion_model=None, channels=None
 
     best_end = None
     for _ in range(4):
-        bpy.ops.clip.setup_defaults()
         bpy.ops.clip.detect_button()
         if bpy.ops.clip.track_full.poll():
             bpy.ops.clip.track_full(silent=True)

--- a/functions/core.py
+++ b/functions/core.py
@@ -1675,8 +1675,6 @@ def _run_test_cycle(context, pattern_size=None, motion_model=None, channels=None
 
     total_end = 0
     for _ in range(4):
-        if bpy.ops.clip.setup_defaults.poll():
-            bpy.ops.clip.setup_defaults(silent=True)
         if bpy.ops.clip.detect_features.poll():
             bpy.ops.clip.detect_features()
         else:

--- a/functions/core.py
+++ b/functions/core.py
@@ -427,18 +427,6 @@ class CLIP_OT_detect_button(bpy.types.Operator):
             min_distance = int(min_distance_base * factor)
             attempt += 1
 
-        settings = clip.tracking.settings
-        if (
-            LAST_DETECT_COUNT is not None
-            and new_markers == LAST_DETECT_COUNT
-            and new_markers > 0
-            and detection_threshold <= MIN_THRESHOLD
-        ):
-            settings.default_pattern_size = int(settings.default_pattern_size * 0.9)
-            settings.default_pattern_size = clamp_pattern_size(
-                settings.default_pattern_size, clip
-            )
-            settings.default_search_size = settings.default_pattern_size * 2
         LAST_DETECT_COUNT = new_markers
         context.scene.threshold_value = threshold_value
         context.scene.nm_count = new_markers
@@ -1687,8 +1675,6 @@ def _run_test_cycle(context, pattern_size=None, motion_model=None, channels=None
 
     best_end = None
     for _ in range(4):
-        if bpy.ops.clip.setup_defaults.poll():
-            bpy.ops.clip.setup_defaults(silent=True)
         if bpy.ops.clip.detect_features.poll():
             bpy.ops.clip.detect_features()
         else:

--- a/functions/core.py
+++ b/functions/core.py
@@ -1687,7 +1687,12 @@ def _run_test_cycle(context, pattern_size=None, motion_model=None, channels=None
 
     best_end = None
     for _ in range(4):
-        bpy.ops.clip.detect_button()
+        if bpy.ops.clip.setup_defaults.poll():
+            bpy.ops.clip.setup_defaults(silent=True)
+        if bpy.ops.clip.detect_features.poll():
+            bpy.ops.clip.detect_features()
+        else:
+            print("\u274c 'detect_features' kann im aktuellen Kontext nicht ausgef\u00fchrt werden.")
         if bpy.ops.clip.track_full.poll():
             bpy.ops.clip.track_full(silent=True)
             end_frame = LAST_TRACK_END

--- a/ui/panels.py
+++ b/ui/panels.py
@@ -86,7 +86,22 @@ class CLIP_PT_test_subpanel(bpy.types.Panel):
 
     def draw(self, context):
         layout = self.layout
-        
+
+        layout.operator('clip.test_pattern', text='Test Pattern')
+        layout.operator('clip.test_motion', text='Test Motion')
+        layout.operator('clip.test_channel', text='Test Chanal')
+
+
+class CLIP_PT_test_detail_panel(bpy.types.Panel):
+    bl_space_type = 'CLIP_EDITOR'
+    bl_region_type = 'UI'
+    bl_category = 'Addon'
+    bl_parent_id = 'CLIP_PT_test_subpanel'
+    bl_label = 'Details'
+
+    def draw(self, context):
+        layout = self.layout
+
         layout.operator('clip.setup_defaults', text='Test Defaults')
         layout.operator('clip.detect_button', text='Test Detect')
         layout.operator('clip.test_track', text='Test Track')
@@ -99,5 +114,6 @@ panel_classes = (
     CLIP_PT_stufen_panel,
     CLIP_PT_test_panel,
     CLIP_PT_test_subpanel,
+    CLIP_PT_test_detail_panel,
 )
 

--- a/ui/panels.py
+++ b/ui/panels.py
@@ -88,6 +88,9 @@ class CLIP_PT_test_subpanel(bpy.types.Panel):
         layout = self.layout
 
         layout.label(text="Test Aktionen")
+        layout.operator('clip.test_pattern', text='Test Pattern')
+        layout.operator('clip.test_motion', text='Test Motion')
+        layout.operator('clip.test_channel', text='Test Chanal')
 
 
 class CLIP_PT_test_detail_panel(bpy.types.Panel):

--- a/ui/panels.py
+++ b/ui/panels.py
@@ -87,9 +87,7 @@ class CLIP_PT_test_subpanel(bpy.types.Panel):
     def draw(self, context):
         layout = self.layout
 
-        layout.operator('clip.test_pattern', text='Test Pattern')
-        layout.operator('clip.test_motion', text='Test Motion')
-        layout.operator('clip.test_channel', text='Test Chanal')
+        layout.label(text="Test Aktionen")
 
 
 class CLIP_PT_test_detail_panel(bpy.types.Panel):
@@ -107,6 +105,7 @@ class CLIP_PT_test_detail_panel(bpy.types.Panel):
         layout.operator('clip.test_track', text='Test Track')
         layout.operator('clip.prefix_test', text='TEST Name')
         layout.operator('clip.select_test_tracks', text='TEST select')
+        layout.operator('clip.error_value', text='Error Value')
 
 panel_classes = (
     CLIP_PT_tracking_panel,


### PR DESCRIPTION
## Summary
- add `test_value` scene property
- implement helper `_run_test_cycle`
- add operators `CLIP_OT_test_pattern`, `CLIP_OT_test_motion`, `CLIP_OT_test_channel`
- update operator registration
- add Detail subpanel in UI and move existing test buttons
- include new test buttons in Test subpanel

## Testing
- `python -m py_compile __init__.py functions/core.py ui/panels.py`


------
https://chatgpt.com/codex/tasks/task_e_6883dba0c0d8832d948ba3db6bb24626