### PR TITLE
Enhance test cycle evaluation

### DIFF
--- a/functions/core.py
+++ b/functions/core.py
@@ -2035,10 +2035,24 @@ class CLIP_OT_test_pattern(bpy.types.Operator):
         min_error = None
 
         while True:
-            frames, err = _run_test_cycle(context)
+            frames1, err1 = _run_test_cycle(context)
             print(
-                f"[Test Pattern] size={settings.default_pattern_size} frames={frames} error={err}"
+                f"[Test Pattern] size={settings.default_pattern_size} run=1 frames={frames1} error={err1}"
             )
+
+            # Zweiter Durchgang zur Absicherung gegen Tracking-Fehler
+            frames2, err2 = _run_test_cycle(context)
+            print(
+                f"[Test Pattern] size={settings.default_pattern_size} run=2 frames={frames2} error={err2}"
+            )
+
+            if frames2 > frames1 or (frames2 == frames1 and err2 < err1):
+                frames = frames2
+                err = err2
+            else:
+                frames = frames1
+                err = err1
+
 
             if (
                 best_frames is None

--- a/functions/core.py
+++ b/functions/core.py
@@ -93,7 +93,16 @@ def add_pending_tracks(tracks):
 
 def clean_pending_tracks(clip):
     """Remove deleted tracks from the pending list."""
-    names = {t.name for t in clip.tracking.tracks}
+    names = set()
+    for tr in clip.tracking.tracks:
+        try:
+            names.add(tr.name)
+        except UnicodeDecodeError:
+            print(
+                f"\u26a0\ufe0f Warnung: Marker-Name kann nicht gelesen werden (wahrscheinlich defekt): {tr}"
+            )
+            continue
+
     remaining = []
     for t in PENDING_RENAME:
         try:

--- a/functions/core.py
+++ b/functions/core.py
@@ -126,6 +126,14 @@ def rename_pending_tracks(clip):
     PENDING_RENAME.clear()
 
 
+def run_detect(**kwargs):
+    """Safely invoke Blender's feature detection operator."""
+    if bpy.ops.clip.detect_features.poll():
+        bpy.ops.clip.detect_features(**kwargs)
+    else:
+        print("❌ Detect Features konnte im aktuellen Kontext nicht ausgeführt werden.")
+
+
 def cycle_motion_model(settings, clip, reset_size=True):
     """Cycle to the next default motion model."""
     current = settings.default_motion_model
@@ -392,16 +400,11 @@ class CLIP_OT_detect_button(bpy.types.Operator):
         while True:
             names_before = {t.name for t in clip.tracking.tracks}
             # Sicherer Aufruf des internen Operators
-            if bpy.ops.clip.detect_features.poll():
-                bpy.ops.clip.detect_features(
-                    threshold=detection_threshold,
-                    min_distance=min_distance,
-                    margin=margin,
-                )
-            else:
-                print(
-                    "❌ 'detect_features' kann im aktuellen Kontext nicht ausgeführt werden."
-                )
+            run_detect(
+                threshold=detection_threshold,
+                min_distance=min_distance,
+                margin=margin,
+            )
             names_after = {t.name for t in clip.tracking.tracks}
             new_tracks = [
                 t for t in clip.tracking.tracks if t.name in names_after - names_before
@@ -1047,16 +1050,11 @@ class CLIP_OT_all_detect(bpy.types.Operator):
         new_markers = 0
         while True:
             names_before = {t.name for t in clip.tracking.tracks}
-            if bpy.ops.clip.detect_features.poll():
-                bpy.ops.clip.detect_features(
-                    threshold=detection_threshold,
-                    min_distance=min_distance,
-                    margin=margin,
-                )
-            else:
-                print(
-                    "❌ 'detect_features' kann im aktuellen Kontext nicht ausgeführt werden."
-                )
+            run_detect(
+                threshold=detection_threshold,
+                min_distance=min_distance,
+                margin=margin,
+            )
             names_after = {t.name for t in clip.tracking.tracks}
             new_tracks = [
                 t for t in clip.tracking.tracks if t.name in names_after - names_before
@@ -1186,16 +1184,11 @@ class CLIP_OT_cycle_detect(bpy.types.Operator):
         new_tracks = []
         while True:
             names_before = {t.name for t in clip.tracking.tracks}
-            if bpy.ops.clip.detect_features.poll():
-                bpy.ops.clip.detect_features(
-                    threshold=detection_threshold,
-                    min_distance=min_distance,
-                    margin=margin,
-                )
-            else:
-                print(
-                    "❌ 'detect_features' kann im aktuellen Kontext nicht ausgeführt werden."
-                )
+            run_detect(
+                threshold=detection_threshold,
+                min_distance=min_distance,
+                margin=margin,
+            )
             names_after = {t.name for t in clip.tracking.tracks}
             new_tracks = [
                 t for t in clip.tracking.tracks if t.name in names_after - names_before


### PR DESCRIPTION
## Summary
- add `calculate_error_value` helper
- record total error in `_run_test_cycle`
- stop resetting defaults during test cycles
- use safe internal `detect_features` calls
- evaluate pattern, motion model and channel tests based on frames and error

## Testing
- `python -m py_compile functions/core.py`

------
https://chatgpt.com/codex/tasks/task_e_6884197b78a0832d8ac945ed36fdec55