### PR TITLE
Refactor margin computation helpers

### DIFF
--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -1,2 +1,6 @@
 # Expose helper functions via relative import
 from .utils import *
+from .feature_math import (
+    calculate_base_values,
+    apply_threshold_to_margin_and_distance,
+)

--- a/helpers/feature_math.py
+++ b/helpers/feature_math.py
@@ -1,0 +1,12 @@
+def calculate_base_values(image_width):
+    """Berechnet die Basiswerte für margin und min_distance anhand der Bildbreite."""
+    margin_base = int(image_width * 0.025)
+    min_distance_base = int(image_width * 0.05)
+    return margin_base, min_distance_base
+
+
+def apply_threshold_to_margin_and_distance(threshold, margin_base, min_distance_base):
+    """Skaliert margin und min_distance entsprechend dem aktuellen Threshold-Wert."""
+    margin = max(1, int(margin_base * threshold))
+    min_distance = max(1, int(min_distance_base * threshold))
+    return margin, min_distance

--- a/helpers/test_feature_math.py
+++ b/helpers/test_feature_math.py
@@ -1,0 +1,16 @@
+from .feature_math import (
+    calculate_base_values,
+    apply_threshold_to_margin_and_distance,
+)
+
+
+def test_base_values():
+    margin_base, min_distance_base = calculate_base_values(4000)
+    assert margin_base == 100
+    assert min_distance_base == 200
+
+
+def test_threshold_scaling():
+    margin, distance = apply_threshold_to_margin_and_distance(0.5, 100, 200)
+    assert margin == 50
+    assert distance == 100

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -6,6 +6,11 @@ import math
 import re
 from bpy.props import IntProperty, FloatProperty, BoolProperty
 
+from .feature_math import (
+    calculate_base_values,
+    apply_threshold_to_margin_and_distance,
+)
+
 # Frames, die mit zu wenig Markern gefunden wurden
 NF = []
 
@@ -184,8 +189,9 @@ def compute_detection_params(threshold_value, margin_base, min_distance_base):
         )
     detection_threshold = max(min(threshold_value, 1.0), MIN_THRESHOLD)
     factor = math.log10(detection_threshold * 100000000) / 8
-    margin = int(margin_base * factor)
-    min_distance = int(min_distance_base * factor)
+    margin, min_distance = apply_threshold_to_margin_and_distance(
+        factor, margin_base, min_distance_base
+    )
     return detection_threshold, margin, min_distance
 
 

--- a/operators/tracking/solver.py
+++ b/operators/tracking/solver.py
@@ -7,6 +7,10 @@ from bpy.props import IntProperty, FloatProperty, BoolProperty
 
 # Import utility functions via relative path
 from ...helpers import *
+from ...helpers.feature_math import (
+    calculate_base_values,
+    apply_threshold_to_margin_and_distance,
+)
 
 
 class OBJECT_OT_simple_operator(bpy.types.Operator):
@@ -394,8 +398,7 @@ class CLIP_OT_detect_button(bpy.types.Operator):
 
         threshold_value = context.scene.tracker_threshold
 
-        margin_base = int(width * 0.025)
-        min_distance_base = int(width * 0.05)
+        margin_base, min_distance_base = calculate_base_values(width)
         print(
             f"[BASE DEBUG] width={width}, margin_base={margin_base}, min_distance_base={min_distance_base}"
         )
@@ -960,8 +963,7 @@ class CLIP_OT_all_detect(bpy.types.Operator):
             self.report({'WARNING'}, "Ung\u00fcltige Clipgr\u00f6\u00dfe")
             return {'CANCELLED'}
 
-        margin_base = int(width * 0.025)
-        min_distance_base = int(width * 0.05)
+        margin_base, min_distance_base = calculate_base_values(width)
         print(
             f"[BASE DEBUG] width={width}, margin_base={margin_base}, min_distance_base={min_distance_base}"
         )
@@ -1108,8 +1110,7 @@ class CLIP_OT_cycle_detect(bpy.types.Operator):
 
         width, _ = clip.size
 
-        margin_base = int(width * 0.025)
-        min_distance_base = int(width * 0.05)
+        margin_base, min_distance_base = calculate_base_values(width)
         print(f"[BASE DEBUG] width={width}, margin_base={margin_base}, min_distance_base={min_distance_base}")
 
         target = context.scene.marker_frame * 4
@@ -1968,8 +1969,7 @@ def detect_features_once(context=None, clip=None, threshold=None):
             print("\u26a0\ufe0f Clipgr\u00f6\u00dfe ist 0 - Detect abgebrochen")
             return
 
-        margin_base = int(width * 0.025)
-        min_distance_base = int(width * 0.05)
+        margin_base, min_distance_base = calculate_base_values(width)
         print(
             f"[BASE DEBUG] width={width}, margin_base={margin_base}, min_distance_base={min_distance_base}"
         )


### PR DESCRIPTION
## Summary
- centralize margin and distance calculations in `helpers/feature_math.py`
- expose helper functions in package
- use `calculate_base_values` in solver
- use `apply_threshold_to_margin_and_distance` inside `compute_detection_params`
- provide simple unit tests for the new helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bpy')*

------
https://chatgpt.com/codex/tasks/task_e_6887b2e8cab4832d994c24cfa7310798