### PR TITLE
Update pattern test to single cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ Seit Version 1.186 schalten die Testfunktionen den Proxy vor der Feature-Erkennu
 Seit Version 1.187 erhöht sich die Abbruchschwelle für den Fehler beim Pattern-Test auf 20 %.
 Seit Version 1.188 wird beim Pattern-Test nach einem Rückgang der Frame-Anzahl noch vier weitere Größenwerte getestet, bevor der Vorgang abgebrochen wird.
 Seit Version 1.189 sind die Abläufe der Testfunktionen in modulare Schritte unterteilt, um die Wartbarkeit des Codes zu verbessern.
+Seit Version 1.190 testet "Test Pattern" jede Größe nur noch einmal mit vier Durchgängen.
 
 ## License
 

--- a/functions/core.py
+++ b/functions/core.py
@@ -2039,15 +2039,8 @@ def _run_test_cycle(context, cleanup=False):
 
 
 def run_pattern_size_test(context):
-    """Execute two cycles for the current pattern size and return the best."""
-    first_frames, first_err = _run_test_cycle(context, cleanup=True)
-    second_frames, second_err = _run_test_cycle(context, cleanup=True)
-
-    if second_frames > first_frames or (
-        second_frames == first_frames and second_err < first_err
-    ):
-        return second_frames, second_err
-    return first_frames, first_err
+    """Execute a single cycle for the current pattern size."""
+    return _run_test_cycle(context, cleanup=True)
 
 
 class CLIP_OT_test_pattern(bpy.types.Operator):


### PR DESCRIPTION
## Summary
- reduce `run_pattern_size_test` to a single test cycle
- document the change in README

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6884cb80f2d8832d9cda081b265494dc