### PR TITLE
Fix test operator import for channel

### DIFF
--- a/operators/tests/channel.py
+++ b/operators/tests/channel.py
@@ -1,4 +1,5 @@
 import bpy
+from .pattern import CLIP_OT_test_pattern
 from ...helpers.tracking_helpers import (
     run_pattern_size_test,
     evaluate_motion_models,
@@ -36,6 +37,4 @@ operator_classes = (
     CLIP_OT_test_motion,
     CLIP_OT_test_channel,
 )
-
-operator_classes = (CLIP_OT_test_channel,)
 


### PR DESCRIPTION
## Summary
- import `CLIP_OT_test_pattern` in `channel.py`
- remove duplicate `operator_classes` definition

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888319e743c832db5388a97061fe66e