### PR TITLE
Refactor initial operator executes

### DIFF
--- a/operators/tracking/exec/simple_operator.py
+++ b/operators/tracking/exec/simple_operator.py
@@ -1,0 +1,7 @@
+import bpy
+
+
+def execute(self, context):
+    """Execute a simple operator reporting 'Hello World from Addon'."""
+    self.report({'INFO'}, "Hello World from Addon")
+    return {'FINISHED'}

--- a/operators/tracking/exec/track_bidirectional.py
+++ b/operators/tracking/exec/track_bidirectional.py
@@ -1,0 +1,40 @@
+import bpy
+from ...helpers.utils import update_frame_display
+
+
+def execute(self, context):
+    """Track selected markers backwards and then forwards."""
+    clip = context.space_data.clip
+    if not clip:
+        self.report({'WARNING'}, "Kein Clip geladen")
+        return {'CANCELLED'}
+
+    if not any(t.select for t in clip.tracking.tracks):
+        self.report({'WARNING'}, "Keine Tracks ausgewählt")
+        return {'CANCELLED'}
+
+    scene = context.scene
+    original_start = scene.frame_start
+    original_end = scene.frame_end
+    current = scene.frame_current
+
+    if not bpy.ops.clip.track_markers.poll():
+        self.report({'WARNING'}, "Tracking nicht möglich")
+        return {'CANCELLED'}
+
+    scene.frame_start = original_start
+    scene.frame_end = current
+    bpy.ops.clip.track_markers(backwards=True, sequence=True)
+
+    scene.frame_start = current
+    scene.frame_end = original_end
+    scene.frame_current = current
+    update_frame_display(context)
+    bpy.ops.clip.track_markers(backwards=False, sequence=True)
+
+    scene.frame_start = original_start
+    scene.frame_end = original_end
+    scene.frame_current = current
+    update_frame_display(context)
+
+    return {'FINISHED'}

--- a/operators/tracking/exec/track_partial.py
+++ b/operators/tracking/exec/track_partial.py
@@ -1,0 +1,38 @@
+import bpy
+from ...helpers.marker_helpers import ensure_valid_selection
+from ...helpers.tracking_helpers import track_markers_range
+
+
+def execute(self, context):
+    """Track selected markers backwards then forwards within scene range."""
+    scene = context.scene
+    clip = context.space_data.clip
+    if not clip:
+        self.report({'WARNING'}, "Kein Clip geladen")
+        return {'CANCELLED'}
+
+    if not ensure_valid_selection(clip, scene.frame_current):
+        self.report({'WARNING'}, "Keine gültigen Marker ausgewählt")
+        return {'CANCELLED'}
+
+    original_start = scene.frame_start
+    original_end = scene.frame_end
+    current = scene.frame_current
+
+    print(f"[Track Partial] current {current} start {original_start} end {original_end}")
+
+    clip.use_proxy = True
+
+    if bpy.ops.clip.track_markers.poll():
+        print("[Track Partial] track backwards")
+        track_markers_range(scene, original_start, current, current, True)
+
+        print("[Track Partial] track forwards")
+        track_markers_range(scene, current, original_end, current, False)
+
+    print(f"[Track Partial] done at frame {scene.frame_current}")
+
+    scene.frame_start = original_start
+    scene.frame_end = original_end
+
+    return {'FINISHED'}


### PR DESCRIPTION
## Summary
- extract execute methods for the first few operators into their own modules
- call these helpers from `track.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888d10b8814832db765b4a2eb9a1b88