### PR TITLE
Centralize marker target logic

### DIFF
--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -3,4 +3,6 @@ from .utils import *
 from .feature_math import (
     calculate_base_values,
     apply_threshold_to_margin_and_distance,
+    marker_target_aggressive,
+    marker_target_conservative,
 )

--- a/helpers/feature_math.py
+++ b/helpers/feature_math.py
@@ -10,3 +10,13 @@ def apply_threshold_to_margin_and_distance(threshold, margin_base, min_distance_
     margin = max(1, int(margin_base * threshold))
     min_distance = max(1, int(min_distance_base * threshold))
     return margin, min_distance
+
+
+def marker_target_aggressive(marker_frame: int) -> int:
+    """Return the desired marker count for aggressive detection."""
+    return int(marker_frame * 4)
+
+
+def marker_target_conservative(marker_frame: int) -> int:
+    """Return the desired marker count for conservative detection."""
+    return max(1, int(marker_frame / 3))

--- a/helpers/test_feature_math.py
+++ b/helpers/test_feature_math.py
@@ -1,6 +1,8 @@
 from .feature_math import (
     calculate_base_values,
     apply_threshold_to_margin_and_distance,
+    marker_target_aggressive,
+    marker_target_conservative,
 )
 
 
@@ -14,3 +16,12 @@ def test_threshold_scaling():
     margin, distance = apply_threshold_to_margin_and_distance(0.5, 100, 200)
     assert margin == 50
     assert distance == 100
+
+
+def test_marker_aggressive():
+    assert marker_target_aggressive(100) == 400
+
+
+def test_marker_conservative():
+    assert marker_target_conservative(90) == 30
+    assert marker_target_conservative(2) == 1

--- a/operators/tracking/solver.py
+++ b/operators/tracking/solver.py
@@ -10,6 +10,8 @@ from ...helpers import *
 from ...helpers.feature_math import (
     calculate_base_values,
     apply_threshold_to_margin_and_distance,
+    marker_target_aggressive,
+    marker_target_conservative,
 )
 
 
@@ -132,7 +134,7 @@ class CLIP_OT_track_nr1(bpy.types.Operator):
 
         clip = getattr(context.space_data, "clip", None)
 
-        target = context.scene.marker_frame * 4
+        target = marker_target_aggressive(context.scene.marker_frame)
         target_min = int(target * 0.9)
         target_max = int(target * 1.1)
 
@@ -394,7 +396,7 @@ class CLIP_OT_detect_button(bpy.types.Operator):
             return {'CANCELLED'}
 
         mframe = context.scene.marker_frame
-        mf_base = mframe / 3
+        mf_base = marker_target_conservative(mframe)
 
         threshold_value = context.scene.tracker_threshold
 
@@ -634,7 +636,7 @@ class CLIP_OT_count_button(bpy.types.Operator):
         context.scene.nm_count = count
 
         mframe = context.scene.marker_frame
-        mf_base = mframe / 3
+        mf_base = marker_target_conservative(mframe)
         track_min = mf_base * 0.8
         track_max = mf_base * 1.2
 
@@ -968,7 +970,7 @@ class CLIP_OT_all_detect(bpy.types.Operator):
             f"[BASE DEBUG] width={width}, margin_base={margin_base}, min_distance_base={min_distance_base}"
         )
 
-        mfp = context.scene.marker_frame * 4
+        mfp = marker_target_aggressive(context.scene.marker_frame)
         mfp_min = mfp * 0.9
         mfp_max = mfp * 1.1
 
@@ -1113,7 +1115,7 @@ class CLIP_OT_cycle_detect(bpy.types.Operator):
         margin_base, min_distance_base = calculate_base_values(width)
         print(f"[BASE DEBUG] width={width}, margin_base={margin_base}, min_distance_base={min_distance_base}")
 
-        target = context.scene.marker_frame * 4
+        target = marker_target_aggressive(context.scene.marker_frame)
         target_min = target * 0.9
         target_max = target * 1.1
 
@@ -1201,7 +1203,7 @@ class CLIP_OT_all_cycle(bpy.types.Operator):
 
             count = len(PENDING_RENAME)
             mframe = context.scene.marker_frame
-            mf_base = mframe * 4
+            mf_base = marker_target_aggressive(mframe)
             track_min = mf_base * 0.8
             track_max = mf_base * 1.2
 
@@ -1513,7 +1515,7 @@ def _Test_detect(self, context, use_defaults=True):
         self.report({'WARNING'}, "Kein Clip geladen")
         return {'CANCELLED'}
 
-    mf_base = context.scene.marker_frame / 3
+    mf_base = marker_target_conservative(context.scene.marker_frame)
     mf_min = mf_base * 0.9
     mf_max = mf_base * 1.1
 


### PR DESCRIPTION
## Summary
- add new helper functions `marker_target_aggressive` and `marker_target_conservative`
- export new helpers and extend tests
- use the new helpers throughout `solver.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bpy')*

------
https://chatgpt.com/codex/tasks/task_e_6887b53b34e4832dbc0d889dc9c483c9