### PR TITLE
Add basic test panels

### DIFF
--- a/operators/__init__.py
+++ b/operators/__init__.py
@@ -3,6 +3,16 @@ from .place_marker_operator import TRACKING_OT_place_marker
 from .cleanup_operator import CLIP_OT_cleanup_tracks
 from .test_marker_base_operator import TRACKING_OT_test_marker_base
 from .error_value_operator import CLIP_OT_error_value
+from .test_panel_operators import (
+    TRACKING_OT_test_cycle,
+    TRACKING_OT_test_base,
+    TRACKING_OT_test_place_marker,
+    TRACKING_OT_test_track_markers,
+    TRACKING_OT_test_error_value,
+    TRACKING_OT_test_tracking_lengths,
+    TRACKING_OT_test_cycle_motion,
+    TRACKING_OT_test_tracking_channels,
+)
 
 operator_classes = (
     TRACKING_OT_marker_basis_values,
@@ -10,4 +20,12 @@ operator_classes = (
     CLIP_OT_cleanup_tracks,
     TRACKING_OT_test_marker_base,
     CLIP_OT_error_value,
+    TRACKING_OT_test_cycle,
+    TRACKING_OT_test_base,
+    TRACKING_OT_test_place_marker,
+    TRACKING_OT_test_track_markers,
+    TRACKING_OT_test_error_value,
+    TRACKING_OT_test_tracking_lengths,
+    TRACKING_OT_test_cycle_motion,
+    TRACKING_OT_test_tracking_channels,
 )

--- a/operators/test_panel_operators.py
+++ b/operators/test_panel_operators.py
@@ -1,0 +1,77 @@
+import bpy
+
+
+class TRACKING_OT_test_cycle(bpy.types.Operator):
+    bl_idname = "tracking.test_cycle"
+    bl_label = "Test Cycle"
+
+    def execute(self, context):
+        return {'FINISHED'}
+
+
+class TRACKING_OT_test_base(bpy.types.Operator):
+    bl_idname = "tracking.test_base"
+    bl_label = "Test Base"
+
+    def execute(self, context):
+        return {'FINISHED'}
+
+
+class TRACKING_OT_test_place_marker(bpy.types.Operator):
+    bl_idname = "tracking.test_place_marker"
+    bl_label = "Place Marker"
+
+    def execute(self, context):
+        return {'FINISHED'}
+
+
+class TRACKING_OT_test_track_markers(bpy.types.Operator):
+    bl_idname = "tracking.test_track_markers"
+    bl_label = "Track Markers"
+
+    def execute(self, context):
+        return {'FINISHED'}
+
+
+class TRACKING_OT_test_error_value(bpy.types.Operator):
+    bl_idname = "tracking.test_error_value"
+    bl_label = "Error Value"
+
+    def execute(self, context):
+        return {'FINISHED'}
+
+
+class TRACKING_OT_test_tracking_lengths(bpy.types.Operator):
+    bl_idname = "tracking.test_tracking_lengths"
+    bl_label = "Tracking Lengths"
+
+    def execute(self, context):
+        return {'FINISHED'}
+
+
+class TRACKING_OT_test_cycle_motion(bpy.types.Operator):
+    bl_idname = "tracking.test_cycle_motion"
+    bl_label = "Cycle Motion"
+
+    def execute(self, context):
+        return {'FINISHED'}
+
+
+class TRACKING_OT_test_tracking_channels(bpy.types.Operator):
+    bl_idname = "tracking.test_tracking_channels"
+    bl_label = "Tracking Channels"
+
+    def execute(self, context):
+        return {'FINISHED'}
+
+
+operator_classes = (
+    TRACKING_OT_test_cycle,
+    TRACKING_OT_test_base,
+    TRACKING_OT_test_place_marker,
+    TRACKING_OT_test_track_markers,
+    TRACKING_OT_test_error_value,
+    TRACKING_OT_test_tracking_lengths,
+    TRACKING_OT_test_cycle_motion,
+    TRACKING_OT_test_tracking_channels,
+)

--- a/ui/panels/__init__.py
+++ b/ui/panels/__init__.py
@@ -1,5 +1,11 @@
 from .api_panel import TRACKING_PT_api_functions
+from .test_panel import (
+    TRACKING_PT_test,
+    TRACKING_PT_test_details,
+)
 
 panel_classes = (
     TRACKING_PT_api_functions,
+    TRACKING_PT_test,
+    TRACKING_PT_test_details,
 )

--- a/ui/panels/test_panel.py
+++ b/ui/panels/test_panel.py
@@ -1,0 +1,38 @@
+import bpy
+
+
+class TRACKING_PT_test(bpy.types.Panel):
+    bl_label = "Test"
+    bl_idname = "TRACKING_PT_test"
+    bl_space_type = 'CLIP_EDITOR'
+    bl_region_type = 'UI'
+    bl_category = "Tracking Tools"
+
+    def draw(self, context):
+        layout = self.layout
+        layout.operator("tracking.test_cycle", text="Test Cycle")
+
+
+class TRACKING_PT_test_details(bpy.types.Panel):
+    bl_label = "Test details"
+    bl_idname = "TRACKING_PT_test_details"
+    bl_space_type = 'CLIP_EDITOR'
+    bl_region_type = 'UI'
+    bl_category = "Tracking Tools"
+    bl_parent_id = "TRACKING_PT_test"
+
+    def draw(self, context):
+        layout = self.layout
+        layout.operator("tracking.test_base", text="Test Base")
+        layout.operator("tracking.test_place_marker", text="Place Marker")
+        layout.operator("tracking.test_track_markers", text="Track Markers")
+        layout.operator("tracking.test_error_value", text="Error Value")
+        layout.operator("tracking.test_tracking_lengths", text="Tracking Lengths")
+        layout.operator("tracking.test_cycle_motion", text="Cycle Motion")
+        layout.operator("tracking.test_tracking_channels", text="Tracking Channels")
+
+
+panel_classes = (
+    TRACKING_PT_test,
+    TRACKING_PT_test_details,
+)


### PR DESCRIPTION
## Summary
- add placeholder operators for a future test panel
- hook new operators into registration
- create a new Test panel with subpanel 'Test details'
- register the new panels

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688a1a290b78832d8d07ce0863a8e107