### PR TITLE
Adjust test pattern loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ zuerst "Select NEW" und anschließend "Name Track" ausgeführt.
 Seit Version 1.181 besitzt das API-Unterpanel einen Button "TEST select", der alle Marker mit dem Präfix TEST_ auswählt.
 Seit Version 1.182 gibt es dort zusätzlich einen Button "Test Detect", der Marker erkennt, bis ihre Anzahl im Zielbereich liegt.
 Seit Version 1.183 besitzt dieses Unter-Panel auch einen Button "Test Track", der selektierte Marker bis zum Sequenzende vorwärts verfolgt.
-Seit Version 1.184 werten die Testfunktionen zusätzlich den Fehler der Markerpositionen aus. Nach jedem der vier Tracking-Durchgänge wird der Error berechnet und aufsummiert. Bei der Pattern-Größe wird der Test beendet, sobald keine Fortschritte mehr erzielt werden oder der Fehlerwert um mehr als 20 % über dem bisherigen Minimum liegt. Motion Model und Farbkanäle wählen direkt die Kombination mit dem besten Verhältnis aus maximaler Frame-Anzahl und minimalem Error.
+Seit Version 1.184 werten die Testfunktionen zusätzlich den Fehler der Markerpositionen aus. Nach jedem der vier Tracking-Durchgänge wird der Error berechnet und aufsummiert. Bei der Pattern-Größe wird der Test beendet, sobald keine Fortschritte mehr erzielt werden oder der Fehlerwert um mehr als 15 % über dem bisherigen Minimum liegt. Motion Model und Farbkanäle wählen direkt die Kombination mit dem besten Verhältnis aus maximaler Frame-Anzahl und minimalem Error.
 Seit Version 1.185 führt "Test Pattern" jeden Größenwert zweimal aus und verwendet das bessere Ergebnis, um Ausreißer durch Tracking-Fehler zu vermeiden.
 Seit Version 1.186 schalten die Testfunktionen den Proxy vor der Feature-Erkennung aus und vor dem Tracking wieder ein, damit alle Schritte mit konsistenten Einstellungen ausgeführt werden.
 Seit Version 1.187 erhöht sich die Abbruchschwelle für den Fehler beim Pattern-Test auf 20 %.
@@ -315,6 +315,7 @@ Seit Version 1.189 sind die Abläufe der Testfunktionen in modulare Schritte unt
 Seit Version 1.190 testet "Test Pattern" jede Größe nur noch einmal mit vier Durchgängen.
 Seit Version 1.191 führt "Test Pattern" pro Größe nur noch drei Tracking-Durchgänge aus.
 Seit Version 1.192 führt "Test Pattern" pro Größe nur noch einen Tracking-Durchgang aus.
+Seit Version 1.193 verringert sich die Abbruchschwelle für den Fehler beim Pattern-Test auf 15 %.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -313,6 +313,8 @@ Seit Version 1.187 erhöht sich die Abbruchschwelle für den Fehler beim Pattern
 Seit Version 1.188 wird beim Pattern-Test nach einem Rückgang der Frame-Anzahl noch vier weitere Größenwerte getestet, bevor der Vorgang abgebrochen wird.
 Seit Version 1.189 sind die Abläufe der Testfunktionen in modulare Schritte unterteilt, um die Wartbarkeit des Codes zu verbessern.
 Seit Version 1.190 testet "Test Pattern" jede Größe nur noch einmal mit vier Durchgängen.
+Seit Version 1.191 führt "Test Pattern" pro Größe nur noch drei Tracking-Durchgänge aus.
+Seit Version 1.192 führt "Test Pattern" pro Größe nur noch einen Tracking-Durchgang aus.
 
 ## License
 

--- a/functions/core.py
+++ b/functions/core.py
@@ -2080,7 +2080,7 @@ class CLIP_OT_test_pattern(bpy.types.Operator):
                 min_error = error_sum
 
             if last_score is not None:
-                if score == last_score and error_sum > min_error * 1.2:
+                if score == last_score and error_sum > min_error * 1.15:
                     break
 
                 if drops_left > 0:

--- a/functions/core.py
+++ b/functions/core.py
@@ -2080,7 +2080,7 @@ class CLIP_OT_test_pattern(bpy.types.Operator):
                 min_error = error_sum
 
             if last_score is not None:
-                if score == last_score and error_sum > min_error * 1.15:
+                if score == last_score and error_sum > min_error * 1.1:
                     break
 
                 if drops_left > 0:

--- a/functions/core.py
+++ b/functions/core.py
@@ -2020,12 +2020,12 @@ def run_iteration(context):
     return frames, error_val
 
 
-def _run_test_cycle(context, cleanup=False):
-    """Run detection and tracking four times and return total frames and error."""
+def _run_test_cycle(context, cleanup=False, cycles=4):
+    """Run detection and tracking multiple times and return total frames and error."""
     clip = context.space_data.clip
     total_end = 0
     total_error = 0.0
-    for i in range(4):
+    for i in range(cycles):
         print(f"[Test Cycle] Durchgang {i + 1}")
         frames, err = run_iteration(context)
         total_end += frames
@@ -2039,8 +2039,8 @@ def _run_test_cycle(context, cleanup=False):
 
 
 def run_pattern_size_test(context):
-    """Execute a single cycle for the current pattern size."""
-    return _run_test_cycle(context, cleanup=True)
+    """Execute a single cycle for the current pattern size with one tracking pass."""
+    return _run_test_cycle(context, cleanup=True, cycles=1)
 
 
 class CLIP_OT_test_pattern(bpy.types.Operator):


### PR DESCRIPTION
## Summary
- allow specifying number of cycles when running a test cycle
- run pattern size tests with a single cycle instead of three
- note in README that test pattern now tracks once per size

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6884cf6e96ac832d916c1a4d0b7684ea