### PR TITLE
Add default settings operator

### DIFF
--- a/operators/__init__.py
+++ b/operators/__init__.py
@@ -5,6 +5,7 @@ from . import (
     cleanup_tracks,
     setup_defaults,
     setup_test_defaults,
+    tracking_default_settings_operator,
     tests,
     error_value,
 )
@@ -15,6 +16,7 @@ operator_classes = (
     *cleanup_tracks.operator_classes,
     *setup_defaults.operator_classes,
     *setup_test_defaults.operator_classes,
+    *tracking_default_settings_operator.operator_classes,
     *tests.operator_classes,
     *error_value.operator_classes,
 )

--- a/operators/tracking_default_settings_operator.py
+++ b/operators/tracking_default_settings_operator.py
@@ -1,0 +1,50 @@
+import bpy
+
+class TRACKING_OT_set_default_settings(bpy.types.Operator):
+    bl_idname = "tracking.set_default_settings"
+    bl_label = "Default Settings"
+    bl_description = "Setzt alle Standardwerte f\u00fcr das Tracking"
+
+    @classmethod
+    def poll(cls, context):
+        return context.space_data and context.space_data.clip
+
+    def execute(self, context):
+        scene = context.scene
+        clip = context.space_data.clip
+        tracking = clip.tracking
+        settings = tracking.settings
+
+        image_width = clip.size[0]
+        margin = int(image_width * 0.025)
+        min_distance = int(image_width * 0.05)
+        detection_threshold = 0.5
+
+        marker_basis = scene.get("marker_basis", 20)
+        min_track_length = scene.get("frames_track", 10)
+
+        pattern_size = int(image_width / 100)
+        search_size = pattern_size
+
+        settings.motion_model = 'Loc'
+        settings.use_keyframe_selection = True
+        settings.use_normalization = True
+
+        settings.use_red_channel = True
+        settings.use_green_channel = True
+        settings.use_blue_channel = True
+
+        settings.weight = 1.0
+        settings.correlation_min = 0.9
+        settings.use_mask = False
+
+        if "repeat_frame" not in scene:
+            scene["repeat_frame"] = {}
+
+        self.report({'INFO'}, f"Defaults gesetzt: Margin={margin}, Pattern={pattern_size}")
+        return {'FINISHED'}
+
+
+operator_classes = (
+    TRACKING_OT_set_default_settings,
+)

--- a/ui/panels/panels_extra.py
+++ b/ui/panels/panels_extra.py
@@ -8,8 +8,8 @@ class CLIP_PT_test_panel(bpy.types.Panel):
 
     def draw(self, context):
         layout = self.layout
-        # Dieses Panel bleibt bewusst leer, um die API-Funktionen
-        # nicht doppelt darzustellen.
+        layout.label(text="Initialisierung:")
+        layout.operator("tracking.set_default_settings")
         
 
 class CLIP_PT_test_subpanel(bpy.types.Panel):


### PR DESCRIPTION
## Summary
- add `TRACKING_OT_set_default_settings` operator to apply default tracking values
- register the operator and expose it in API panel

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889729fcce0832db38ec57176c8614e