### PR TITLE
Add bidirectional tracking operator

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -18,7 +18,10 @@ if bpy is not None and not os.environ.get("BLENDER_TEST"):
     from .operators import operator_classes
     from .ui.panels import panel_classes
     from .properties import register_properties, unregister_properties
-    classes = operator_classes + panel_classes
+    from .operators.bidirectional_tracking_operator import (
+        TRACKING_OT_bidirectional_tracking,
+    )
+    classes = operator_classes + panel_classes + (TRACKING_OT_bidirectional_tracking,)
 else:
     classes = ()
 

--- a/operators/bidirectional_tracking_operator.py
+++ b/operators/bidirectional_tracking_operator.py
@@ -1,0 +1,51 @@
+import bpy
+
+
+class TRACKING_OT_bidirectional_tracking(bpy.types.Operator):
+    bl_idname = "tracking.bidirectional_tracking"
+    bl_label = "Tracking"
+    bl_description = (
+        "Bidirektionales Tracking aller selektierten Marker mit L\u00f6schung kurzer Tracks"
+    )
+
+    @classmethod
+    def poll(cls, context):
+        return context.space_data and context.space_data.clip
+
+    def execute(self, context):
+        scene = context.scene
+        clip = context.space_data.clip
+        tracking = clip.tracking
+
+        # 1. Proxy aktivieren
+        if not clip.use_proxy:
+            clip.use_proxy = True
+
+        # 2. Selektierte Marker bidirektional tracken
+        bpy.ops.clip.track_markers(backwards=True, forwards=True)
+
+        # 3. Kurze Tracks identifizieren und l\u00f6schen
+        min_length = scene.get("frames_track", 10)
+        short_tracks = []
+
+        for track in tracking.tracks:
+            if not track.select or track.mute:
+                continue
+
+            frame_numbers = [m.frame for m in track.markers if not m.mute]
+            if not frame_numbers:
+                continue
+
+            track_length = max(frame_numbers) - min(frame_numbers) + 1
+            if track_length < min_length:
+                short_tracks.append(track)
+
+        if short_tracks:
+            for t in short_tracks:
+                t.select = True
+            bpy.ops.clip.delete_track()
+            self.report({'INFO'}, f"{len(short_tracks)} kurze Tracks gel\u00f6scht (< {min_length} Frames)")
+        else:
+            self.report({'INFO'}, "Keine kurzen Tracks gefunden.")
+
+        return {'FINISHED'}

--- a/properties/tracking_props.py
+++ b/properties/tracking_props.py
@@ -8,6 +8,12 @@ tracking_properties = {
         default=20,
         min=1,
     ),
+    "frames_track": IntProperty(
+        name="Frames/Track",
+        description="Minimale L\u00e4nge eines g\u00fcltigen Tracks",
+        default=10,
+        min=1,
+    ),
 }
 
 

--- a/ui/panels/api_panel.py
+++ b/ui/panels/api_panel.py
@@ -13,6 +13,7 @@ class TRACKING_PT_api_functions(bpy.types.Panel):
         layout.prop(context.scene, 'marker_basis', text='Marker/Frame')
         layout.operator('tracking.marker_basis_values')
         layout.operator('tracking.place_marker')
+        layout.operator('tracking.bidirectional_tracking')
 
 
 panel_classes = (


### PR DESCRIPTION
## Summary
- add new operator `tracking.bidirectional_tracking`
- register new operator in the add-on
- add `frames_track` property for determining short tracks
- expose new operator in the API panel

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- `flake8 || true`

------
https://chatgpt.com/codex/tasks/task_e_6889864f3bc0832daa4edd29b2374a1f