### PR TITLE
Add Marker/Frame+ button

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ Seit Version 1.191 führt "Test Pattern" pro Größe nur noch drei Tracking-Durc
 Seit Version 1.192 führt "Test Pattern" pro Größe nur noch einen Tracking-Durchgang aus.
 Seit Version 1.193 verringert sich die Abbruchschwelle für den Fehler beim Pattern-Test auf 15 %.
 Seit Version 1.194 f\u00fchrt der Button "Track Nr. 1" am Ende einmalig "Select Short Tracks" und anschlie\u00dfend "Delete" aus.
+Seit Version 1.195 verf\u00fcgt das API-Panel \u00fcber einen Button "Marker/Frame+", der den Wert im Feld "Marker/Frame" um 10 % erh\u00f6ht.
 
 ## License
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Simple Addon",
     "author": "Your Name",
-    "version": (1, 194),
+    "version": (1, 195),
     "blender": (4, 4, 0),
     "location": "View3D > Object",
     "description": "Zeigt eine einfache Meldung an",

--- a/functions/core.py
+++ b/functions/core.py
@@ -2719,6 +2719,17 @@ class CLIP_OT_frame_jump(bpy.types.Operator):
         return {'FINISHED'}
 
 
+class CLIP_OT_marker_frame_plus(bpy.types.Operator):
+    bl_idname = "clip.marker_frame_plus"
+    bl_label = "Marker/Frame+"
+    bl_description = "Erh\u00f6ht 'Marker/Frame' um 10 %"
+
+    def execute(self, context):
+        scene = context.scene
+        scene.marker_frame = int(scene.marker_frame * 1.1)
+        return {'FINISHED'}
+
+
 class CLIP_OT_api_defaults(bpy.types.Operator):
     bl_idname = "clip.api_defaults"
     bl_label = "Defaults"
@@ -3158,6 +3169,7 @@ operator_classes = (
     CLIP_OT_track_partial,
     CLIP_OT_step_track,
     CLIP_OT_frame_jump,
+    CLIP_OT_marker_frame_plus,
     CLIP_OT_setup_defaults,
     CLIP_OT_track_full,
     CLIP_OT_test_track_backwards,

--- a/ui/panels.py
+++ b/ui/panels.py
@@ -72,6 +72,7 @@ class CLIP_PT_test_panel(bpy.types.Panel):
         layout.operator('clip.channel_g_off', text='Channel G off')
         layout.operator('clip.frame_jump_custom', text='Frame Jump')
         layout.operator('clip.low_marker_frame', text='Low Marker Frame')
+        layout.operator('clip.marker_frame_plus', text='Marker/Frame+')
         layout.operator('clip.marker_position', text='Marker Position')
         layout.operator('clip.good_marker_position', text='GOOD Marker Position')
         layout.operator('clip.camera_solve', text='Kamera solve')


### PR DESCRIPTION
## Summary
- add Marker/Frame+ operator
- expose new button in API panel
- bump addon version to 1.195
- document feature in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688572a04df8832db248a4d42323c739