### PR TITLE
Implement missing tracking operators

### DIFF
--- a/operators/tracking/cycle.py
+++ b/operators/tracking/cycle.py
@@ -48,6 +48,7 @@ from ...helpers.utils import (
     update_frame_display,
     cycle_motion_model,
 )
+from ...helpers.proxy_helpers import enable_proxy
 from ...helpers.set_playhead_to_frame import set_playhead_to_frame
 from ..proxy import CLIP_OT_proxy_on, CLIP_OT_proxy_off, CLIP_OT_proxy_build
 class CLIP_OT_track_nr1(bpy.types.Operator):

--- a/operators/tracking/navigation.py
+++ b/operators/tracking/navigation.py
@@ -1,0 +1,45 @@
+import bpy
+
+from ...helpers.set_playhead_to_frame import set_playhead_to_frame
+
+class CLIP_OT_frame_jump_custom(bpy.types.Operator):
+    bl_idname = "clip.frame_jump_custom"
+    bl_label = "Frame Jump"
+    bl_description = "Springt um 'Frames/Track' Frames vor"
+
+    def execute(self, context):
+        scene = context.scene
+        step = getattr(scene, "frames_track", 1)
+        frame = min(scene.frame_current + step, scene.frame_end)
+        set_playhead_to_frame(scene, frame)
+        return {'FINISHED'}
+
+
+class CLIP_OT_marker_frame_plus(bpy.types.Operator):
+    bl_idname = "clip.marker_frame_plus"
+    bl_label = "Marker/Frame+"
+    bl_description = "Erh\u00f6ht den Marker/Frame Wert"
+
+    def execute(self, context):
+        scene = context.scene
+        scene.marker_frame += 1
+        return {'FINISHED'}
+
+
+class CLIP_OT_marker_frame_minus(bpy.types.Operator):
+    bl_idname = "clip.marker_frame_minus"
+    bl_label = "Marker/Frame-"
+    bl_description = "Verringert den Marker/Frame Wert"
+
+    def execute(self, context):
+        scene = context.scene
+        if scene.marker_frame > 1:
+            scene.marker_frame -= 1
+        return {'FINISHED'}
+
+
+operator_classes = (
+    CLIP_OT_frame_jump_custom,
+    CLIP_OT_marker_frame_plus,
+    CLIP_OT_marker_frame_minus,
+)

--- a/operators/tracking/solver.py
+++ b/operators/tracking/solver.py
@@ -1,8 +1,9 @@
-from . import detect, track, cleanup, cycle
+from . import detect, track, cleanup, cycle, navigation
 
 operator_classes = (
     *cycle.operator_classes,
     *track.operator_classes,
     *detect.operator_classes,
     *cleanup.operator_classes,
+    *navigation.operator_classes,
 )


### PR DESCRIPTION
## Summary
- add custom navigation operators to modify marker frame count and move the playhead
- register new operators through the tracking solver
- fix `cycle` operator by importing `enable_proxy`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68883b2be9a8832da9f52dfd364a9aa7