### PR TITLE
Initialize threshold when starting Track Nr.1

### DIFF
--- a/operators/tracking/solver.py
+++ b/operators/tracking/solver.py
@@ -239,6 +239,9 @@ class CLIP_OT_track_nr1(bpy.types.Operator):
         return None
 
     def execute(self, context):
+        # set the starting threshold only once when the operator is triggered
+        context.scene.threshold_value = 0.5
+        context.scene.tracker_threshold = 0.5
         print(
             f"[Track Nr.1] starting threshold {context.scene.threshold_value:.8f}"
         )


### PR DESCRIPTION
## Summary
- initialize `threshold_value` and `tracker_threshold` to `0.5` when `Track Nr.1` is triggered

## Testing
- `python -m py_compile operators/tracking/solver.py`


------
https://chatgpt.com/codex/tasks/task_e_68869f6f12cc832d99ef3af2b8b3cf9c