### PR TITLE
Add error evaluation for test cycles

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ zuerst "Select NEW" und anschließend "Name Track" ausgeführt.
 Seit Version 1.181 besitzt das API-Unterpanel einen Button "TEST select", der alle Marker mit dem Präfix TEST_ auswählt.
 Seit Version 1.182 gibt es dort zusätzlich einen Button "Test Detect", der Marker erkennt, bis ihre Anzahl im Zielbereich liegt.
 Seit Version 1.183 besitzt dieses Unter-Panel auch einen Button "Test Track", der selektierte Marker bis zum Sequenzende vorwärts verfolgt.
+Seit Version 1.184 werten die Testfunktionen zusätzlich den Fehler der Markerpositionen aus. Nach jedem der vier Tracking-Durchgänge wird der Error berechnet und aufsummiert. Bei der Pattern-Größe wird der Test beendet, sobald keine Fortschritte mehr erzielt werden oder der Fehlerwert um mehr als 10 % über dem bisherigen Minimum liegt. Motion Model und Farbkanäle wählen direkt die Kombination mit dem besten Verhältnis aus maximaler Frame-Anzahl und minimalem Error.
 
 ## License
 


### PR DESCRIPTION
## Summary
- compute tracking error with new `calculate_clip_error` helper
- accumulate error in `_run_test_cycle`
- update pattern, motion and channel tests to consider error values
- document error evaluation feature in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68842f7c5bec832d9a7b25ea3643b0c4