### PR TITLE
Fix import cycle and reorganize prefixes

### DIFF
--- a/helpers/prefix_test.py
+++ b/helpers/prefix_test.py
@@ -1,0 +1,2 @@
+# Präfix für Test-Tracker
+PREFIX_TEST = "TEST_"

--- a/helpers/prefixes.py
+++ b/helpers/prefixes.py
@@ -1,3 +1,0 @@
-# Zusätzliche Präfixe für Marker
-PREFIX_TEST = "TEST_"
-PREFIX_RECOVERED = "RECOVERED_"

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -9,7 +9,6 @@ from bpy.props import IntProperty, FloatProperty, BoolProperty
 from .prefix_good import PREFIX_GOOD
 from .prefix_track import PREFIX_TRACK
 from .prefix_new import PREFIX_NEW
-from ..t.helpers import delete_selected_tracks
 
 from .feature_math import (
     calculate_base_values,
@@ -254,6 +253,7 @@ def remove_close_tracks(clip, new_tracks, distance_px, names_before):
     for t in close_tracks:
         t.select = True
     if close_tracks:
+        from ..t.helpers.delete_tracks import delete_selected_tracks
         if delete_selected_tracks():
             clean_pending_tracks(clip)
 

--- a/operators/tracking/export.py
+++ b/operators/tracking/export.py
@@ -6,7 +6,7 @@ from ...helpers import strip_prefix
 from ...helpers.prefix_new import PREFIX_NEW
 from ...helpers.prefix_track import PREFIX_TRACK
 from ...helpers.prefix_good import PREFIX_GOOD
-from ...helpers.prefixes import PREFIX_TEST, PREFIX_RECOVERED
+from ...helpers.prefix_test import PREFIX_TEST
 
 class CLIP_OT_prefix_new(bpy.types.Operator):
     bl_idname = "clip.prefix_new"
@@ -28,7 +28,7 @@ class CLIP_OT_prefix_new(bpy.types.Operator):
                 _ = track.name
             except Exception as e:
                 print(f"\u26a0\ufe0f Marker-Name fehlerhaft: {track} ({e})")
-                track.name = f"{PREFIX_RECOVERED}{i:03d}"
+                track.name = f"RECOVERED_{i:03d}"
             else:
                 safe = unicodedata.normalize("NFKD", track.name).encode(
                     "ascii", "ignore"

--- a/operators/tracking/solver.py
+++ b/operators/tracking/solver.py
@@ -9,7 +9,7 @@ from ...helpers.utils import jump_to_frame_with_few_markers
 from ...helpers.prefix_new import PREFIX_NEW
 from ...helpers.prefix_track import PREFIX_TRACK
 from ...helpers.prefix_good import PREFIX_GOOD
-from ...helpers.prefixes import PREFIX_TEST, PREFIX_RECOVERED
+from ...helpers.prefix_test import PREFIX_TEST
 from ...helpers.select_track_tracks import select_track_tracks
 from ...helpers.select_new_tracks import select_new_tracks
 from ...helpers.feature_math import (


### PR DESCRIPTION
## Summary
- remove cross-import in `helpers.utils` and import deletion helper lazily
- add `helpers/prefix_test.py` and move `PREFIX_TEST` there
- inline `RECOVERED_` string in export operator
- update imports in solver and export modules
- delete obsolete `helpers/prefixes.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bpy')*

------
https://chatgpt.com/codex/tasks/task_e_6887ed4d177c832db499126a81fb3cb0