### PR TITLE
Fix duplicate registration of test pattern operator

### DIFF
--- a/operators/tests/channel.py
+++ b/operators/tests/channel.py
@@ -1,5 +1,4 @@
 import bpy
-from .pattern import CLIP_OT_test_pattern
 from .motion import CLIP_OT_test_motion
 from ...helpers.tracking_helpers import (
     run_pattern_size_test,
@@ -34,7 +33,6 @@ class CLIP_OT_test_channel(bpy.types.Operator):
 
 
 operator_classes = (
-    CLIP_OT_test_pattern,
     CLIP_OT_test_motion,
     CLIP_OT_test_channel,
 )


### PR DESCRIPTION
## Summary
- remove `CLIP_OT_test_pattern` import from `channel.py`
- avoid including the same operator twice

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888348c1c3c832da5ef3d22811ba00c