### PR TITLE
Add marker basis operator

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,43 @@
+bl_info = {
+    "name": "Tracking Tools",
+    "author": "Addon Author",
+    "version": (1, 0, 0),
+    "blender": (4, 4, 0),
+    "location": "Clip Editor",
+    "description": "Beispiel Addon mit Marker Basis Value",
+    "category": "Tracking",
+}
+
+try:
+    import bpy  # type: ignore
+except ModuleNotFoundError:
+    bpy = None
+
+import os
+if bpy is not None and not os.environ.get("BLENDER_TEST"):
+    from .operators import operator_classes
+    from .ui.panels import panel_classes
+    from .properties import register_properties, unregister_properties
+    classes = operator_classes + panel_classes
+else:
+    classes = ()
+
+
+def register():
+    if bpy is None:
+        return
+    register_properties()
+    for cls in classes:
+        bpy.utils.register_class(cls)
+
+
+def unregister():
+    if bpy is None:
+        return
+    for cls in reversed(classes):
+        bpy.utils.unregister_class(cls)
+    unregister_properties()
+
+
+if __name__ == "__main__":
+    register()

--- a/operators/__init__.py
+++ b/operators/__init__.py
@@ -1,0 +1,5 @@
+from .tracking_marker_basis_operator import TRACKING_OT_marker_basis_values
+
+operator_classes = (
+    TRACKING_OT_marker_basis_values,
+)

--- a/operators/tracking_marker_basis_operator.py
+++ b/operators/tracking_marker_basis_operator.py
@@ -1,0 +1,34 @@
+import bpy
+
+
+class TRACKING_OT_marker_basis_values(bpy.types.Operator):
+    bl_idname = "tracking.marker_basis_values"
+    bl_label = "Marker Basis Value"
+    bl_description = (
+        "Berechnet marker_plus, marker_adapt, min_marker, max_marker aus marker_basis"
+    )
+
+    @classmethod
+    def poll(cls, context):
+        return context.space_data and context.space_data.clip
+
+    def execute(self, context):
+        scene = context.scene
+
+        marker_basis = scene.get("marker_basis", 20)
+
+        marker_plus = marker_basis * 4
+        marker_adapt = marker_plus
+        max_marker = marker_adapt * 1.1
+        min_marker = marker_adapt * 0.9
+
+        scene["marker_plus"] = marker_plus
+        scene["marker_adapt"] = marker_adapt
+        scene["max_marker"] = max_marker
+        scene["min_marker"] = min_marker
+
+        self.report(
+            {'INFO'},
+            f"marker_basis={marker_basis}, adapt={int(marker_adapt)}, min={int(min_marker)}, max={int(max_marker)}"
+        )
+        return {'FINISHED'}

--- a/properties/__init__.py
+++ b/properties/__init__.py
@@ -1,0 +1,9 @@
+from . import tracking_props
+
+
+def register_properties():
+    tracking_props.register_props()
+
+
+def unregister_properties():
+    tracking_props.unregister_props()

--- a/properties/tracking_props.py
+++ b/properties/tracking_props.py
@@ -1,0 +1,22 @@
+import bpy
+from bpy.props import IntProperty
+
+tracking_properties = {
+    "marker_basis": IntProperty(
+        name="Marker / Frame",
+        description="Basiswert f\u00fcr Marker pro Frame",
+        default=20,
+        min=1,
+    ),
+}
+
+
+def register_props():
+    for name, prop in tracking_properties.items():
+        setattr(bpy.types.Scene, name, prop)
+
+
+def unregister_props():
+    for name in tracking_properties.keys():
+        if hasattr(bpy.types.Scene, name):
+            delattr(bpy.types.Scene, name)

--- a/ui/panels/api_panel.py
+++ b/ui/panels/api_panel.py
@@ -1,0 +1,19 @@
+import bpy
+
+
+class TRACKING_PT_api_functions(bpy.types.Panel):
+    bl_label = "API Funktionen"
+    bl_idname = "TRACKING_PT_api_functions"
+    bl_space_type = 'CLIP_EDITOR'
+    bl_region_type = 'UI'
+    bl_category = "Tracking Tools"
+
+    def draw(self, context):
+        layout = self.layout
+        layout.prop(context.scene, 'marker_basis', text='Marker/Frame')
+        layout.operator('tracking.marker_basis_values')
+
+
+panel_classes = (
+    TRACKING_PT_api_functions,
+)


### PR DESCRIPTION
## Summary
- add minimal addon structure
- implement `TRACKING_OT_marker_basis_values` operator
- store computed marker values in scene custom properties
- expose input field and button in API panel

## Testing
- `python -m py_compile __init__.py operators/*.py properties/*.py ui/panels/*.py`


------
https://chatgpt.com/codex/tasks/task_e_688976f8a678832d9d0ff0a9b316cf11