### PR TITLE
Refactor channel toggle into helper

### DIFF
--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -33,3 +33,4 @@ from .delete_tracks import delete_selected_tracks
 from .select_short_tracks import select_short_tracks
 from .find_low_marker_frame import find_next_low_marker_frame
 from .set_playhead_to_frame import set_playhead_to_frame
+from .set_tracking_channels import set_tracking_channels

--- a/helpers/set_tracking_channels.py
+++ b/helpers/set_tracking_channels.py
@@ -1,0 +1,12 @@
+import bpy
+
+
+def set_tracking_channels(clip, red=None, green=None, blue=None):
+    """Set default tracking channel flags on the given clip."""
+    settings = clip.tracking.settings
+    if red is not None:
+        settings.use_default_red_channel = red
+    if green is not None:
+        settings.use_default_green_channel = green
+    if blue is not None:
+        settings.use_default_blue_channel = blue

--- a/operators/setup_defaults.py
+++ b/operators/setup_defaults.py
@@ -1,4 +1,5 @@
 import bpy
+from ..helpers import set_tracking_channels
 
 class CLIP_OT_api_defaults(bpy.types.Operator):
     bl_idname = "clip.api_defaults"
@@ -20,9 +21,7 @@ class CLIP_OT_api_defaults(bpy.types.Operator):
         settings.default_pattern_match = 'KEYFRAME'
         settings.use_default_brute = True
         settings.use_default_normalization = True
-        settings.use_default_red_channel = True
-        settings.use_default_green_channel = True
-        settings.use_default_blue_channel = True
+        set_tracking_channels(clip, True, True, True)
         settings.default_weight = 1.0
         settings.default_correlation_min = 0.9
         settings.default_margin = 100

--- a/operators/test_setup_defaults.py
+++ b/operators/test_setup_defaults.py
@@ -1,5 +1,6 @@
 import bpy
 from bpy.props import BoolProperty
+from ..helpers import set_tracking_channels
 
 class CLIP_OT_setup_defaults(bpy.types.Operator):
     bl_idname = "clip.setup_defaults"
@@ -23,9 +24,7 @@ class CLIP_OT_setup_defaults(bpy.types.Operator):
         settings.default_pattern_match = 'KEYFRAME'
         settings.use_default_brute = True
         settings.use_default_normalization = True
-        settings.use_default_red_channel = True
-        settings.use_default_green_channel = True
-        settings.use_default_blue_channel = True
+        set_tracking_channels(clip, True, True, True)
 
         settings.default_weight = 1.0
         settings.default_correlation_min = 0.9

--- a/operators/tracking/solver.py
+++ b/operators/tracking/solver.py
@@ -10,6 +10,7 @@ from ...helpers.prefix_new import PREFIX_NEW
 from ...helpers.prefix_track import PREFIX_TRACK
 from ...helpers.prefix_good import PREFIX_GOOD
 from ...helpers.prefix_test import PREFIX_TEST
+from ...helpers import set_tracking_channels
 from ...helpers.select_track_tracks import select_track_tracks
 from ...helpers.select_new_tracks import select_new_tracks
 from ...helpers.feature_math import (
@@ -641,9 +642,7 @@ class CLIP_OT_motion_detect(bpy.types.Operator):
             "pattern_match", settings.default_pattern_match
         )
         r, g, b = TEST_SETTINGS.get("channels_active", (True, True, True))
-        settings.use_default_red_channel = r
-        settings.use_default_green_channel = g
-        settings.use_default_blue_channel = b
+        set_tracking_channels(clip, r, g, b)
 
         for model in MOTION_MODELS:
             settings.default_motion_model = model
@@ -717,11 +716,8 @@ class CLIP_OT_channel_detect(bpy.types.Operator):
         )
 
         for channels in CHANNEL_COMBOS:
-            (
-                settings.use_default_red_channel,
-                settings.use_default_green_channel,
-                settings.use_default_blue_channel,
-            ) = channels
+            r, g, b = channels
+            set_tracking_channels(clip, r, g, b)
             end_frame = _Test_detect_mm(self, context)
             if end_frame is None:
                 continue
@@ -735,11 +731,8 @@ class CLIP_OT_channel_detect(bpy.types.Operator):
                 best_end = end_frame
                 best_channels = channels
 
-        (
-            settings.use_default_red_channel,
-            settings.use_default_green_channel,
-            settings.use_default_blue_channel,
-        ) = best_channels
+        r, g, b = best_channels
+        set_tracking_channels(clip, r, g, b)
         TEST_END_FRAME = best_end
         TEST_SETTINGS["channels_active"] = best_channels
 
@@ -793,9 +786,7 @@ class CLIP_OT_apply_settings(bpy.types.Operator):
         channels = TEST_SETTINGS.get("channels_active")
         if channels:
             r, g, b = channels
-            settings.use_default_red_channel = r
-            settings.use_default_green_channel = g
-            settings.use_default_blue_channel = b
+            set_tracking_channels(clip, r, g, b)
 
         self.report({'INFO'}, "Gespeicherte Test Detect Werte gesetzt")
         return {'FINISHED'}
@@ -2106,7 +2097,7 @@ class CLIP_OT_channel_r_on(bpy.types.Operator):
             self.report({'WARNING'}, "Kein Clip geladen")
             return {'CANCELLED'}
 
-        clip.tracking.settings.use_default_red_channel = True
+        set_tracking_channels(clip, red=True)
         return {'FINISHED'}
 
 
@@ -2121,7 +2112,7 @@ class CLIP_OT_channel_r_off(bpy.types.Operator):
             self.report({'WARNING'}, "Kein Clip geladen")
             return {'CANCELLED'}
 
-        clip.tracking.settings.use_default_red_channel = False
+        set_tracking_channels(clip, red=False)
         return {'FINISHED'}
 
 
@@ -2136,7 +2127,7 @@ class CLIP_OT_channel_g_on(bpy.types.Operator):
             self.report({'WARNING'}, "Kein Clip geladen")
             return {'CANCELLED'}
 
-        clip.tracking.settings.use_default_green_channel = True
+        set_tracking_channels(clip, green=True)
         return {'FINISHED'}
 
 
@@ -2151,7 +2142,7 @@ class CLIP_OT_channel_g_off(bpy.types.Operator):
             self.report({'WARNING'}, "Kein Clip geladen")
             return {'CANCELLED'}
 
-        clip.tracking.settings.use_default_green_channel = False
+        set_tracking_channels(clip, green=False)
         return {'FINISHED'}
 
 
@@ -2166,7 +2157,7 @@ class CLIP_OT_channel_b_on(bpy.types.Operator):
             self.report({'WARNING'}, "Kein Clip geladen")
             return {'CANCELLED'}
 
-        clip.tracking.settings.use_default_blue_channel = True
+        set_tracking_channels(clip, blue=True)
         return {'FINISHED'}
 
 
@@ -2181,7 +2172,7 @@ class CLIP_OT_channel_b_off(bpy.types.Operator):
             self.report({'WARNING'}, "Kein Clip geladen")
             return {'CANCELLED'}
 
-        clip.tracking.settings.use_default_blue_channel = False
+        set_tracking_channels(clip, blue=False)
         return {'FINISHED'}
 
 


### PR DESCRIPTION
## Summary
- add `set_tracking_channels` helper to apply default color channels
- expose helper via `helpers.__init__`
- use the helper in solver and setup defaults operators

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bpy')*

------
https://chatgpt.com/codex/tasks/task_e_688a1b4ace94832db7ce4134478af104