### PR TITLE
Add tracking progress feedback

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Simple Addon",
     "author": "Your Name",
-    "version": (1, 196),
+    "version": (1, 197),
     "blender": (4, 4, 0),
     "location": "View3D > Object",
     "description": "Zeigt eine einfache Meldung an",
@@ -48,6 +48,11 @@ def register():
         description="Fehlergrenze für Operationen",
         default=2.0,
     )
+    bpy.types.Scene.track_status = bpy.props.StringProperty(
+        name="Track Status",
+        description="Aktueller Tracking-Status",
+        default="",
+    )
     for cls in classes:
         bpy.utils.register_class(cls)
 
@@ -67,6 +72,8 @@ def unregister():
         del bpy.types.Scene.test_value
     if hasattr(bpy.types.Scene, "error_threshold"):
         del bpy.types.Scene.error_threshold
+    if hasattr(bpy.types.Scene, "track_status"):
+        del bpy.types.Scene.track_status
 
 
 if __name__ == "__main__":

--- a/ui/panels.py
+++ b/ui/panels.py
@@ -32,6 +32,8 @@ class CLIP_PT_stufen_panel(bpy.types.Panel):
 
     def draw(self, context):
         layout = self.layout
+        if context.scene.track_status:
+            layout.label(text=context.scene.track_status)
         layout.operator('clip.panel_button', text='Proxy')
         layout.operator('clip.track_nr1', text='Track Nr. 1')
         layout.operator('clip.cleanup', text='Cleanup')


### PR DESCRIPTION
## Summary
- add progress tracking status property to keep users informed
- show current tracking frame and a completion message
- update track_markers_range to step through frames with progress feedback
- display tracking status in the Stufen panel
- bump addon version to 1.197

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688616996b00832daa08007813af1864