### PR TITLE
Fix Blender addon helper imports

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -10,10 +10,10 @@ bl_info = {
 
 import bpy
 
-# Use absolute imports starting from the add-on package root
-from tracking_main.operators import operator_classes
-from ui import panel_classes
-from properties import register_properties, unregister_properties
+# Use relative imports within the add-on package
+from .operators import operator_classes
+from .ui import panel_classes
+from .properties import register_properties, unregister_properties
 classes = operator_classes + panel_classes
 
 

--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -1,2 +1,2 @@
-# Expose helper functions via absolute import path
-from tracking_main.helpers.utils import *
+# Expose helper functions via relative import
+from .utils import *

--- a/operators/__init__.py
+++ b/operators/__init__.py
@@ -1,4 +1,4 @@
-# Absolute import to the tracking operator package
-from tracking_main.operators import tracking
+# Relative import to the tracking operator package
+from . import tracking
 
 operator_classes = tracking.operator_classes

--- a/operators/tracking/__init__.py
+++ b/operators/tracking/__init__.py
@@ -1,5 +1,5 @@
-# Import operator modules via absolute paths
-from tracking_main.operators.tracking import solver, camera, export
+# Import operator modules via relative paths
+from . import solver, camera, export
 
 operator_classes = (
     *solver.operator_classes,

--- a/operators/tracking/export.py
+++ b/operators/tracking/export.py
@@ -1,7 +1,7 @@
 import bpy
 from bpy.props import BoolProperty
-# Import helper via absolute package path
-from tracking_main.helpers import strip_prefix
+# Import helper via relative package path
+from ...helpers import strip_prefix
 
 class CLIP_OT_prefix_new(bpy.types.Operator):
     bl_idname = "clip.prefix_new"

--- a/operators/tracking/export.py
+++ b/operators/tracking/export.py
@@ -1,7 +1,7 @@
 import bpy
 from bpy.props import BoolProperty
 # Import helper via absolute package path
-from t.helpers import strip_prefix
+from tracking_main.helpers import strip_prefix
 
 class CLIP_OT_prefix_new(bpy.types.Operator):
     bl_idname = "clip.prefix_new"

--- a/operators/tracking/solver.py
+++ b/operators/tracking/solver.py
@@ -5,8 +5,8 @@ import math
 import re
 from bpy.props import IntProperty, FloatProperty, BoolProperty
 
-# Import utility functions via absolute path
-from tracking_main.helpers import *
+# Import utility functions via relative path
+from ...helpers import *
 
 
 class OBJECT_OT_simple_operator(bpy.types.Operator):

--- a/operators/tracking/solver.py
+++ b/operators/tracking/solver.py
@@ -6,7 +6,7 @@ import re
 from bpy.props import IntProperty, FloatProperty, BoolProperty
 
 # Import utility functions via absolute path
-from t.helpers import *
+from tracking_main.helpers import *
 
 
 class OBJECT_OT_simple_operator(bpy.types.Operator):

--- a/properties/__init__.py
+++ b/properties/__init__.py
@@ -1,5 +1,5 @@
-# Absolute imports for property modules
-from tracking_main.properties import tracking_props, test_props
+# Relative imports for property modules
+from . import tracking_props, test_props
 
 
 def register_properties():

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -1,1 +1,1 @@
-from tracking_main.panels import *
+from .panels import *

--- a/ui/panels/__init__.py
+++ b/ui/panels/__init__.py
@@ -1,5 +1,5 @@
-# Absolute imports for panel modules
-from tracking_main.ui.panels import tracking_panel, settings_panel, test_panels
+# Relative imports for panel modules
+from . import tracking_panel, settings_panel, test_panels
 
 panel_classes = (
     *tracking_panel.panel_classes,


### PR DESCRIPTION
## Summary
- fix absolute helper imports in solver.py and export.py

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688650fad9b0832d860af5b48f0cea5d