### PR TITLE
Rework test cycles to use detect_features

### DIFF
--- a/functions/core.py
+++ b/functions/core.py
@@ -1965,7 +1965,10 @@ def _run_test_cycle(context, cleanup=False):
         if bpy.ops.clip.delete_selected.poll():
             bpy.ops.clip.delete_selected(silent=True)
         if cleanup:
-            clip.tracking.tracks.clear()
+            for t in clip.tracking.tracks:
+                t.select = True
+            if bpy.ops.clip.delete_track.poll():
+                bpy.ops.clip.delete_track()
     print(f"[Test Cycle] Summe End-Frames: {total_end}")
     return total_end
 

--- a/functions/core.py
+++ b/functions/core.py
@@ -1954,8 +1954,6 @@ def _run_test_cycle(context, cleanup=False):
     total_end = 0
     for i in range(4):
         print(f"[Test Cycle] Durchgang {i + 1}")
-        if bpy.ops.clip.setup_defaults.poll():
-            bpy.ops.clip.setup_defaults(silent=True)
         if bpy.ops.clip.detect_features.poll():
             bpy.ops.clip.detect_features()
         if bpy.ops.clip.track_full.poll():


### PR DESCRIPTION
## Summary
- invoke `bpy.ops.clip.detect_features()` directly in `_run_test_cycle`
- allow optional cleanup of markers between cycles
- use cleanup in pattern size tests to avoid leftover tracks

## Testing
- `python -m py_compile functions/core.py`

------
https://chatgpt.com/codex/tasks/task_e_688424ce9378832dac6399fb06232921