### PR TITLE
Add helper for adjusting tracking channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,8 @@ Seit Version 1.199 werden NEW_-Marker nur noch im Schritt "Rename" von Track Nr.
 in TRACK_ umbenannt. Dabei wird ausschließlich das Präfix ersetzt.
 Seit Version 1.200 verfügt das Stufen-Panel über einen Button "Track", der den
 vollständigen Tracking-Ablauf mit adaptivem Threshold startet.
+Seit Version 1.201 kann über die Funktion `set_tracking_channels()` festgelegt
+werden, welche Farbkanäle beim Tracking berücksichtigt werden.
 
 ## Tracker Lifecycle & Naming
 

--- a/tracking-codex-remove-all-files-except-essential-ones/helpers/set_tracking_channels.py
+++ b/tracking-codex-remove-all-files-except-essential-ones/helpers/set_tracking_channels.py
@@ -1,0 +1,12 @@
+import bpy
+
+
+def set_tracking_channels(red: bool = True, green: bool = True, blue: bool = True) -> None:
+    """Set the RGB channels used for tracking operations."""
+    settings = bpy.context.scene.tracking_settings
+
+    settings.use_red_channel = red
+    settings.use_green_channel = green
+    settings.use_blue_channel = blue
+
+    print(f"\U0001F39A️ RGB-Kan\u00e4le gesetzt: R={red}, G={green}, B={blue}")


### PR DESCRIPTION
## Summary
- add `set_tracking_channels` helper module
- mention the new function in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688a165d5760832d966cb81419b3483d