### PR TITLE
Add final cleanup to Track Nr. 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ Seit Version 1.190 testet "Test Pattern" jede Größe nur noch einmal mit vier D
 Seit Version 1.191 führt "Test Pattern" pro Größe nur noch drei Tracking-Durchgänge aus.
 Seit Version 1.192 führt "Test Pattern" pro Größe nur noch einen Tracking-Durchgang aus.
 Seit Version 1.193 verringert sich die Abbruchschwelle für den Fehler beim Pattern-Test auf 15 %.
+Seit Version 1.194 f\u00fchrt der Button "Track Nr. 1" am Ende einmalig "Select Short Tracks" und anschlie\u00dfend "Delete" aus.
 
 ## License
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Simple Addon",
     "author": "Your Name",
-    "version": (1, 193),
+    "version": (1, 194),
     "blender": (4, 4, 0),
     "location": "View3D > Object",
     "description": "Zeigt eine einfache Meldung an",

--- a/functions/core.py
+++ b/functions/core.py
@@ -401,6 +401,9 @@ class CLIP_OT_track_nr1(bpy.types.Operator):
         count = rename_new_tracks(context)
         if count:
             self.report({'INFO'}, f"{count} Tracks umbenannt")
+
+        # abschließend kurze TRACK_-Marker entfernen
+        cleanup_short_tracks(context)
         return None
 
     def execute(self, context):


### PR DESCRIPTION
## Summary
- call `cleanup_short_tracks` once more when `Track Nr. 1` finishes
- bump addon version to 1.194
- document new behaviour in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68855b90d0f0832d9943aec6fef0fcac