### PR TITLE
Add API functions panel

### DIFF
--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -25,7 +25,7 @@ if bpy is not None:
         detect_features_main,
         detect_features_test,
     )
-    from .proxy_helpers import enable_proxy, disable_proxy
+    from .proxy_utils import create_proxy, enable_proxy, disable_proxy
     from .marker_helpers import (
         has_active_marker,
         get_undertracked_markers,
@@ -49,4 +49,7 @@ if bpy is not None:
         set_color_channels,
         optimize_tracking_parameters,
     )
+    from .clip_resolution import calculate_base_values_from_clip
+    from .marker_validation import calculate_marker_target_from_ui
+    from .tracking_defaults import set_default_tracking_settings
 

--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -52,4 +52,10 @@ if bpy is not None:
     from .clip_resolution import calculate_base_values_from_clip
     from .marker_validation import calculate_marker_target_from_ui
     from .tracking_defaults import set_default_tracking_settings
+    from .tracking_core import track_bidirectional
+    from .track_cleanup import cleanup_error_tracks, cleanup_tracks
+    from .frame_navigation import (
+        find_next_low_marker_frame,
+        set_playhead_to_frame_from_ui,
+    )
 

--- a/helpers/clip_resolution.py
+++ b/helpers/clip_resolution.py
@@ -1,0 +1,15 @@
+import bpy
+from .marker_targeting import calculate_base_values
+
+
+def calculate_base_values_from_clip(context=None, clip=None):
+    """Liest Clip-Aufl\u00f6sung aus und berechnet margin_base + min_distance_base."""
+    if context is None:
+        context = bpy.context
+    if clip is None:
+        clip = getattr(context.space_data, "clip", None)
+    if clip is None:
+        print("\u26a0\ufe0f Kein aktiver Movie Clip gefunden.")
+        return 0, 0
+    width, _ = clip.size
+    return calculate_base_values(width)

--- a/helpers/frame_navigation.py
+++ b/helpers/frame_navigation.py
@@ -1,0 +1,29 @@
+import bpy
+from .feature_detection import find_next_low_marker_frame as _find_next_low_marker_frame
+from .set_playhead_to_frame import set_playhead_to_frame
+
+
+def find_next_low_marker_frame(context=None):
+    """Find and jump to the next frame with too few markers."""
+    if context is None:
+        context = bpy.context
+    scene = context.scene
+    clip = getattr(context.space_data, "clip", None)
+    if clip is None:
+        print("\u26A0\uFE0F Kein aktiver Movie Clip gefunden.")
+        return None, 0
+    frame, count = _find_next_low_marker_frame(scene, clip, scene.marker_frame)
+    if frame is not None:
+        set_playhead_to_frame(scene, frame)
+    return frame, count
+
+
+def set_playhead_to_frame_from_ui(context=None):
+    """Set playhead using the UI value ``scene.marker_frame``."""
+    if context is None:
+        context = bpy.context
+    scene = context.scene
+    set_playhead_to_frame(scene, scene.marker_frame)
+
+
+__all__ = ["find_next_low_marker_frame", "set_playhead_to_frame_from_ui"]

--- a/helpers/marker_validation.py
+++ b/helpers/marker_validation.py
@@ -1,0 +1,10 @@
+import bpy
+from .marker_targeting import marker_target_conservative
+
+
+def calculate_marker_target_from_ui(context=None):
+    """Holt marker_basis aus Szene-UI und berechnet marker_plus usw."""
+    if context is None:
+        context = bpy.context
+    frame = getattr(context.scene, "marker_frame", 0)
+    return marker_target_conservative(frame)

--- a/helpers/proxy_utils.py
+++ b/helpers/proxy_utils.py
@@ -1,5 +1,10 @@
 import bpy
 
+def create_proxy():
+    """Erstellt Proxy-Dateien mit dem vorhandenen Operator."""
+    if bpy.ops.clip.proxy_build.poll():
+        bpy.ops.clip.proxy_build()
+
 
 def enable_proxy():
     """Enable proxies if possible."""
@@ -11,3 +16,4 @@ def disable_proxy():
     """Disable proxies if possible."""
     if bpy.ops.clip.proxy_off.poll():
         bpy.ops.clip.proxy_off()
+

--- a/helpers/track_cleanup.py
+++ b/helpers/track_cleanup.py
@@ -1,0 +1,16 @@
+import bpy
+
+
+def cleanup_error_tracks(scene, clip):
+    """Wrapper around operator cleanup_error_tracks."""
+    from ..operators.cleanup_tracks import cleanup_error_tracks as _cleanup
+    _cleanup(scene, clip)
+
+
+def cleanup_tracks():
+    """Run the builtin cleanup operator if available."""
+    if bpy.ops.clip.cleanup.poll():
+        bpy.ops.clip.cleanup()
+
+
+__all__ = ["cleanup_error_tracks", "cleanup_tracks"]

--- a/helpers/tracking_core.py
+++ b/helpers/tracking_core.py
@@ -1,0 +1,4 @@
+import bpy
+from .tracking_variants import track_bidirectional
+
+__all__ = ["track_bidirectional"]

--- a/helpers/tracking_defaults.py
+++ b/helpers/tracking_defaults.py
@@ -1,0 +1,24 @@
+import bpy
+
+
+def set_default_tracking_settings(context=None):
+    """Setzt alle Tracking-Parameter laut Vorgabe."""
+    if context is None:
+        context = bpy.context
+    clip = getattr(context.space_data, "clip", None)
+    if clip is None:
+        print("\u26a0\ufe0f Kein Clip geladen")
+        return
+    settings = clip.tracking.settings
+    settings.default_pattern_size = 10
+    settings.default_search_size = settings.default_pattern_size * 2
+    settings.default_motion_model = 'Loc'
+    settings.default_pattern_match = 'KEYFRAME'
+    settings.use_default_brute = True
+    settings.use_default_normalization = True
+    settings.use_default_red_channel = True
+    settings.use_default_green_channel = True
+    settings.use_default_blue_channel = True
+    settings.default_weight = 1.0
+    settings.default_correlation_min = 0.9
+    settings.default_margin = 10

--- a/operators/__init__.py
+++ b/operators/__init__.py
@@ -7,6 +7,7 @@ from . import (
     setup_test_defaults,
     tests,
     error_value,
+    api_functions,
 )
 
 operator_classes = (
@@ -17,4 +18,5 @@ operator_classes = (
     *setup_test_defaults.operator_classes,
     *tests.operator_classes,
     *error_value.operator_classes,
+    *api_functions.operator_classes,
 )

--- a/operators/api_functions.py
+++ b/operators/api_functions.py
@@ -1,0 +1,102 @@
+import bpy
+
+from ..helpers.feature_detection import detect_features_once
+from ..helpers.tracking_variants import track_bidirectional
+from ..helpers.select_short_tracks import select_short_tracks
+from .cleanup_tracks import cleanup_error_tracks
+from ..helpers.optimize_tracking import optimize_tracking_parameters
+
+
+def create_proxy():
+    """Build proxies using the existing operator if available."""
+    if bpy.ops.clip.proxy_build.poll():
+        bpy.ops.clip.proxy_build()
+
+
+def cleanup_tracks():
+    """Run the cleanup operator if available."""
+    if bpy.ops.clip.cleanup.poll():
+        bpy.ops.clip.cleanup()
+
+
+class TRACKING_OT_create_proxy(bpy.types.Operator):
+    bl_idname = "tracking.create_proxy"
+    bl_label = "Create Proxy"
+
+    def execute(self, context):
+        create_proxy()
+        return {'FINISHED'}
+
+
+class TRACKING_OT_detect_features_once(bpy.types.Operator):
+    bl_idname = "tracking.detect_features_once"
+    bl_label = "Detect Features"
+
+    def execute(self, context):
+        detect_features_once()
+        return {'FINISHED'}
+
+
+class TRACKING_OT_track_bidirectional(bpy.types.Operator):
+    bl_idname = "tracking.track_bidirectional"
+    bl_label = "Track Bidirectional"
+
+    def execute(self, context):
+        scene = context.scene
+        track_bidirectional(scene.frame_start, scene.frame_end)
+        return {'FINISHED'}
+
+
+class TRACKING_OT_select_short_tracks(bpy.types.Operator):
+    bl_idname = "tracking.select_short_tracks"
+    bl_label = "Select Short Tracks"
+
+    def execute(self, context):
+        clip = getattr(context.space_data, "clip", None)
+        if clip is None:
+            self.report({'WARNING'}, "Kein aktiver Movie Clip gefunden.")
+            return {'CANCELLED'}
+        select_short_tracks(clip, context.scene.frames_track)
+        return {'FINISHED'}
+
+
+class TRACKING_OT_cleanup_error_tracks(bpy.types.Operator):
+    bl_idname = "tracking.cleanup_error_tracks"
+    bl_label = "Cleanup Error Tracks"
+
+    def execute(self, context):
+        clip = getattr(context.space_data, "clip", None)
+        if clip is None:
+            self.report({'WARNING'}, "Kein aktiver Movie Clip gefunden.")
+            return {'CANCELLED'}
+        cleanup_error_tracks(context.scene, clip)
+        return {'FINISHED'}
+
+
+class TRACKING_OT_cleanup_tracks(bpy.types.Operator):
+    bl_idname = "tracking.cleanup_tracks"
+    bl_label = "Cleanup Tracks"
+
+    def execute(self, context):
+        cleanup_tracks()
+        return {'FINISHED'}
+
+
+class TRACKING_OT_optimize_tracking(bpy.types.Operator):
+    bl_idname = "tracking.optimize_tracking"
+    bl_label = "Optimize Tracking"
+
+    def execute(self, context):
+        optimize_tracking_parameters()
+        return {'FINISHED'}
+
+
+operator_classes = (
+    TRACKING_OT_create_proxy,
+    TRACKING_OT_detect_features_once,
+    TRACKING_OT_track_bidirectional,
+    TRACKING_OT_select_short_tracks,
+    TRACKING_OT_cleanup_error_tracks,
+    TRACKING_OT_cleanup_tracks,
+    TRACKING_OT_optimize_tracking,
+)

--- a/operators/api_functions.py
+++ b/operators/api_functions.py
@@ -1,16 +1,14 @@
 import bpy
 
+from ..helpers.proxy_utils import create_proxy, enable_proxy, disable_proxy
 from ..helpers.feature_detection import detect_features_once
 from ..helpers.tracking_variants import track_bidirectional
 from ..helpers.select_short_tracks import select_short_tracks
-from .cleanup_tracks import cleanup_error_tracks
+from ..operators.cleanup_tracks import cleanup_error_tracks
 from ..helpers.optimize_tracking import optimize_tracking_parameters
-
-
-def create_proxy():
-    """Build proxies using the existing operator if available."""
-    if bpy.ops.clip.proxy_build.poll():
-        bpy.ops.clip.proxy_build()
+from ..helpers.clip_resolution import calculate_base_values_from_clip
+from ..helpers.marker_validation import calculate_marker_target_from_ui
+from ..helpers.tracking_defaults import set_default_tracking_settings
 
 
 def cleanup_tracks():
@@ -25,6 +23,27 @@ class TRACKING_OT_create_proxy(bpy.types.Operator):
 
     def execute(self, context):
         create_proxy()
+        self.report({'INFO'}, "Proxy erstellt")
+        return {'FINISHED'}
+
+
+class TRACKING_OT_enable_proxy(bpy.types.Operator):
+    bl_idname = "tracking.enable_proxy"
+    bl_label = "Enable Proxy"
+
+    def execute(self, context):
+        enable_proxy()
+        self.report({'INFO'}, "Proxy aktiviert")
+        return {'FINISHED'}
+
+
+class TRACKING_OT_disable_proxy(bpy.types.Operator):
+    bl_idname = "tracking.disable_proxy"
+    bl_label = "Disable Proxy"
+
+    def execute(self, context):
+        disable_proxy()
+        self.report({'INFO'}, "Proxy deaktiviert")
         return {'FINISHED'}
 
 
@@ -34,6 +53,7 @@ class TRACKING_OT_detect_features_once(bpy.types.Operator):
 
     def execute(self, context):
         detect_features_once()
+        self.report({'INFO'}, "Features erkannt")
         return {'FINISHED'}
 
 
@@ -44,6 +64,7 @@ class TRACKING_OT_track_bidirectional(bpy.types.Operator):
     def execute(self, context):
         scene = context.scene
         track_bidirectional(scene.frame_start, scene.frame_end)
+        self.report({'INFO'}, "Tracking abgeschlossen")
         return {'FINISHED'}
 
 
@@ -56,7 +77,38 @@ class TRACKING_OT_select_short_tracks(bpy.types.Operator):
         if clip is None:
             self.report({'WARNING'}, "Kein aktiver Movie Clip gefunden.")
             return {'CANCELLED'}
-        select_short_tracks(clip, context.scene.frames_track)
+        count = select_short_tracks(clip, context.scene.frames_track)
+        self.report({'INFO'}, f"{count} kurze Tracks ausgewählt")
+        return {'FINISHED'}
+
+
+class TRACKING_OT_calculate_margin_distance(bpy.types.Operator):
+    bl_idname = "tracking.calculate_margin_distance"
+    bl_label = "Berechne Margin & Distance"
+
+    def execute(self, context):
+        margin, distance = calculate_base_values_from_clip(context=context)
+        self.report({'INFO'}, f"Margin: {margin}, MinDist: {distance}")
+        return {'FINISHED'}
+
+
+class TRACKING_OT_calculate_marker_target(bpy.types.Operator):
+    bl_idname = "tracking.calculate_marker_target"
+    bl_label = "Markerziel berechnen"
+
+    def execute(self, context):
+        target = calculate_marker_target_from_ui(context=context)
+        self.report({'INFO'}, f"Markerziel: {target}")
+        return {'FINISHED'}
+
+
+class TRACKING_OT_set_tracking_defaults(bpy.types.Operator):
+    bl_idname = "tracking.set_tracking_defaults"
+    bl_label = "Tracking-Defaults"
+
+    def execute(self, context):
+        set_default_tracking_settings(context=context)
+        self.report({'INFO'}, "Tracking-Defaults gesetzt")
         return {'FINISHED'}
 
 
@@ -70,6 +122,7 @@ class TRACKING_OT_cleanup_error_tracks(bpy.types.Operator):
             self.report({'WARNING'}, "Kein aktiver Movie Clip gefunden.")
             return {'CANCELLED'}
         cleanup_error_tracks(context.scene, clip)
+        self.report({'INFO'}, "Fehlerhafte Tracks bereinigt")
         return {'FINISHED'}
 
 
@@ -79,6 +132,7 @@ class TRACKING_OT_cleanup_tracks(bpy.types.Operator):
 
     def execute(self, context):
         cleanup_tracks()
+        self.report({'INFO'}, "Tracks bereinigt")
         return {'FINISHED'}
 
 
@@ -88,14 +142,20 @@ class TRACKING_OT_optimize_tracking(bpy.types.Operator):
 
     def execute(self, context):
         optimize_tracking_parameters()
+        self.report({'INFO'}, "Optimierung abgeschlossen")
         return {'FINISHED'}
 
 
 operator_classes = (
     TRACKING_OT_create_proxy,
+    TRACKING_OT_enable_proxy,
+    TRACKING_OT_disable_proxy,
     TRACKING_OT_detect_features_once,
     TRACKING_OT_track_bidirectional,
     TRACKING_OT_select_short_tracks,
+    TRACKING_OT_calculate_margin_distance,
+    TRACKING_OT_calculate_marker_target,
+    TRACKING_OT_set_tracking_defaults,
     TRACKING_OT_cleanup_error_tracks,
     TRACKING_OT_cleanup_tracks,
     TRACKING_OT_optimize_tracking,

--- a/operators/api_functions.py
+++ b/operators/api_functions.py
@@ -2,19 +2,19 @@ import bpy
 
 from ..helpers.proxy_utils import create_proxy, enable_proxy, disable_proxy
 from ..helpers.feature_detection import detect_features_once
-from ..helpers.tracking_variants import track_bidirectional
+from ..helpers.tracking_core import track_bidirectional
 from ..helpers.select_short_tracks import select_short_tracks
-from ..operators.cleanup_tracks import cleanup_error_tracks
+from ..helpers.track_cleanup import cleanup_error_tracks, cleanup_tracks
+from ..helpers.frame_navigation import (
+    find_next_low_marker_frame,
+    set_playhead_to_frame_from_ui,
+)
 from ..helpers.optimize_tracking import optimize_tracking_parameters
 from ..helpers.clip_resolution import calculate_base_values_from_clip
 from ..helpers.marker_validation import calculate_marker_target_from_ui
 from ..helpers.tracking_defaults import set_default_tracking_settings
 
 
-def cleanup_tracks():
-    """Run the cleanup operator if available."""
-    if bpy.ops.clip.cleanup.poll():
-        bpy.ops.clip.cleanup()
 
 
 class TRACKING_OT_create_proxy(bpy.types.Operator):
@@ -146,6 +146,29 @@ class TRACKING_OT_optimize_tracking(bpy.types.Operator):
         return {'FINISHED'}
 
 
+class TRACKING_OT_find_next_low_marker_frame(bpy.types.Operator):
+    bl_idname = "tracking.find_next_low_marker_frame"
+    bl_label = "Next Low Marker Frame"
+
+    def execute(self, context):
+        frame, count = find_next_low_marker_frame(context=context)
+        if frame is None:
+            self.report({'INFO'}, "Kein Frame gefunden")
+        else:
+            self.report({'INFO'}, f"Frame {frame} ({count} Marker)")
+        return {'FINISHED'}
+
+
+class TRACKING_OT_set_playhead_to_frame(bpy.types.Operator):
+    bl_idname = "tracking.set_playhead_to_frame"
+    bl_label = "Set Playhead"
+
+    def execute(self, context):
+        set_playhead_to_frame_from_ui(context=context)
+        self.report({'INFO'}, "Playhead gesetzt")
+        return {'FINISHED'}
+
+
 operator_classes = (
     TRACKING_OT_create_proxy,
     TRACKING_OT_enable_proxy,
@@ -159,4 +182,6 @@ operator_classes = (
     TRACKING_OT_cleanup_error_tracks,
     TRACKING_OT_cleanup_tracks,
     TRACKING_OT_optimize_tracking,
+    TRACKING_OT_find_next_low_marker_frame,
+    TRACKING_OT_set_playhead_to_frame,
 )

--- a/ui/panels/__init__.py
+++ b/ui/panels/__init__.py
@@ -1,8 +1,9 @@
 # Relative imports for panel modules
-from . import tracking_panel, settings_panel, panels_extra
+from . import tracking_panel, settings_panel, panels_extra, api_panel
 
 panel_classes = (
     *tracking_panel.panel_classes,
     *settings_panel.panel_classes,
     *panels_extra.panel_classes,
+    *api_panel.panel_classes,
 )

--- a/ui/panels/api_panel.py
+++ b/ui/panels/api_panel.py
@@ -10,31 +10,29 @@ class TRACKING_PT_api_functions(bpy.types.Panel):
 
     def draw(self, context):
         layout = self.layout
-        layout.label(text="Tracking-Schritte manuell ausführen:")
-
-        # Proxy-Funktionen
+        layout.label(text="Initialisierung:")
+        layout.operator("tracking.set_tracking_defaults")
         layout.operator("tracking.create_proxy")
         layout.operator("tracking.enable_proxy")
-        layout.operator("tracking.disable_proxy")
-
-        # Analyse & Tracking
-        layout.operator("tracking.detect_features_once")
-        layout.operator("tracking.track_bidirectional")
-        layout.operator("tracking.select_short_tracks")
-
-        # Berechnungen
         layout.operator("tracking.calculate_margin_distance")
         layout.operator("tracking.calculate_marker_target")
 
-        # Einstellungen setzen
-        layout.operator("tracking.set_tracking_defaults")
-
-        # Cleanup
+        layout.separator()
+        layout.label(text="Markererkennung & Cleanup:")
+        layout.operator("tracking.detect_features_once")
+        layout.operator("tracking.select_short_tracks")
         layout.operator("tracking.cleanup_error_tracks")
         layout.operator("tracking.cleanup_tracks")
 
-        # Optimierung
+        layout.separator()
+        layout.label(text="Tracking:")
+        layout.operator("tracking.track_bidirectional")
+
+        layout.separator()
+        layout.label(text="Optimierung & Analyse:")
         layout.operator("tracking.optimize_tracking")
+        layout.operator("tracking.find_next_low_marker_frame")
+        layout.operator("tracking.set_playhead_to_frame")
 
 
 panel_classes = (

--- a/ui/panels/api_panel.py
+++ b/ui/panels/api_panel.py
@@ -11,12 +11,29 @@ class TRACKING_PT_api_functions(bpy.types.Panel):
     def draw(self, context):
         layout = self.layout
         layout.label(text="Tracking-Schritte manuell ausführen:")
+
+        # Proxy-Funktionen
         layout.operator("tracking.create_proxy")
+        layout.operator("tracking.enable_proxy")
+        layout.operator("tracking.disable_proxy")
+
+        # Analyse & Tracking
         layout.operator("tracking.detect_features_once")
         layout.operator("tracking.track_bidirectional")
         layout.operator("tracking.select_short_tracks")
+
+        # Berechnungen
+        layout.operator("tracking.calculate_margin_distance")
+        layout.operator("tracking.calculate_marker_target")
+
+        # Einstellungen setzen
+        layout.operator("tracking.set_tracking_defaults")
+
+        # Cleanup
         layout.operator("tracking.cleanup_error_tracks")
         layout.operator("tracking.cleanup_tracks")
+
+        # Optimierung
         layout.operator("tracking.optimize_tracking")
 
 

--- a/ui/panels/api_panel.py
+++ b/ui/panels/api_panel.py
@@ -1,0 +1,25 @@
+import bpy
+
+
+class TRACKING_PT_api_functions(bpy.types.Panel):
+    bl_label = "API Funktionen"
+    bl_idname = "TRACKING_PT_api_functions"
+    bl_space_type = 'CLIP_EDITOR'
+    bl_region_type = 'UI'
+    bl_category = "Tracking Tools"
+
+    def draw(self, context):
+        layout = self.layout
+        layout.label(text="Tracking-Schritte manuell ausführen:")
+        layout.operator("tracking.create_proxy")
+        layout.operator("tracking.detect_features_once")
+        layout.operator("tracking.track_bidirectional")
+        layout.operator("tracking.select_short_tracks")
+        layout.operator("tracking.cleanup_error_tracks")
+        layout.operator("tracking.cleanup_tracks")
+        layout.operator("tracking.optimize_tracking")
+
+
+panel_classes = (
+    TRACKING_PT_api_functions,
+)


### PR DESCRIPTION
## Summary
- add `TRACKING_PT_api_functions` panel
- implement several `tracking.*` operators for manual cycle control
- expose operators via new module
- register the operators and panel

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68895c78d388832d861d59004f8cf147