### PR TITLE
Add tracking helper functions

### DIFF
--- a/helpers/tracking_variants.py
+++ b/helpers/tracking_variants.py
@@ -1,0 +1,24 @@
+import bpy
+
+
+def track_bidirectional(start_frame, end_frame):
+    """Führt bidirektionales Tracking von start bis end aus."""
+    scene = bpy.context.scene
+    scene.frame_start = start_frame
+    scene.frame_end = end_frame
+
+    print(f"[Track Bidirectional] start {start_frame} end {end_frame}")
+    bpy.ops.clip.track_partial(backwards=True)
+    bpy.ops.clip.track_partial(backwards=False)
+    print(f"[Track Bidirectional] done")
+
+
+def track_forward_only(start_frame, end_frame):
+    """Führt nur vorwärts Tracking aus."""
+    scene = bpy.context.scene
+    scene.frame_start = start_frame
+    scene.frame_end = end_frame
+
+    print(f"[Track Forward Only] start {start_frame} end {end_frame}")
+    bpy.ops.clip.track_partial(backwards=False)
+    print(f"[Track Forward Only] done")

--- a/helpers/tracking_variants.py
+++ b/helpers/tracking_variants.py
@@ -1,24 +1,27 @@
 import bpy
 
 
-def track_bidirectional(start_frame, end_frame):
-    """Führt bidirektionales Tracking von start bis end aus."""
-    scene = bpy.context.scene
-    scene.frame_start = start_frame
-    scene.frame_end = end_frame
+def track_bidirectional(start_frame: int, end_frame: int) -> None:
+    """Führt bidirektionales Tracking durch (für Track Nr. 1)."""
 
+    scene = bpy.context.scene
+    scene.frame_current = start_frame
     print(f"[Track Bidirectional] start {start_frame} end {end_frame}")
-    bpy.ops.clip.track_partial(backwards=True)
-    bpy.ops.clip.track_partial(backwards=False)
-    print(f"[Track Bidirectional] done")
+
+    # Track zuerst rückwärts, dann vorwärts
+    bpy.ops.clip.track_markers(backwards=True)
+    bpy.ops.clip.track_markers(backwards=False)
+
+    print("[Track Bidirectional] done")
 
 
-def track_forward_only(start_frame, end_frame):
-    """Führt nur vorwärts Tracking aus."""
+def track_forward_only(start_frame: int, end_frame: int) -> None:
+    """Führt nur vorwärts Tracking durch (für Track Nr. 2)."""
+
     scene = bpy.context.scene
-    scene.frame_start = start_frame
-    scene.frame_end = end_frame
-
+    scene.frame_current = start_frame
     print(f"[Track Forward Only] start {start_frame} end {end_frame}")
-    bpy.ops.clip.track_partial(backwards=False)
-    print(f"[Track Forward Only] done")
+
+    bpy.ops.clip.track_markers(backwards=False)
+
+    print("[Track Forward Only] done")

--- a/helpers/tracking_variants.py
+++ b/helpers/tracking_variants.py
@@ -8,9 +8,9 @@ def track_bidirectional(start_frame: int, end_frame: int) -> None:
     scene.frame_current = start_frame
     print(f"[Track Bidirectional] start {start_frame} end {end_frame}")
 
-    # Track zuerst rückwärts, dann vorwärts
-    bpy.ops.clip.track_markers(backwards=True)
-    bpy.ops.clip.track_markers(backwards=False)
+    # Track zuerst rückwärts, dann vorwärts – jeweils über die gesamte Sequenz
+    bpy.ops.clip.track_markers(backwards=True, sequence=True)
+    bpy.ops.clip.track_markers(backwards=False, sequence=True)
 
     print("[Track Bidirectional] done")
 
@@ -22,6 +22,6 @@ def track_forward_only(start_frame: int, end_frame: int) -> None:
     scene.frame_current = start_frame
     print(f"[Track Forward Only] start {start_frame} end {end_frame}")
 
-    bpy.ops.clip.track_markers(backwards=False)
+    bpy.ops.clip.track_markers(backwards=False, sequence=True)
 
     print("[Track Forward Only] done")

--- a/operators/tracking/solver.py
+++ b/operators/tracking/solver.py
@@ -12,6 +12,10 @@ from ...helpers.feature_math import (
     marker_target_aggressive,
     marker_target_conservative,
 )
+from ...helpers.tracking_variants import (
+    track_bidirectional,
+    track_forward_only,
+)
 from ..proxy import CLIP_OT_proxy_on, CLIP_OT_proxy_off, CLIP_OT_proxy_build
 
 class OBJECT_OT_simple_operator(bpy.types.Operator):
@@ -112,7 +116,7 @@ class CLIP_OT_track_nr1(bpy.types.Operator):
         self._start = scene.frame_current
         enable_proxy()
         if bpy.ops.clip.track_partial.poll():
-            bpy.ops.clip.track_partial()
+            track_bidirectional(scene.frame_start, scene.frame_end)
         self._end = scene.frame_current
         self._tracked = self._end - self._start
         print(
@@ -285,7 +289,7 @@ class CLIP_OT_track_nr2(bpy.types.Operator):
                     bpy.ops.clip.proxy_off()
                 bpy.ops.clip.cycle_detect()
             if bpy.ops.clip.track_partial.poll():
-                bpy.ops.clip.track_partial()
+                track_forward_only(scene.frame_start, scene.frame_end)
             if bpy.ops.clip.cleanup.poll():
                 bpy.ops.clip.cleanup()
                 if bpy.ops.clip.setup_defaults.poll():


### PR DESCRIPTION
## Summary
- add helper functions to run forward-only and bidirectional tracking
- use these new helpers in Track Nr.1 and Track Nr.2

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bpy')*

------
https://chatgpt.com/codex/tasks/task_e_6887c196dc04832da2e88395f318b706