### PR TITLE
Persist tracker threshold across detect

### DIFF
--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -182,13 +182,13 @@ def detect_new_tracks(clip, detection_threshold, min_distance, margin):
     names_before = {t.name for t in clip.tracking.tracks}
     if bpy.ops.clip.proxy_off.poll():
         bpy.ops.clip.proxy_off()
-    print(f"[Detect Features] threshold {detection_threshold:.3f}")
+    print(f"[Detect Features] threshold {detection_threshold:.5f}")
     bpy.ops.clip.detect_features(
         threshold=detection_threshold,
         min_distance=min_distance,
         margin=margin,
     )
-    print(f"[Detect Features] finished threshold {detection_threshold:.3f}")
+    print(f"[Detect Features] finished threshold {detection_threshold:.5f}")
     names_after = {t.name for t in clip.tracking.tracks}
     new_tracks = [t for t in clip.tracking.tracks if t.name in names_after - names_before]
     return new_tracks, names_before

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -182,13 +182,19 @@ def detect_new_tracks(clip, detection_threshold, min_distance, margin):
     names_before = {t.name for t in clip.tracking.tracks}
     if bpy.ops.clip.proxy_off.poll():
         bpy.ops.clip.proxy_off()
-    print(f"[Detect Features] threshold {detection_threshold:.5f}")
+    print(
+        f"[Detect Features] threshold {detection_threshold:.8f}, "
+        f"margin {margin}, min_distance {min_distance}"
+    )
     bpy.ops.clip.detect_features(
         threshold=detection_threshold,
         min_distance=min_distance,
         margin=margin,
     )
-    print(f"[Detect Features] finished threshold {detection_threshold:.5f}")
+    print(
+        f"[Detect Features] finished threshold {detection_threshold:.8f}, "
+        f"margin {margin}, min_distance {min_distance}"
+    )
     names_after = {t.name for t in clip.tracking.tracks}
     new_tracks = [t for t in clip.tracking.tracks if t.name in names_after - names_before]
     return new_tracks, names_before

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -182,11 +182,13 @@ def detect_new_tracks(clip, detection_threshold, min_distance, margin):
     names_before = {t.name for t in clip.tracking.tracks}
     if bpy.ops.clip.proxy_off.poll():
         bpy.ops.clip.proxy_off()
+    print(f"[Detect Features] threshold {detection_threshold:.3f}")
     bpy.ops.clip.detect_features(
         threshold=detection_threshold,
         min_distance=min_distance,
         margin=margin,
     )
+    print(f"[Detect Features] finished threshold {detection_threshold:.3f}")
     names_after = {t.name for t in clip.tracking.tracks}
     new_tracks = [t for t in clip.tracking.tracks if t.name in names_after - names_before]
     return new_tracks, names_before

--- a/operators/tracking/camera.py
+++ b/operators/tracking/camera.py
@@ -127,7 +127,7 @@ def cleanup_pass(scene, clip, threshold):
 
     selected = sum(1 for t in clip.tracking.tracks if t.select)
     if selected:
-        print(f"[Cleanup] {selected} Tracks, Threshold {threshold:.2f}")
+        print(f"[Cleanup] {selected} Tracks, Threshold {threshold:.5f}")
         if bpy.ops.clip.delete_selected.poll():
             bpy.ops.clip.delete_selected()
         return True

--- a/operators/tracking/solver.py
+++ b/operators/tracking/solver.py
@@ -347,7 +347,7 @@ class CLIP_OT_detect_button(bpy.types.Operator):
         mframe = context.scene.marker_frame
         mf_base = mframe / 3
 
-        threshold_value = 1.0
+        threshold_value = context.scene.tracker_threshold
 
         detection_threshold = max(min(threshold_value, 1.0), MIN_THRESHOLD)
 
@@ -426,6 +426,7 @@ class CLIP_OT_detect_button(bpy.types.Operator):
             settings.default_search_size = settings.default_pattern_size * 2
         LAST_DETECT_COUNT = new_markers
         context.scene.threshold_value = threshold_value
+        context.scene.tracker_threshold = threshold_value
         context.scene.nm_count = new_markers
         # Keep newly detected tracks selected
         for track in clip.tracking.tracks:
@@ -910,7 +911,7 @@ class CLIP_OT_all_detect(bpy.types.Operator):
         mfp_min = mfp * 0.9
         mfp_max = mfp * 1.1
 
-        threshold_value = 1.0
+        threshold_value = context.scene.tracker_threshold
         detection_threshold = max(min(threshold_value, 1.0), MIN_THRESHOLD)
         factor = math.log10(detection_threshold * 10000000000) / 10
         margin = int(margin_base * factor)
@@ -1011,6 +1012,7 @@ class CLIP_OT_all_detect(bpy.types.Operator):
             attempt += 1
 
         context.scene.threshold_value = threshold_value
+        context.scene.tracker_threshold = threshold_value
         context.scene.nm_count = new_markers
 
         # Keep newly detected tracks selected
@@ -1047,7 +1049,7 @@ class CLIP_OT_cycle_detect(bpy.types.Operator):
         target_min = target * 0.9
         target_max = target * 1.1
 
-        threshold_value = 1.0
+        threshold_value = context.scene.tracker_threshold
         detection_threshold, margin, min_distance = compute_detection_params(
             threshold_value, margin_base, min_distance_base
         )
@@ -1090,6 +1092,9 @@ class CLIP_OT_cycle_detect(bpy.types.Operator):
         if new_tracks and bpy.ops.clip.prefix_new.poll():
             bpy.ops.clip.prefix_new(silent=True)
         add_pending_tracks(new_tracks)
+
+        context.scene.threshold_value = threshold_value
+        context.scene.tracker_threshold = threshold_value
 
         return {'FINISHED'}
 

--- a/operators/tracking/solver.py
+++ b/operators/tracking/solver.py
@@ -1860,7 +1860,7 @@ def detect_features_once():
             print(f"[Detect Features] using threshold {threshold:.3f}")
         if bpy.ops.clip.proxy_off.poll():
             bpy.ops.clip.proxy_off()
-        bpy.ops.clip.detect_features()
+        bpy.ops.clip.detect_features(threshold=threshold)
         print(
             f"[Detect Features] finished with threshold {threshold:.3f}"
         )

--- a/operators/tracking/solver.py
+++ b/operators/tracking/solver.py
@@ -1415,7 +1415,8 @@ def _Test_detect(self, context, use_defaults=True):
 
     if use_defaults:
         bpy.ops.clip.setup_defaults(silent=True)
-    context.scene.threshold_value = 1.0
+        context.scene.threshold_value = 1.0
+
 
     # Begin Test detect cycle
     prev_best = TEST_END_FRAME

--- a/operators/tracking/solver.py
+++ b/operators/tracking/solver.py
@@ -122,6 +122,9 @@ class CLIP_OT_track_nr1(bpy.types.Operator):
                 bpy.ops.clip.proxy_off()
             bpy.ops.clip.cycle_detect()
             context.scene.tracker_threshold = context.scene.threshold_value
+            print(
+                f"[Track Nr.1] saved threshold {context.scene.tracker_threshold:.3f}"
+            )
 
         if bpy.ops.clip.prefix_new.poll():
             bpy.ops.clip.prefix_new()
@@ -1846,7 +1849,9 @@ def detect_features_once():
     if bpy.ops.clip.detect_features.poll():
         clip = bpy.context.space_data.clip
         if clip and clip.tracking:
-            clip.tracking.settings.default_correlation_min = bpy.context.scene.tracker_threshold
+            threshold = bpy.context.scene.tracker_threshold
+            clip.tracking.settings.default_correlation_min = threshold
+            print(f"[Detect Features] using threshold {threshold:.3f}")
         if bpy.ops.clip.proxy_off.poll():
             bpy.ops.clip.proxy_off()
         bpy.ops.clip.detect_features()

--- a/operators/tracking/solver.py
+++ b/operators/tracking/solver.py
@@ -121,6 +121,7 @@ class CLIP_OT_track_nr1(bpy.types.Operator):
             if bpy.ops.clip.proxy_off.poll():
                 bpy.ops.clip.proxy_off()
             bpy.ops.clip.cycle_detect()
+            context.scene.tracker_threshold = context.scene.threshold_value
 
         if bpy.ops.clip.prefix_new.poll():
             bpy.ops.clip.prefix_new()
@@ -1843,6 +1844,9 @@ def enable_proxy():
 def detect_features_once():
     """Run feature detection if available."""
     if bpy.ops.clip.detect_features.poll():
+        clip = bpy.context.space_data.clip
+        if clip and clip.tracking:
+            clip.tracking.settings.default_correlation_min = bpy.context.scene.tracker_threshold
         if bpy.ops.clip.proxy_off.poll():
             bpy.ops.clip.proxy_off()
         bpy.ops.clip.detect_features()

--- a/operators/tracking/solver.py
+++ b/operators/tracking/solver.py
@@ -123,7 +123,7 @@ class CLIP_OT_track_nr1(bpy.types.Operator):
             bpy.ops.clip.cycle_detect()
             threshold = context.scene.threshold_value
             context.scene.tracker_threshold = threshold
-            print(f"[Track Nr.1] saved threshold {threshold:.3f}")
+            print(f"[Track Nr.1] saved threshold {threshold:.5f}")
 
         if bpy.ops.clip.prefix_new.poll():
             bpy.ops.clip.prefix_new()
@@ -1852,12 +1852,12 @@ def detect_features_once():
     """Run feature detection if available."""
     if bpy.ops.clip.detect_features.poll():
         threshold = bpy.context.scene.tracker_threshold
-        print(f"[Detect Features] using threshold {threshold:.3f}")
+        print(f"[Detect Features] using threshold {threshold:.5f}")
         if bpy.ops.clip.proxy_off.poll():
             bpy.ops.clip.proxy_off()
         bpy.ops.clip.detect_features(threshold=threshold)
         print(
-            f"[Detect Features] finished with threshold {threshold:.3f}"
+            f"[Detect Features] finished with threshold {threshold:.5f}"
         )
 
 

--- a/operators/tracking/solver.py
+++ b/operators/tracking/solver.py
@@ -121,10 +121,10 @@ class CLIP_OT_track_nr1(bpy.types.Operator):
             if bpy.ops.clip.proxy_off.poll():
                 bpy.ops.clip.proxy_off()
             bpy.ops.clip.cycle_detect()
-            context.scene.tracker_threshold = context.scene.threshold_value
-            print(
-                f"[Track Nr.1] saved threshold {context.scene.tracker_threshold:.3f}"
-            )
+            threshold = context.scene.threshold_value
+            context.scene.tracker_threshold = threshold
+            clip.tracking.settings.correlation_min = threshold
+            print(f"[Track Nr.1] saved threshold {threshold:.3f}")
 
         if bpy.ops.clip.prefix_new.poll():
             bpy.ops.clip.prefix_new()
@@ -1850,11 +1850,15 @@ def detect_features_once():
         clip = bpy.context.space_data.clip
         if clip and clip.tracking:
             threshold = bpy.context.scene.tracker_threshold
-            clip.tracking.settings.default_correlation_min = threshold
-            print(f"[Detect Features] using threshold {threshold:.3f}")
+            settings = clip.tracking.settings
+            settings.correlation_min = threshold
+            print(f"[Detect Features] using threshold {settings.correlation_min:.3f}")
         if bpy.ops.clip.proxy_off.poll():
             bpy.ops.clip.proxy_off()
         bpy.ops.clip.detect_features()
+        print(
+            f"[Detect Features] finished with threshold {settings.correlation_min:.3f}"
+        )
 
 
 def track_full_clip():

--- a/operators/tracking/solver.py
+++ b/operators/tracking/solver.py
@@ -123,7 +123,10 @@ class CLIP_OT_track_nr1(bpy.types.Operator):
             bpy.ops.clip.cycle_detect()
             threshold = context.scene.threshold_value
             context.scene.tracker_threshold = threshold
-            clip.tracking.settings.correlation_min = threshold
+            settings = clip.tracking.settings
+            settings.default_correlation_min = threshold
+            for track in clip.tracking.tracks:
+                track.correlation_min = threshold
             print(f"[Track Nr.1] saved threshold {threshold:.3f}")
 
         if bpy.ops.clip.prefix_new.poll():
@@ -1851,13 +1854,15 @@ def detect_features_once():
         if clip and clip.tracking:
             threshold = bpy.context.scene.tracker_threshold
             settings = clip.tracking.settings
-            settings.correlation_min = threshold
-            print(f"[Detect Features] using threshold {settings.correlation_min:.3f}")
+            settings.default_correlation_min = threshold
+            for track in clip.tracking.tracks:
+                track.correlation_min = threshold
+            print(f"[Detect Features] using threshold {threshold:.3f}")
         if bpy.ops.clip.proxy_off.poll():
             bpy.ops.clip.proxy_off()
         bpy.ops.clip.detect_features()
         print(
-            f"[Detect Features] finished with threshold {settings.correlation_min:.3f}"
+            f"[Detect Features] finished with threshold {threshold:.3f}"
         )
 
 

--- a/operators/tracking/solver.py
+++ b/operators/tracking/solver.py
@@ -1415,7 +1415,6 @@ def _Test_detect(self, context, use_defaults=True):
 
     if use_defaults:
         bpy.ops.clip.setup_defaults(silent=True)
-        context.scene.threshold_value = 1.0
 
 
     # Begin Test detect cycle
@@ -1439,7 +1438,6 @@ def _Test_detect(self, context, use_defaults=True):
                     bpy.ops.clip.delete_track()
                 for t in clip.tracking.tracks:
                     t.select = False
-                context.scene.threshold_value = 1.0
                 attempt += 1
 
             if attempt >= 10 and not (mf_min <= count <= mf_max):

--- a/operators/tracking/solver.py
+++ b/operators/tracking/solver.py
@@ -123,10 +123,6 @@ class CLIP_OT_track_nr1(bpy.types.Operator):
             bpy.ops.clip.cycle_detect()
             threshold = context.scene.threshold_value
             context.scene.tracker_threshold = threshold
-            settings = clip.tracking.settings
-            settings.default_correlation_min = threshold
-            for track in clip.tracking.tracks:
-                track.correlation_min = threshold
             print(f"[Track Nr.1] saved threshold {threshold:.3f}")
 
         if bpy.ops.clip.prefix_new.poll():
@@ -1855,14 +1851,8 @@ def enable_proxy():
 def detect_features_once():
     """Run feature detection if available."""
     if bpy.ops.clip.detect_features.poll():
-        clip = bpy.context.space_data.clip
-        if clip and clip.tracking:
-            threshold = bpy.context.scene.tracker_threshold
-            settings = clip.tracking.settings
-            settings.default_correlation_min = threshold
-            for track in clip.tracking.tracks:
-                track.correlation_min = threshold
-            print(f"[Detect Features] using threshold {threshold:.3f}")
+        threshold = bpy.context.scene.tracker_threshold
+        print(f"[Detect Features] using threshold {threshold:.3f}")
         if bpy.ops.clip.proxy_off.poll():
             bpy.ops.clip.proxy_off()
         bpy.ops.clip.detect_features(threshold=threshold)

--- a/properties/tracking_props.py
+++ b/properties/tracking_props.py
@@ -19,8 +19,10 @@ tracking_properties = {
     ),
     "tracker_threshold": FloatProperty(
         name="Tracker Threshold",
-        description="Zuletzt verwendeter Threshold-Wert",
-        default=0.5,
+        description="Persistent threshold value for detect features",
+        default=0.015,
+        min=0.0,
+        max=1.0,
     ),
     "error_threshold": FloatProperty(
         name="Error Threshold",

--- a/properties/tracking_props.py
+++ b/properties/tracking_props.py
@@ -17,6 +17,11 @@ tracking_properties = {
         description="Gespeicherter Threshold-Wert",
         default=1.0,
     ),
+    "tracker_threshold": FloatProperty(
+        name="Tracker Threshold",
+        description="Zuletzt verwendeter Threshold-Wert",
+        default=0.5,
+    ),
     "error_threshold": FloatProperty(
         name="Error Threshold",
         description="Fehlergrenze für Operationen",

--- a/properties/tracking_props.py
+++ b/properties/tracking_props.py
@@ -20,7 +20,7 @@ tracking_properties = {
     "tracker_threshold": FloatProperty(
         name="Tracker Threshold",
         description="Persistent threshold value for detect features",
-        default=0.015,
+        default=0.5,
         min=0.0,
         max=1.0,
     ),

--- a/properties/tracking_props.py
+++ b/properties/tracking_props.py
@@ -21,7 +21,7 @@ tracking_properties = {
         name="Tracker Threshold",
         description="Persistent threshold value for detect features",
         default=0.5,
-        min=0.0,
+        min=0.00000001,
         max=1.0,
     ),
     "error_threshold": FloatProperty(


### PR DESCRIPTION
## Summary
- add new scene property `tracker_threshold`
- remember last detection threshold in `Track Nr.1`
- reuse stored threshold for subsequent `Detect Features` calls

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688657e47760832dad925b17e7301007