### PR TITLE
Fix property names and cleanup settings registration

### DIFF
--- a/helpers/cleanup_tracks.py
+++ b/helpers/cleanup_tracks.py
@@ -79,16 +79,16 @@ def max_track_error(scene: bpy.types.Scene, clip: bpy.types.MovieClip) -> float:
 
 def cleanup_error_tracks(scene: bpy.types.Scene, clip: bpy.types.MovieClip) -> None:
     """Delete tracking markers while decreasing the error threshold."""
-    original = scene.error_threshold
+    original = scene.error_per_track
     max_err = max_track_error(scene, clip)
-    scene.error_threshold = max_err
+    scene.error_per_track = max_err
     threshold = max_err
     while threshold >= original:
         while cleanup_pass(scene, clip, threshold):
             pass
         threshold *= 0.9
-        scene.error_threshold = threshold
-    scene.error_threshold = original
+        scene.error_per_track = threshold
+    scene.error_per_track = original
 
 
 def cleanup_pass(scene: bpy.types.Scene, clip: bpy.types.MovieClip, threshold: float) -> bool:

--- a/helpers/test_marker_base.py
+++ b/helpers/test_marker_base.py
@@ -5,7 +5,7 @@ def test_marker_base(context):
     """Berechnet Marker-Basiswerte aus dem Eingabefeld 'marker/Frame'."""
 
     scene = context.scene
-    marker_basis = scene.get("marker_per_frame", 12)
+    marker_basis = scene.get("marker_basis", 12)
 
     marker_plus = marker_basis / 3
     marker_adapt = marker_plus

--- a/operators/bidirectional_tracking_operator.py
+++ b/operators/bidirectional_tracking_operator.py
@@ -25,7 +25,7 @@ class TRACKING_OT_bidirectional_tracking(bpy.types.Operator):
         bpy.ops.clip.track_markers(backwards=True, forwards=True)
 
         # 3. Kurze Tracks identifizieren und l\u00f6schen
-        min_length = scene.get("frames_track", 10)
+        min_length = scene.get("frames_per_track", 10)
         short_tracks = []
 
         for track in tracking.tracks:

--- a/operators/track_default_settings.py
+++ b/operators/track_default_settings.py
@@ -37,47 +37,11 @@ class TRACKING_OT_set_default_settings(bpy.types.Operator):
         self.report({'INFO'}, "Tracking-Defaults gesetzt")
         return {'FINISHED'}
 
-class TRACKING_PT_api_functions(bpy.types.Panel):
-    bl_label = "API Funktionen"
-    bl_idname = "TRACKING_PT_api_functions"
-    bl_space_type = 'CLIP_EDITOR'
-    bl_region_type = 'UI'
-    bl_category = "Addon"
 
-    def draw(self, context):
-        layout = self.layout
-        layout.label(text="Tracking-Vorgaben:")
-        layout.prop(context.scene, "marker_basis")
-        layout.prop(context.scene, "frames_track")
-
-        layout.separator()
-        layout.label(text="Initialisierung:")
-        layout.operator("tracking.set_default_settings")
-        layout.operator("tracking.marker_basis_values")
-
-
-classes = (
-    TRACKING_OT_set_default_settings,
-    TRACKING_OT_marker_basis_values,
-    TRACKING_PT_api_functions,
-)
+classes = (TRACKING_OT_set_default_settings,)
 
 
 def register():
-    bpy.types.Scene.marker_basis = bpy.props.IntProperty(
-        name="Marker/Frame",
-        default=20,
-        min=1,
-        description="Zielanzahl von Markern pro Frame",
-    )
-
-    bpy.types.Scene.frames_track = bpy.props.IntProperty(
-        name="Frames/Track",
-        default=10,
-        min=1,
-        description="Minimale Länge eines gültigen Tracks",
-    )
-
     for cls in classes:
         bpy.utils.register_class(cls)
 
@@ -85,9 +49,6 @@ def register():
 def unregister():
     for cls in reversed(classes):
         bpy.utils.unregister_class(cls)
-
-    del bpy.types.Scene.marker_basis
-    del bpy.types.Scene.frames_track
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- remove duplicate UI elements from `track_default_settings`
- rely on `error_per_track` property in cleanup helper
- refer to `frames_per_track` for minimum track length
- use `marker_basis` in marker base test

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688a049a9658832db43f13d5e5271401