### PR TITLE
Fix tests removing GOOD markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ Seit Version 1.190 testet "Test Pattern" jede Größe nur noch einmal mit vier D
 Seit Version 1.191 führt "Test Pattern" pro Größe nur noch drei Tracking-Durchgänge aus.
 Seit Version 1.192 führt "Test Pattern" pro Größe nur noch einen Tracking-Durchgang aus.
 Seit Version 1.193 verringert sich die Abbruchschwelle für den Fehler beim Pattern-Test auf 15 %.
+Seit Version 1.194 ignorieren "Test Pattern", "Test Motion" und "Test Channel" GOOD_-Marker und löschen diese nicht mehr.
 
 ## License
 

--- a/functions/core.py
+++ b/functions/core.py
@@ -2005,7 +2005,12 @@ def track_full_clip():
 
 
 def delete_selected_tracks():
-    """Delete all selected tracks."""
+    """Delete all selected tracks, ignoring GOOD_ tracks."""
+    clip = bpy.context.space_data.clip
+    if clip:
+        for t in clip.tracking.tracks:
+            if t.select and t.name.startswith("GOOD_"):
+                t.select = False
     if bpy.ops.clip.delete_selected.poll():
         bpy.ops.clip.delete_selected(silent=True)
 
@@ -2031,9 +2036,9 @@ def rename_new_tracks(context):
 
 
 def cleanup_all_tracks(clip):
-    """Remove all tracks from the clip."""
+    """Remove all non-GOOD_ tracks from the clip."""
     for t in clip.tracking.tracks:
-        t.select = True
+        t.select = not t.name.startswith("GOOD_")
     if bpy.ops.clip.delete_track.poll():
         bpy.ops.clip.delete_track()
 


### PR DESCRIPTION
## Summary
- prevent `delete_selected_tracks` from removing GOOD_ markers
- skip GOOD_ markers in `cleanup_all_tracks`
- document the new behavior in the README

## Testing
- `python -m py_compile functions/core.py __init__.py ui/panels.py`

------
https://chatgpt.com/codex/tasks/task_e_68851706d778832db036327b1bfe8773