### PR TITLE
Add button for default tracking

### DIFF
--- a/ui/panels/api_panel.py
+++ b/ui/panels/api_panel.py
@@ -15,5 +15,6 @@ class TRACKING_PT_api_functions(bpy.types.Panel):
         layout.prop(context.scene, 'error_per_track', text='Error/Track')
         layout.operator('tracking.marker_basis_values')
         layout.operator('tracking.place_marker')
+        layout.operator('tracking.set_default_settings', text='Track Default')
         layout.operator('tracking.bidirectional_tracking')
         layout.operator("clip.cleanup_tracks", text="Cleanup Tracks")


### PR DESCRIPTION
## Summary
- expose a `Track Default` button in the main panel

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688a08c78dfc832dbe383654c225bc2a