### PR TITLE
Fix missing import in channel tests

### DIFF
--- a/operators/tests/channel.py
+++ b/operators/tests/channel.py
@@ -1,5 +1,6 @@
 import bpy
 from .pattern import CLIP_OT_test_pattern
+from .motion import CLIP_OT_test_motion
 from ...helpers.tracking_helpers import (
     run_pattern_size_test,
     evaluate_motion_models,


### PR DESCRIPTION
## Summary
- fix missing import for `CLIP_OT_test_motion` in channel test module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888330af4c4832dbce6f2fef313d8d0