### PR TITLE
Implement helper function to compute tracking lengths

### DIFF
--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -2,3 +2,4 @@ from .cleanup_tracks import cleanup_error_tracks, max_track_error
 from .delete_tracks import delete_selected_tracks
 from .test_marker_base import test_marker_base
 from .track_markers_until_end import track_markers_until_end
+from .get_tracking_lengths import get_tracking_lengths

--- a/helpers/get_tracking_lengths.py
+++ b/helpers/get_tracking_lengths.py
@@ -1,0 +1,32 @@
+import bpy
+
+
+def get_tracking_lengths():
+    """Ermittelt für alle selektierten Tracking-Tracks die Tracking-Länge in Frames."""
+    space = bpy.context.space_data
+    clip = space.clip if space and space.type == 'CLIP_EDITOR' else None
+
+    if not clip:
+        print("❌ Kein Clip aktiv oder falscher Editor.")
+        return {}
+
+    results = {}
+    for track in clip.tracking.tracks:
+        if not track.select:
+            continue
+
+        valid_frames = sorted([
+            marker.frame for marker in track.markers if not marker.mute
+        ])
+
+        if valid_frames:
+            start = valid_frames[0]
+            end = valid_frames[-1]
+            length = len(set(valid_frames))
+            results[track.name] = {
+                "start": start,
+                "end": end,
+                "length": length,
+            }
+
+    return results


### PR DESCRIPTION
## Summary
- add `get_tracking_lengths` helper to retrieve valid tracking ranges for selected tracks
- expose `get_tracking_lengths` from the helpers package

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688a13e82a14832d91f257a9ecf67e09