### PR TITLE
Fix duplicate registration of motion test operator

### DIFF
--- a/operators/tests/__init__.py
+++ b/operators/tests/__init__.py
@@ -1,7 +1,8 @@
-from . import pattern, motion, channel
+from . import pattern, channel
+from .motion import CLIP_OT_test_motion
 
 operator_classes = (
+    CLIP_OT_test_motion,
     *pattern.operator_classes,
-    *motion.operator_classes,
     *channel.operator_classes,
 )

--- a/operators/tests/channel.py
+++ b/operators/tests/channel.py
@@ -1,5 +1,4 @@
 import bpy
-from .motion import CLIP_OT_test_motion
 from ...helpers.tracking_helpers import (
     run_pattern_size_test,
     evaluate_motion_models,
@@ -33,7 +32,6 @@ class CLIP_OT_test_channel(bpy.types.Operator):
 
 
 operator_classes = (
-    CLIP_OT_test_motion,
     CLIP_OT_test_channel,
 )
 


### PR DESCRIPTION
## Summary
- avoid registering `CLIP_OT_test_motion` multiple times
- register the operator in `tests/__init__.py` only once

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888361228ac832d9494d7fa638db6d0