### PR TITLE
Fix relative helper imports

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -15,6 +15,8 @@ except ModuleNotFoundError:  # allow import outside Blender
 
 # Use relative imports within the add-on package
 import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), "helpers"))
 if bpy is not None and not os.environ.get("BLENDER_TEST"):
     from .operators import operator_classes
     from .ui import panel_classes

--- a/operators/tests/channel.py
+++ b/operators/tests/channel.py
@@ -1,5 +1,5 @@
 import bpy
-from ..helpers.tracking_helpers import (
+from ...helpers.tracking_helpers import (
     run_pattern_size_test,
     evaluate_motion_models,
     evaluate_channel_combinations,

--- a/operators/tests/motion.py
+++ b/operators/tests/motion.py
@@ -1,5 +1,5 @@
 import bpy
-from ..helpers.tracking_helpers import (
+from ...helpers.tracking_helpers import (
     run_pattern_size_test,
     evaluate_motion_models,
     evaluate_channel_combinations,

--- a/operators/tests/pattern.py
+++ b/operators/tests/pattern.py
@@ -1,5 +1,5 @@
 import bpy
-from ..helpers.tracking_helpers import (
+from ...helpers.tracking_helpers import (
     run_pattern_size_test,
     evaluate_motion_models,
     evaluate_channel_combinations,

--- a/operators/tracking/cleanup.py
+++ b/operators/tracking/cleanup.py
@@ -4,37 +4,37 @@ import re
 from bpy.props import IntProperty, FloatProperty, BoolProperty
 
 # Import utility functions via relative path
-from ...helpers.prefix_new import PREFIX_NEW
-from ...helpers.prefix_track import PREFIX_TRACK
-from ...helpers.prefix_good import PREFIX_GOOD
-from ...helpers.prefix_testing import PREFIX_TEST
-from ...helpers.select_track_tracks import select_track_tracks
-from ...helpers.select_new_tracks import select_new_tracks
-from ...helpers.select_short_tracks import select_short_tracks
-from ...helpers.delete_selected_tracks import delete_selected_tracks
-from ...helpers.detection_helpers import (
+from ..helpers.prefix_new import PREFIX_NEW
+from ..helpers.prefix_track import PREFIX_TRACK
+from ..helpers.prefix_good import PREFIX_GOOD
+from ..helpers.prefix_testing import PREFIX_TEST
+from ..helpers.select_track_tracks import select_track_tracks
+from ..helpers.select_new_tracks import select_new_tracks
+from ..helpers.select_short_tracks import select_short_tracks
+from ..helpers.delete_selected_tracks import delete_selected_tracks
+from ..helpers.detection_helpers import (
     detect_features_once,
     find_next_low_marker_frame,
 )
-from ...helpers.marker_helpers import (
+from ..helpers.marker_helpers import (
     cleanup_all_tracks,
     ensure_valid_selection,
     select_tracks_by_names,
     select_tracks_by_prefix,
     get_undertracked_markers,
 )
-from ...helpers.feature_math import (
+from ..helpers.feature_math import (
     calculate_base_values,
     apply_threshold_to_margin_and_distance,
     marker_target_aggressive,
     marker_target_conservative,
 )
-from ...helpers.tracking_variants import (
+from ..helpers.tracking_variants import (
     track_bidirectional,
     track_forward_only,
 )
-from ...helpers.tracking_helpers import track_markers_range
-from ...helpers.utils import (
+from ..helpers.tracking_helpers import track_markers_range
+from ..helpers.utils import (
     add_timer,
     jump_to_frame_with_few_markers,
     compute_detection_params,
@@ -48,7 +48,7 @@ from ...helpers.utils import (
     update_frame_display,
     cycle_motion_model,
 )
-from ...helpers.set_playhead_to_frame import set_playhead_to_frame
+from ..helpers.set_playhead_to_frame import set_playhead_to_frame
 from ..proxy import CLIP_OT_proxy_on, CLIP_OT_proxy_off, CLIP_OT_proxy_build
 class CLIP_OT_delete_selected(bpy.types.Operator):
     bl_idname = "clip.delete_selected"

--- a/operators/tracking/cycle.py
+++ b/operators/tracking/cycle.py
@@ -4,37 +4,37 @@ import re
 from bpy.props import IntProperty, FloatProperty, BoolProperty
 
 # Import utility functions via relative path
-from ...helpers.prefix_new import PREFIX_NEW
-from ...helpers.prefix_track import PREFIX_TRACK
-from ...helpers.prefix_good import PREFIX_GOOD
-from ...helpers.prefix_testing import PREFIX_TEST
-from ...helpers.select_track_tracks import select_track_tracks
-from ...helpers.select_new_tracks import select_new_tracks
-from ...helpers.select_short_tracks import select_short_tracks
-from ...helpers.delete_selected_tracks import delete_selected_tracks
-from ...helpers.detection_helpers import (
+from ..helpers.prefix_new import PREFIX_NEW
+from ..helpers.prefix_track import PREFIX_TRACK
+from ..helpers.prefix_good import PREFIX_GOOD
+from ..helpers.prefix_testing import PREFIX_TEST
+from ..helpers.select_track_tracks import select_track_tracks
+from ..helpers.select_new_tracks import select_new_tracks
+from ..helpers.select_short_tracks import select_short_tracks
+from ..helpers.delete_selected_tracks import delete_selected_tracks
+from ..helpers.detection_helpers import (
     detect_features_once,
     find_next_low_marker_frame,
 )
-from ...helpers.marker_helpers import (
+from ..helpers.marker_helpers import (
     cleanup_all_tracks,
     ensure_valid_selection,
     select_tracks_by_names,
     select_tracks_by_prefix,
     get_undertracked_markers,
 )
-from ...helpers.feature_math import (
+from ..helpers.feature_math import (
     calculate_base_values,
     apply_threshold_to_margin_and_distance,
     marker_target_aggressive,
     marker_target_conservative,
 )
-from ...helpers.tracking_variants import (
+from ..helpers.tracking_variants import (
     track_bidirectional,
     track_forward_only,
 )
-from ...helpers.tracking_helpers import track_markers_range
-from ...helpers.utils import (
+from ..helpers.tracking_helpers import track_markers_range
+from ..helpers.utils import (
     add_timer,
     jump_to_frame_with_few_markers,
     compute_detection_params,
@@ -48,7 +48,7 @@ from ...helpers.utils import (
     update_frame_display,
     cycle_motion_model,
 )
-from ...helpers.set_playhead_to_frame import set_playhead_to_frame
+from ..helpers.set_playhead_to_frame import set_playhead_to_frame
 from ..proxy import CLIP_OT_proxy_on, CLIP_OT_proxy_off, CLIP_OT_proxy_build
 class CLIP_OT_track_nr1(bpy.types.Operator):
     bl_idname = "clip.track_nr1"

--- a/operators/tracking/detect.py
+++ b/operators/tracking/detect.py
@@ -4,37 +4,37 @@ import re
 from bpy.props import IntProperty, FloatProperty, BoolProperty
 
 # Import utility functions via relative path
-from ...helpers.prefix_new import PREFIX_NEW
-from ...helpers.prefix_track import PREFIX_TRACK
-from ...helpers.prefix_good import PREFIX_GOOD
-from ...helpers.prefix_testing import PREFIX_TEST
-from ...helpers.select_track_tracks import select_track_tracks
-from ...helpers.select_new_tracks import select_new_tracks
-from ...helpers.select_short_tracks import select_short_tracks
-from ...helpers.delete_selected_tracks import delete_selected_tracks
-from ...helpers.detection_helpers import (
+from ..helpers.prefix_new import PREFIX_NEW
+from ..helpers.prefix_track import PREFIX_TRACK
+from ..helpers.prefix_good import PREFIX_GOOD
+from ..helpers.prefix_testing import PREFIX_TEST
+from ..helpers.select_track_tracks import select_track_tracks
+from ..helpers.select_new_tracks import select_new_tracks
+from ..helpers.select_short_tracks import select_short_tracks
+from ..helpers.delete_selected_tracks import delete_selected_tracks
+from ..helpers.detection_helpers import (
     detect_features_once,
     find_next_low_marker_frame,
 )
-from ...helpers.marker_helpers import (
+from ..helpers.marker_helpers import (
     cleanup_all_tracks,
     ensure_valid_selection,
     select_tracks_by_names,
     select_tracks_by_prefix,
     get_undertracked_markers,
 )
-from ...helpers.feature_math import (
+from ..helpers.feature_math import (
     calculate_base_values,
     apply_threshold_to_margin_and_distance,
     marker_target_aggressive,
     marker_target_conservative,
 )
-from ...helpers.tracking_variants import (
+from ..helpers.tracking_variants import (
     track_bidirectional,
     track_forward_only,
 )
-from ...helpers.tracking_helpers import track_markers_range
-from ...helpers.utils import (
+from ..helpers.tracking_helpers import track_markers_range
+from ..helpers.utils import (
     add_timer,
     jump_to_frame_with_few_markers,
     compute_detection_params,
@@ -48,7 +48,7 @@ from ...helpers.utils import (
     update_frame_display,
     cycle_motion_model,
 )
-from ...helpers.set_playhead_to_frame import set_playhead_to_frame
+from ..helpers.set_playhead_to_frame import set_playhead_to_frame
 from ..proxy import CLIP_OT_proxy_on, CLIP_OT_proxy_off, CLIP_OT_proxy_build
 class CLIP_OT_detect_button(bpy.types.Operator):
     bl_idname = "clip.detect_button"

--- a/operators/tracking/export.py
+++ b/operators/tracking/export.py
@@ -2,11 +2,11 @@ import bpy
 from bpy.props import BoolProperty
 import unicodedata
 # Import helper via relative package path
-from ...helpers import strip_prefix
-from ...helpers.prefix_new import PREFIX_NEW
-from ...helpers.prefix_track import PREFIX_TRACK
-from ...helpers.prefix_good import PREFIX_GOOD
-from ...helpers.prefix_testing import PREFIX_TEST
+from ..helpers import strip_prefix
+from ..helpers.prefix_new import PREFIX_NEW
+from ..helpers.prefix_track import PREFIX_TRACK
+from ..helpers.prefix_good import PREFIX_GOOD
+from ..helpers.prefix_testing import PREFIX_TEST
 
 class CLIP_OT_prefix_new(bpy.types.Operator):
     bl_idname = "clip.prefix_new"

--- a/operators/tracking/track.py
+++ b/operators/tracking/track.py
@@ -4,37 +4,37 @@ import re
 from bpy.props import IntProperty, FloatProperty, BoolProperty
 
 # Import utility functions via relative path
-from ...helpers.prefix_new import PREFIX_NEW
-from ...helpers.prefix_track import PREFIX_TRACK
-from ...helpers.prefix_good import PREFIX_GOOD
-from ...helpers.prefix_testing import PREFIX_TEST
-from ...helpers.select_track_tracks import select_track_tracks
-from ...helpers.select_new_tracks import select_new_tracks
-from ...helpers.select_short_tracks import select_short_tracks
-from ...helpers.delete_selected_tracks import delete_selected_tracks
-from ...helpers.detection_helpers import (
+from ..helpers.prefix_new import PREFIX_NEW
+from ..helpers.prefix_track import PREFIX_TRACK
+from ..helpers.prefix_good import PREFIX_GOOD
+from ..helpers.prefix_testing import PREFIX_TEST
+from ..helpers.select_track_tracks import select_track_tracks
+from ..helpers.select_new_tracks import select_new_tracks
+from ..helpers.select_short_tracks import select_short_tracks
+from ..helpers.delete_selected_tracks import delete_selected_tracks
+from ..helpers.detection_helpers import (
     detect_features_once,
     find_next_low_marker_frame,
 )
-from ...helpers.marker_helpers import (
+from ..helpers.marker_helpers import (
     cleanup_all_tracks,
     ensure_valid_selection,
     select_tracks_by_names,
     select_tracks_by_prefix,
     get_undertracked_markers,
 )
-from ...helpers.feature_math import (
+from ..helpers.feature_math import (
     calculate_base_values,
     apply_threshold_to_margin_and_distance,
     marker_target_aggressive,
     marker_target_conservative,
 )
-from ...helpers.tracking_variants import (
+from ..helpers.tracking_variants import (
     track_bidirectional,
     track_forward_only,
 )
-from ...helpers.tracking_helpers import track_markers_range
-from ...helpers.utils import (
+from ..helpers.tracking_helpers import track_markers_range
+from ..helpers.utils import (
     add_timer,
     jump_to_frame_with_few_markers,
     compute_detection_params,
@@ -48,7 +48,7 @@ from ...helpers.utils import (
     update_frame_display,
     cycle_motion_model,
 )
-from ...helpers.set_playhead_to_frame import set_playhead_to_frame
+from ..helpers.set_playhead_to_frame import set_playhead_to_frame
 from ..proxy import CLIP_OT_proxy_on, CLIP_OT_proxy_off, CLIP_OT_proxy_build
 class OBJECT_OT_simple_operator(bpy.types.Operator):
     bl_idname = "object.simple_operator"


### PR DESCRIPTION
## Summary
- update helper import paths inside the add-on
- adjust operator test imports
- extend `__init__` to add `helpers` to `sys.path`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68882ee47e64832daad56f809bdc0479