### PR TITLE
Add proxy builder operator and helpers

### DIFF
--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -5,6 +5,8 @@ from .track_markers_until_end import track_markers_until_end
 from .get_tracking_lengths import get_tracking_lengths
 from .cycle_motion_model import cycle_motion_model
 from .set_tracking_channels import set_tracking_channels
+from .proxy_enable import enable_proxy
+from .proxy_disable import disable_proxy
 from .test_cyclus import (
     evaluate_tracking,
     find_optimal_pattern,

--- a/helpers/proxy_disable.py
+++ b/helpers/proxy_disable.py
@@ -1,0 +1,3 @@
+def disable_proxy(clip):
+    if clip:
+        clip.use_proxy = False

--- a/helpers/proxy_enable.py
+++ b/helpers/proxy_enable.py
@@ -1,0 +1,3 @@
+def enable_proxy(clip):
+    if clip:
+        clip.use_proxy = True

--- a/operators/__init__.py
+++ b/operators/__init__.py
@@ -3,6 +3,7 @@ from .place_marker_operator import TRACKING_OT_place_marker
 from .cleanup_operator import CLIP_OT_cleanup_tracks
 from .test_marker_base_operator import TRACKING_OT_test_marker_base
 from .error_value_operator import CLIP_OT_error_value
+from .proxy_builder import CLIP_OT_proxy_build
 from .test_panel_operators import (
     TRACKING_OT_test_cycle,
     TRACKING_OT_test_base,
@@ -28,4 +29,5 @@ operator_classes = (
     TRACKING_OT_test_tracking_lengths,
     TRACKING_OT_test_cycle_motion,
     TRACKING_OT_test_tracking_channels,
+    CLIP_OT_proxy_build,
 )

--- a/operators/proxy_builder.py
+++ b/operators/proxy_builder.py
@@ -1,0 +1,36 @@
+import bpy
+import os
+import shutil
+
+
+class CLIP_OT_proxy_build(bpy.types.Operator):
+    bl_idname = "clip.proxy_build"
+    bl_label = "Proxy erstellen (50%)"
+    bl_description = "Erstellt Proxy-Dateien mit 50% Größe"
+
+    def execute(self, context):
+        clip = getattr(context.space_data, "clip", None)
+        if clip is None:
+            self.report({'WARNING'}, "Kein aktiver Movie Clip gefunden.")
+            return {'CANCELLED'}
+
+        clip.use_proxy = True
+        clip.proxy.build_25 = False
+        clip.proxy.build_50 = True
+        clip.proxy.build_75 = False
+        clip.proxy.build_100 = False
+        clip.proxy.quality = 50
+        clip.proxy.directory = "//proxies"
+
+        proxy_dir = bpy.path.abspath(clip.proxy.directory)
+        project_dir = bpy.path.abspath("//")
+        if os.path.abspath(proxy_dir).startswith(os.path.abspath(project_dir)):
+            if os.path.exists(proxy_dir):
+                try:
+                    shutil.rmtree(proxy_dir)
+                except Exception as e:
+                    self.report({'WARNING'}, f"Fehler beim Löschen des Proxy-Verzeichnisses: {e}")
+
+        bpy.ops.clip.rebuild_proxy()
+        self.report({'INFO'}, "Proxy auf 50% erstellt")
+        return {'FINISHED'}


### PR DESCRIPTION
## Summary
- add CLIP_OT_proxy_build operator for rebuilding proxies
- register proxy builder operator
- add enable_proxy and disable_proxy helper functions
- expose new helpers from helpers package

## Testing
- `python -m py_compile operators/*.py helpers/*.py properties/*.py ui/panels/*.py`

------
https://chatgpt.com/codex/tasks/task_e_688a1d4caf40832dadeb2884450f59f3