### PR TITLE
Add error value operator

### DIFF
--- a/operators/__init__.py
+++ b/operators/__init__.py
@@ -2,10 +2,12 @@ from .tracking_marker_basis_operator import TRACKING_OT_marker_basis_values
 from .place_marker_operator import TRACKING_OT_place_marker
 from .cleanup_operator import CLIP_OT_cleanup_tracks
 from .test_marker_base_operator import TRACKING_OT_test_marker_base
+from .error_value_operator import CLIP_OT_error_value
 
 operator_classes = (
     TRACKING_OT_marker_basis_values,
     TRACKING_OT_place_marker,
     CLIP_OT_cleanup_tracks,
     TRACKING_OT_test_marker_base,
+    CLIP_OT_error_value,
 )

--- a/operators/error_value_operator.py
+++ b/operators/error_value_operator.py
@@ -1,0 +1,43 @@
+import bpy
+from bpy.types import Operator
+
+
+class CLIP_OT_error_value(Operator):
+    bl_idname = "clip.error_value"
+    bl_label = "Error Value"
+    bl_description = "Berechnet die Standardabweichung der Markerpositionen der Selektion"
+
+    def execute(self, context):
+        clip = context.space_data.clip
+        if not clip:
+            self.report({'WARNING'}, "Kein Clip geladen")
+            return {'CANCELLED'}
+
+        x_positions = []
+        y_positions = []
+
+        for track in clip.tracking.tracks:
+            if not track.select:
+                continue
+            for marker in track.markers:
+                if marker.mute:
+                    continue
+                x_positions.append(marker.co[0])
+                y_positions.append(marker.co[1])
+
+        if not x_positions:
+            self.report({'WARNING'}, "Keine Marker ausgewählt")
+            return {'CANCELLED'}
+
+        def std_dev(values):
+            mean_val = sum(values) / len(values)
+            return (sum((v - mean_val) ** 2 for v in values) / len(values)) ** 0.5
+
+        error_x = std_dev(x_positions)
+        error_y = std_dev(y_positions)
+        total_error = error_x + error_y
+
+        self.report({'INFO'}, f"Error X: {error_x:.4f} | Error Y: {error_y:.4f} | Gesamt: {total_error:.4f}")
+        print(f"[Error Value] error_x={error_x:.6f}, error_y={error_y:.6f}, total={total_error:.6f}")
+
+        return {'FINISHED'}


### PR DESCRIPTION
## Summary
- add `CLIP_OT_error_value` for evaluating selected marker error
- register new operator in the operators module

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_688a1076bb0c832d9d5077eac9cc6c1b