### PR TITLE
Add tracking steps overview panel

### DIFF
--- a/ui/panels/settings_panel.py
+++ b/ui/panels/settings_panel.py
@@ -1,4 +1,18 @@
 import bpy
+import inspect
+
+from ...operators.tracking.cycle import CLIP_OT_track_nr1
+
+
+def get_tracking_steps_info():
+    """Return (name, doc) pairs for all step_ methods in CLIP_OT_track_nr1."""
+    steps = []
+    for name, method in inspect.getmembers(CLIP_OT_track_nr1, predicate=inspect.isfunction):
+        if name.startswith("step_"):
+            doc = inspect.getdoc(method) or "Keine Beschreibung vorhanden"
+            first_line = doc.splitlines()[0] if doc else ""
+            steps.append((name, first_line))
+    return steps
 
 class CLIP_PT_final_panel(bpy.types.Panel):
     bl_space_type = 'CLIP_EDITOR'

--- a/ui/panels/tracking_panel.py
+++ b/ui/panels/tracking_panel.py
@@ -1,5 +1,7 @@
 import bpy
 
+from .settings_panel import get_tracking_steps_info
+
 class CLIP_PT_tracking_panel(bpy.types.Panel):
     bl_space_type = 'CLIP_EDITOR'
     bl_region_type = 'UI'
@@ -11,4 +13,24 @@ class CLIP_PT_tracking_panel(bpy.types.Panel):
         layout.label(text="Addon Informationen")
 
 
-panel_classes = (CLIP_PT_tracking_panel,)
+class CLIP_PT_tracking_steps(bpy.types.Panel):
+    bl_space_type = 'CLIP_EDITOR'
+    bl_region_type = 'UI'
+    bl_category = 'Track'
+    bl_label = 'Tracking Schritte'
+
+    def draw(self, context):
+        layout = self.layout
+
+        layout.operator('clip.track_nr1', text='Track Nr. 1')
+
+        layout.label(text="Automatischer Ablauf:")
+        box = layout.box()
+        for name, desc in get_tracking_steps_info():
+            box.label(text=f"{name} \u2013 {desc}")
+
+
+panel_classes = (
+    CLIP_PT_tracking_panel,
+    CLIP_PT_tracking_steps,
+)


### PR DESCRIPTION
## Summary
- add helper to inspect tracking steps from `CLIP_OT_track_nr1`
- show these steps in a new panel within the Track sidebar

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68889ab62f30832da7b472f35991c0c0