### PR TITLE
Add wrappers for feature detection modes

### DIFF
--- a/operators/tracking/solver.py
+++ b/operators/tracking/solver.py
@@ -1996,6 +1996,20 @@ def detect_features_once(context=None, clip=None, threshold=None):
         )
 
 
+def detect_features_main(context, clip, threshold):
+    """Run feature detection with the aggressive marker target."""
+    target = marker_target_aggressive(context.scene.marker_frame)
+    detect_features_once(context=context, clip=clip, threshold=threshold)
+    return target
+
+
+def detect_features_test(context, clip, threshold):
+    """Run feature detection with the conservative marker target."""
+    target = marker_target_conservative(context.scene.marker_frame)
+    detect_features_once(context=context, clip=clip, threshold=threshold)
+    return target
+
+
 def track_full_clip():
     """Track the clip forward if possible."""
     if bpy.ops.clip.track_full.poll():


### PR DESCRIPTION
## Summary
- implement `detect_features_main` and `detect_features_test` wrappers in `solver.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bpy')*

------
https://chatgpt.com/codex/tasks/task_e_6887b7558140832db4df14601772824d