### PR TITLE
Restore proxy build button

### DIFF
--- a/developer.md
+++ b/developer.md
@@ -19,7 +19,7 @@ Bei der Erstellung und Bearbeitung von Blender Skripten und Add-ons sollten stet
 
 ## Eigene Operatoren
 
-Das Add-on implementiert mehrere Operatoren wie `clip.panel_button`, `clip.detect_button`, `clip.prefix_new` und andere. Sie leiten sich von `bpy.types.Operator` ab und greifen über `context.space_data.clip` direkt auf den aktiven Movie Clip zu.
+Das Add-on implementiert mehrere Operatoren wie `clip.proxy_build`, `clip.detect_button`, `clip.prefix_new` und andere. Sie leiten sich von `bpy.types.Operator` ab und greifen über `context.space_data.clip` direkt auf den aktiven Movie Clip zu.
 
 ## Panels
 

--- a/operators/proxy.py
+++ b/operators/proxy.py
@@ -32,9 +32,9 @@ class CLIP_OT_proxy_off(bpy.types.Operator):
         return {'FINISHED'}
 
 
-class CLIP_OT_panel_button(bpy.types.Operator):
+class CLIP_OT_proxy_build(bpy.types.Operator):
     bl_idname = "clip.proxy_build"
-    bl_label = "Proxy bauen"
+    bl_label = "Proxy erstellen (50%)"
     bl_description = "Erstellt Proxy-Dateien mit 50% Größe"
 
     def execute(self, context):
@@ -68,5 +68,5 @@ class CLIP_OT_panel_button(bpy.types.Operator):
 operator_classes = (
     CLIP_OT_proxy_on,
     CLIP_OT_proxy_off,
-    CLIP_OT_panel_button,
+    CLIP_OT_proxy_build,
 )

--- a/operators/tracking/solver.py
+++ b/operators/tracking/solver.py
@@ -11,7 +11,7 @@ from ...helpers.feature_math import (
     marker_target_aggressive,
     marker_target_conservative,
 )
-from ..proxy import CLIP_OT_proxy_on, CLIP_OT_proxy_off, CLIP_OT_panel_button
+from ..proxy import CLIP_OT_proxy_on, CLIP_OT_proxy_off, CLIP_OT_proxy_build
 
 class OBJECT_OT_simple_operator(bpy.types.Operator):
     bl_idname = "object.simple_operator"

--- a/ui/panels/settings_panel.py
+++ b/ui/panels/settings_panel.py
@@ -21,7 +21,7 @@ class CLIP_PT_stufen_panel(bpy.types.Panel):
 
     def draw(self, context):
         layout = self.layout
-        layout.operator('clip.panel_button', text='Proxy')
+        layout.operator('clip.proxy_build', text='Proxy erstellen (50%)')
         layout.operator('clip.track_nr1', text='Track Nr. 1')
         layout.operator('clip.cleanup', text='Cleanup')
         layout.operator('clip.track_nr2', text='Track Nr. 2')

--- a/ui/panels/test_panels.py
+++ b/ui/panels/test_panels.py
@@ -12,6 +12,8 @@ class CLIP_PT_test_panel(bpy.types.Panel):
         layout.operator('clip.api_defaults', text='Defaults')
         layout.operator('clip.proxy_on', text='Proxy on')
         layout.operator('clip.proxy_off', text='Proxy off')
+        layout.operator('clip.proxy_build', text='Proxy erstellen (50%)')
+        layout.separator()
         layout.operator('clip.track_bidirectional', text='Track')
         layout.operator('clip.track_partial', text='Track Partial')
         layout.operator('clip.count_button', text='Count')


### PR DESCRIPTION
## Summary
- fix operator class name for proxy build
- register new operator in panels and solver
- update settings and test panels to show Proxy button
- update docs

## Testing
- `python -m py_compile operators/proxy.py operators/tracking/solver.py ui/panels/settings_panel.py ui/panels/test_panels.py`

------
https://chatgpt.com/codex/tasks/task_e_6887b9c27c68832da42d92e7d27c906c