### PR TITLE
Implement cycle_motion_model helper

### DIFF
--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -3,3 +3,4 @@ from .delete_tracks import delete_selected_tracks
 from .test_marker_base import test_marker_base
 from .track_markers_until_end import track_markers_until_end
 from .get_tracking_lengths import get_tracking_lengths
+from .cycle_motion_model import cycle_motion_model

--- a/helpers/cycle_motion_model.py
+++ b/helpers/cycle_motion_model.py
@@ -1,0 +1,17 @@
+import bpy
+
+
+def cycle_motion_model() -> None:
+    """Cycle the default motion model for newly created markers."""
+    models = ["Loc", "LocRot", "LocScale", "Affine", "Perspective"]
+
+    scene_settings = bpy.context.scene.tracking_settings
+    current = scene_settings.motion_model
+
+    try:
+        index = models.index(current)
+        next_model = models[(index + 1) % len(models)]
+        scene_settings.motion_model = next_model
+        print(f"🔄 Motion Model gewechselt: {current} → {next_model}")
+    except ValueError:
+        print(f"⚠️ Ungültiger Motion-Model-Wert: {current}")


### PR DESCRIPTION
## Summary
- add helper to switch the default motion model in a cycle
- expose the helper via `helpers` package

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688a157cbbf8832d9ee7ecff5594f822