### PR TITLE
Move track selection helpers to dedicated module

### DIFF
--- a/helpers/marker_helpers.py
+++ b/helpers/marker_helpers.py
@@ -1,60 +1,9 @@
 import bpy
-from .prefix_track import PREFIX_TRACK
-from .utils import PENDING_RENAME, clean_pending_tracks
-
-
-def has_active_marker(tracks, frame):
-    for t in tracks:
-        m = t.markers.find_frame(frame)
-        if m and not m.mute and m.co.length_squared != 0.0:
-            return True
-    return False
-
-
-def get_undertracked_markers(clip, min_frames=10):
-    undertracked = []
-    clean_pending_tracks(clip)
-    for track in clip.tracking.tracks:
-        if not (track.name.startswith(PREFIX_TRACK) or track in PENDING_RENAME):
-            continue
-        tracked_frames = [
-            m
-            for m in track.markers
-            if not m.mute and m.co.length_squared != 0.0
-        ]
-        if len(tracked_frames) < min_frames:
-            undertracked.append((track.name, len(tracked_frames)))
-    return undertracked
-
-
-def select_tracks_by_names(clip, name_list):
-    for track in clip.tracking.tracks:
-        track.select = track.name in name_list
-
-
-def select_tracks_by_prefix(clip, prefix):
-    """Select all tracks whose names start with the given prefix."""
-    for track in clip.tracking.tracks:
-        track.select = track.name.startswith(prefix)
-
-
-def ensure_valid_selection(clip, frame):
-    """Validate selected tracks for the given frame."""
-    valid = False
-    for track in clip.tracking.tracks:
-        if track.select:
-            marker = track.markers.find_frame(frame, exact=True)
-            if marker is None or marker.mute:
-                track.select = False
-            else:
-                valid = True
-    return valid
-
-
-def cleanup_all_tracks(clip):
-    """Remove all tracks from the clip."""
-    for t in clip.tracking.tracks:
-        t.select = True
-    from .delete_selected_tracks import delete_selected_tracks
-
-    delete_selected_tracks()
+from .track_selection_utils import (
+    cleanup_all_tracks,
+    ensure_valid_selection,
+    get_undertracked_markers,
+    has_active_marker,
+    select_tracks_by_names,
+    select_tracks_by_prefix,
+)

--- a/helpers/select_short_tracks.py
+++ b/helpers/select_short_tracks.py
@@ -1,27 +1,6 @@
 import bpy
 
-from .prefix_track import PREFIX_TRACK
-from .utils import clean_pending_tracks, PENDING_RENAME
-
-
-def _get_undertracked_markers(clip, min_frames=10):
-    undertracked = []
-    clean_pending_tracks(clip)
-    for track in clip.tracking.tracks:
-        if not (track.name.startswith(PREFIX_TRACK) or track in PENDING_RENAME):
-            continue
-        tracked_frames = [
-            m for m in track.markers
-            if not m.mute and m.co.length_squared != 0.0
-        ]
-        if len(tracked_frames) < min_frames:
-            undertracked.append((track.name, len(tracked_frames)))
-    return undertracked
-
-
-def _select_tracks_by_names(clip, name_list):
-    for track in clip.tracking.tracks:
-        track.select = track.name in name_list
+from .track_selection_utils import get_undertracked_markers, select_tracks_by_names
 
 
 def select_short_tracks(clip, min_length: int):
@@ -29,11 +8,11 @@ def select_short_tracks(clip, min_length: int):
 
     Used by :class:`~operators.tracking.cleanup.CLIP_OT_select_short_tracks`.
     """
-    undertracked = _get_undertracked_markers(clip, min_frames=min_length)
+    undertracked = get_undertracked_markers(clip, min_frames=min_length)
     for t in clip.tracking.tracks:
         t.select = False
     if not undertracked:
         return 0
     names = [name for name, _ in undertracked]
-    _select_tracks_by_names(clip, names)
+    select_tracks_by_names(clip, names)
     return len(names)

--- a/helpers/track_selection_utils.py
+++ b/helpers/track_selection_utils.py
@@ -1,0 +1,60 @@
+import bpy
+from .prefix_track import PREFIX_TRACK
+from .utils import PENDING_RENAME, clean_pending_tracks
+
+
+def has_active_marker(tracks, frame):
+    for t in tracks:
+        m = t.markers.find_frame(frame)
+        if m and not m.mute and m.co.length_squared != 0.0:
+            return True
+    return False
+
+
+def get_undertracked_markers(clip, min_frames=10):
+    undertracked = []
+    clean_pending_tracks(clip)
+    for track in clip.tracking.tracks:
+        if not (track.name.startswith(PREFIX_TRACK) or track in PENDING_RENAME):
+            continue
+        tracked_frames = [
+            m
+            for m in track.markers
+            if not m.mute and m.co.length_squared != 0.0
+        ]
+        if len(tracked_frames) < min_frames:
+            undertracked.append((track.name, len(tracked_frames)))
+    return undertracked
+
+
+def select_tracks_by_names(clip, name_list):
+    for track in clip.tracking.tracks:
+        track.select = track.name in name_list
+
+
+def select_tracks_by_prefix(clip, prefix):
+    """Select all tracks whose names start with the given prefix."""
+    for track in clip.tracking.tracks:
+        track.select = track.name.startswith(prefix)
+
+
+def ensure_valid_selection(clip, frame):
+    """Validate selected tracks for the given frame."""
+    valid = False
+    for track in clip.tracking.tracks:
+        if track.select:
+            marker = track.markers.find_frame(frame, exact=True)
+            if marker is None or marker.mute:
+                track.select = False
+            else:
+                valid = True
+    return valid
+
+
+def cleanup_all_tracks(clip):
+    """Remove all tracks from the clip."""
+    for t in clip.tracking.tracks:
+        t.select = True
+    from .delete_selected_tracks import delete_selected_tracks
+
+    delete_selected_tracks()


### PR DESCRIPTION
## Summary
- add `track_selection_utils.py` with track-selection helper functions
- refactor `marker_helpers.py` to re-export the new helpers
- reuse the new helpers in `select_short_tracks`
- remove duplicated internal implementations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888bd93cb20832db291d877f73ccd62