### PR TITLE
Clean API panel and add operator tooltips

### DIFF
--- a/operators/tracking/cycle.py
+++ b/operators/tracking/cycle.py
@@ -55,6 +55,15 @@ from .cleanup import cleanup_short_tracks
 class CLIP_OT_track_nr1(bpy.types.Operator):
     bl_idname = "clip.track_nr1"
     bl_label = "Track Nr. 1"
+    bl_description = (
+        "1. Suche Frame mit zu wenig Markern\n"
+        "2. Setze Playhead\n"
+        "3. F\u00fchre Feature Detection durch\n"
+        "4. Wende Threshold-Tests an\n"
+        "5. Track bidirektional\n"
+        "6. Entferne schlechte Tracks\n"
+        "7. Wiederhole Zyklus bis Ende"
+    )
     bl_options = {'REGISTER', 'UNDO', 'BLOCKING'}
 
     _timer = None
@@ -254,6 +263,15 @@ class CLIP_OT_track_nr1(bpy.types.Operator):
 class CLIP_OT_track_nr2(bpy.types.Operator):
     bl_idname = "clip.track_nr2"
     bl_label = "Track Nr. 2"
+    bl_description = (
+        "1. Suche Frame mit zu wenig Markern\n"
+        "2. Setze Playhead\n"
+        "3. F\u00fchre Feature Detection durch\n"
+        "4. Wende Threshold-Tests an\n"
+        "5. Track bidirektional\n"
+        "6. Entferne schlechte Tracks\n"
+        "7. Wiederhole Zyklus bis Ende"
+    )
     bl_options = {'REGISTER', 'UNDO'}
 
     def execute(self, context):

--- a/ui/panels/panels_extra.py
+++ b/ui/panels/panels_extra.py
@@ -8,41 +8,9 @@ class CLIP_PT_test_panel(bpy.types.Panel):
 
     def draw(self, context):
         layout = self.layout
-        layout.operator('clip.all_detect', text='Cycle Detect')
-        layout.operator('clip.api_defaults', text='Defaults')
-        layout.operator('clip.proxy_on', text='Proxy on')
-        layout.operator('clip.proxy_off', text='Proxy off')
-        layout.operator('clip.proxy_build', text='Proxy erstellen (50%)')
-        layout.separator()
-        layout.operator('clip.track_bidirectional', text='Track')
-        layout.operator('clip.track_partial', text='Track Partial')
-        layout.operator('clip.count_button', text='Count')
-        layout.operator('clip.prefix_new', text='Name New')
-        layout.operator('clip.prefix_track', text='Name Track')
-        layout.operator('clip.prefix_good', text='Name GOOD')
-        layout.operator('clip.select_active_tracks', text='Select TRACK')
-        layout.operator('clip.select_new_tracks', text='Select NEW')
-        layout.operator('clip.delete_selected', text='Delete')
-        layout.operator('clip.select_short_tracks', text='Select Short Tracks')
-        layout.operator('clip.pattern_up', text='Pattern+')
-        layout.operator('clip.pattern_down', text='Pattern-')
-        layout.operator('clip.motion_cycle', text='Motion Model')
-        layout.operator('clip.match_cycle', text='Match')
-        layout.operator('clip.channel_r_on', text='Channel R on')
-        layout.operator('clip.channel_r_off', text='Channel R off')
-        layout.operator('clip.channel_b_on', text='Channel B on')
-        layout.operator('clip.channel_b_off', text='Channel B off')
-        layout.operator('clip.channel_g_on', text='Channel G on')
-        layout.operator('clip.channel_g_off', text='Channel G off')
-        layout.operator('clip.frame_jump_custom', text='Frame Jump')
-        layout.operator('clip.low_marker_frame', text='Low Marker Frame')
-        layout.operator('clip.marker_frame_plus', text='Marker/Frame+')
-        layout.operator('clip.marker_frame_minus', text='Marker/Frame-')
-        layout.operator('clip.marker_position', text='Marker Position')
-        layout.operator('clip.good_marker_position', text='GOOD Marker Position')
-        layout.operator('clip.camera_solve', text='Kamera solve')
-        layout.operator('clip.track_cleanup', text='Select Error Tracks')
-
+        # Dieses Panel bleibt bewusst leer, um die API-Funktionen
+        # nicht doppelt darzustellen.
+        
 
 class CLIP_PT_test_subpanel(bpy.types.Panel):
     bl_space_type = 'CLIP_EDITOR'
@@ -53,11 +21,8 @@ class CLIP_PT_test_subpanel(bpy.types.Panel):
 
     def draw(self, context):
         layout = self.layout
-        layout.label(text="Test Aktionen")
-        layout.operator('clip.test_pattern', text='Test Pattern')
-        layout.operator('clip.test_motion', text='Test Motion')
-        layout.operator('clip.test_channel', text='Test Channel')
-
+        # Unterpanel ohne Buttons
+        
 
 class CLIP_PT_test_detail_panel(bpy.types.Panel):
     bl_space_type = 'CLIP_EDITOR'
@@ -68,12 +33,7 @@ class CLIP_PT_test_detail_panel(bpy.types.Panel):
 
     def draw(self, context):
         layout = self.layout
-        layout.operator('clip.setup_defaults', text='Test Defaults')
-        layout.operator('clip.detect_button', text='Test Detect')
-        layout.operator('clip.test_track', text='Test Track')
-        layout.operator('clip.prefix_test', text='TEST Name')
-        layout.operator('clip.select_test_tracks', text='TEST select')
-        layout.operator('clip.error_value', text='Error Value')
+        # Keine weiteren Bedienelemente
 
 
 panel_classes = (


### PR DESCRIPTION
## Summary
- remove all buttons from the API functions panel
- leave API subpanels empty as well
- add descriptive tooltips to `track_nr1` and `track_nr2` operators

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688891bbb3a4832dad13cb48c55ceb2c