### PR TITLE
Implement helper to track markers until scene end

### DIFF
--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -1,0 +1,4 @@
+from .cleanup_tracks import cleanup_error_tracks, max_track_error
+from .delete_tracks import delete_selected_tracks
+from .test_marker_base import test_marker_base
+from .track_markers_until_end import track_markers_until_end

--- a/helpers/track_markers_until_end.py
+++ b/helpers/track_markers_until_end.py
@@ -1,0 +1,23 @@
+import bpy
+
+
+def track_markers_until_end() -> None:
+    """Track selected markers forward until the end frame."""
+    scene = bpy.context.scene
+    space = bpy.context.space_data
+    clip = space.clip if space and space.type == 'CLIP_EDITOR' else None
+
+    if not clip:
+        print("❌ Kein Clip aktiv oder falscher Editor.")
+        return
+
+    result = bpy.ops.clip.track_markers(
+        'INVOKE_DEFAULT',
+        backwards=False,
+        sequence=True,
+    )
+
+    if 'CANCELLED' in result:
+        print("❌ Tracking abgebrochen.")
+    else:
+        print("✅ Tracking gestartet (Sequenzmodus).")


### PR DESCRIPTION
## Summary
- add helper `track_markers_until_end` for automated forward tracking until the end frame
- expose the helper via the `helpers` package

## Testing
- `python -m py_compile helpers/track_markers_until_end.py helpers/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_688a1286968c832d86bbf877fe49b596