### PR TITLE
Refactor cleanup process

### DIFF
--- a/functions/core.py
+++ b/functions/core.py
@@ -2318,24 +2318,29 @@ def cleanup_error_tracks(scene, clip):
     threshold = max_err
 
     while threshold >= original:
-        while True:
-            if bpy.ops.clip.track_cleanup.poll():
-                bpy.ops.clip.track_cleanup()
-            else:
-                break
-
-            selected = sum(1 for t in clip.tracking.tracks if t.select)
-            if selected:
-                print(f"[Cleanup] {selected} Tracks, Threshold {threshold:.2f}")
-                if bpy.ops.clip.delete_selected.poll():
-                    bpy.ops.clip.delete_selected()
-            else:
-                break
+        while cleanup_pass(scene, clip, threshold):
+            pass
 
         threshold *= 0.9
         scene.error_threshold = threshold
 
     scene.error_threshold = original
+
+
+def cleanup_pass(scene, clip, threshold):
+    """Run a single cleanup pass and return True if tracks were deleted."""
+    if not bpy.ops.clip.track_cleanup.poll():
+        return False
+    bpy.ops.clip.track_cleanup()
+
+    selected = sum(1 for t in clip.tracking.tracks if t.select)
+    if selected:
+        print(f"[Cleanup] {selected} Tracks, Threshold {threshold:.2f}")
+        if bpy.ops.clip.delete_selected.poll():
+            bpy.ops.clip.delete_selected()
+        return True
+
+    return False
 
 
 class CLIP_OT_track_cleanup(bpy.types.Operator):


### PR DESCRIPTION
## Summary
- factor out repeated error track deletion logic
- call the new helper in `cleanup_error_tracks`

## Testing
- `python -m py_compile __init__.py functions/*.py ui/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6884ec53343c832da6d88c25728bc51f