### PR TITLE
Improve helper docs and rename delete helper

### DIFF
--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -6,7 +6,7 @@ from .feature_math import (
     marker_target_aggressive,
     marker_target_conservative,
 )
-from .delete_tracks import delete_selected_tracks
+from .delete_selected_tracks import delete_selected_tracks
 from .select_short_tracks import select_short_tracks
 from .detection_helpers import (
     find_next_low_marker_frame,

--- a/helpers/delete_selected_tracks.py
+++ b/helpers/delete_selected_tracks.py
@@ -2,7 +2,12 @@ import bpy
 
 
 def delete_selected_tracks():
-    """Delete selected tracks if a clip is active."""
+    """Delete selected tracks if a clip is active.
+
+    This helper is called by various operators such as
+    :class:`~operators.tracking.cleanup.CLIP_OT_track_cleanup` and
+    :class:`~operators.tracking.detect.CLIP_OT_detect_button`.
+    """
     clip = getattr(bpy.context.space_data, "clip", None)
     if clip is None:
         return False

--- a/helpers/marker_helpers.py
+++ b/helpers/marker_helpers.py
@@ -55,6 +55,6 @@ def cleanup_all_tracks(clip):
     """Remove all tracks from the clip."""
     for t in clip.tracking.tracks:
         t.select = True
-    from .delete_tracks import delete_selected_tracks
+    from .delete_selected_tracks import delete_selected_tracks
 
     delete_selected_tracks()

--- a/helpers/select_new_tracks.py
+++ b/helpers/select_new_tracks.py
@@ -2,7 +2,10 @@ import bpy
 from .prefix_new import PREFIX_NEW
 
 def select_new_tracks(clip=None):
-    """Selektiert alle Tracks mit dem Präfix NEW_."""
+    """Select all tracks starting with ``NEW_``.
+
+    Used by :class:`~operators.tracking.cleanup.CLIP_OT_select_new_tracks`.
+    """
     if clip is None:
         clip = bpy.context.space_data.clip
     if not clip:

--- a/helpers/select_short_tracks.py
+++ b/helpers/select_short_tracks.py
@@ -25,7 +25,10 @@ def _select_tracks_by_names(clip, name_list):
 
 
 def select_short_tracks(clip, min_length: int):
-    """Select TRACK_ markers shorter than ``min_length`` and return count."""
+    """Select ``TRACK_`` markers shorter than ``min_length`` and return count.
+
+    Used by :class:`~operators.tracking.cleanup.CLIP_OT_select_short_tracks`.
+    """
     undertracked = _get_undertracked_markers(clip, min_frames=min_length)
     for t in clip.tracking.tracks:
         t.select = False

--- a/helpers/select_track_tracks.py
+++ b/helpers/select_track_tracks.py
@@ -2,7 +2,10 @@ import bpy
 from .prefix_track import PREFIX_TRACK
 
 def select_track_tracks(clip=None):
-    """Selektiert alle Tracks mit dem Präfix TRACK_."""
+    """Select all tracks starting with ``TRACK_``.
+
+    Used by :class:`~operators.tracking.cleanup.CLIP_OT_select_active_tracks`.
+    """
     if clip is None:
         clip = bpy.context.space_data.clip
     if not clip:

--- a/helpers/set_playhead_to_frame.py
+++ b/helpers/set_playhead_to_frame.py
@@ -3,6 +3,10 @@ from .utils import update_frame_display
 
 
 def set_playhead_to_frame(scene, frame: int):
-    """Move the scene playhead to ``frame`` and update the display."""
+    """Move the scene playhead to ``frame`` and update the display.
+
+    Called by operators like :class:`~operators.tracking.detect.CLIP_OT_detect_button`
+    and :class:`~operators.tracking.cleanup.CLIP_OT_track_cleanup`.
+    """
     scene.frame_current = frame
     update_frame_display()

--- a/helpers/tracking_helpers.py
+++ b/helpers/tracking_helpers.py
@@ -11,7 +11,7 @@ from .utils import (
 )
 from .detection_helpers import detect_features_once
 from .proxy_helpers import enable_proxy, disable_proxy
-from .delete_tracks import delete_selected_tracks
+from .delete_selected_tracks import delete_selected_tracks
 from .marker_helpers import cleanup_all_tracks
 
 

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -253,7 +253,7 @@ def remove_close_tracks(clip, new_tracks, distance_px, names_before):
     for t in close_tracks:
         t.select = True
     if close_tracks:
-        from .delete_tracks import delete_selected_tracks
+        from .delete_selected_tracks import delete_selected_tracks
         if delete_selected_tracks():
             clean_pending_tracks(clip)
 

--- a/operators/cleanup_tracks.py
+++ b/operators/cleanup_tracks.py
@@ -1,5 +1,5 @@
 import bpy
-from ..helpers.delete_tracks import delete_selected_tracks
+from ..helpers.delete_selected_tracks import delete_selected_tracks
 from ..helpers.prefix_track import PREFIX_TRACK
 
 

--- a/operators/tracking/cleanup.py
+++ b/operators/tracking/cleanup.py
@@ -11,7 +11,7 @@ from ...helpers.prefix_test import PREFIX_TEST
 from ...helpers.select_track_tracks import select_track_tracks
 from ...helpers.select_new_tracks import select_new_tracks
 from ...helpers.select_short_tracks import select_short_tracks
-from ...helpers.delete_tracks import delete_selected_tracks
+from ...helpers.delete_selected_tracks import delete_selected_tracks
 from ...helpers.detection_helpers import (
     detect_features_once,
     find_next_low_marker_frame,

--- a/operators/tracking/cycle.py
+++ b/operators/tracking/cycle.py
@@ -11,7 +11,7 @@ from ...helpers.prefix_test import PREFIX_TEST
 from ...helpers.select_track_tracks import select_track_tracks
 from ...helpers.select_new_tracks import select_new_tracks
 from ...helpers.select_short_tracks import select_short_tracks
-from ...helpers.delete_tracks import delete_selected_tracks
+from ...helpers.delete_selected_tracks import delete_selected_tracks
 from ...helpers.detection_helpers import (
     detect_features_once,
     find_next_low_marker_frame,

--- a/operators/tracking/detect.py
+++ b/operators/tracking/detect.py
@@ -11,7 +11,7 @@ from ...helpers.prefix_test import PREFIX_TEST
 from ...helpers.select_track_tracks import select_track_tracks
 from ...helpers.select_new_tracks import select_new_tracks
 from ...helpers.select_short_tracks import select_short_tracks
-from ...helpers.delete_tracks import delete_selected_tracks
+from ...helpers.delete_selected_tracks import delete_selected_tracks
 from ...helpers.detection_helpers import (
     detect_features_once,
     find_next_low_marker_frame,

--- a/operators/tracking/track.py
+++ b/operators/tracking/track.py
@@ -11,7 +11,7 @@ from ...helpers.prefix_test import PREFIX_TEST
 from ...helpers.select_track_tracks import select_track_tracks
 from ...helpers.select_new_tracks import select_new_tracks
 from ...helpers.select_short_tracks import select_short_tracks
-from ...helpers.delete_tracks import delete_selected_tracks
+from ...helpers.delete_selected_tracks import delete_selected_tracks
 from ...helpers.detection_helpers import (
     detect_features_once,
     find_next_low_marker_frame,


### PR DESCRIPTION
## Summary
- rename `delete_tracks.py` to `delete_selected_tracks.py`
- update imports to match renamed helper
- document which operators call helper functions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bpy')*

------
https://chatgpt.com/codex/tasks/task_e_688826b32068832daf61eb21f60f2f20