### PR TITLE
Fix clip editor frame sync after jump

### DIFF
--- a/functions/core.py
+++ b/functions/core.py
@@ -459,6 +459,11 @@ class CLIP_OT_track_nr2(bpy.types.Operator):
         frame, _ = find_low_marker_frame(clip, threshold)
         if frame is not None:
             scene.frame_current = frame
+            for area in context.screen.areas:
+                if area.type == 'CLIP_EDITOR':
+                    for space in area.spaces:
+                        if space.type == 'CLIP_EDITOR':
+                            space.clip_user.frame_number = frame
 
         cycles = 0
         while True:


### PR DESCRIPTION
## Summary
- update clip editor's `clip_user.frame_number` when jumping to a frame

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688561166438832dbd7999dcf6be37dd