### PR TITLE
Move test_marker_base_operator to helpers

### DIFF
--- a/helpers/test_marker_base_operator.py
+++ b/helpers/test_marker_base_operator.py
@@ -1,5 +1,5 @@
 import bpy
-from ..helpers.test_marker_base import test_marker_base
+from .test_marker_base import test_marker_base
 
 
 class TRACKING_OT_test_marker_base(bpy.types.Operator):

--- a/operators/__init__.py
+++ b/operators/__init__.py
@@ -1,7 +1,7 @@
 from .tracking_marker_basis_operator import TRACKING_OT_marker_basis_values
 from .place_marker_operator import TRACKING_OT_place_marker
 from .cleanup_operator import CLIP_OT_cleanup_tracks
-from .test_marker_base_operator import TRACKING_OT_test_marker_base
+from ..helpers.test_marker_base_operator import TRACKING_OT_test_marker_base
 from .error_value_operator import CLIP_OT_error_value
 from .test_panel_operators import (
     TRACKING_OT_test_cycle,


### PR DESCRIPTION
## Summary
- relocate `test_marker_base_operator` into the helpers package
- update operator imports

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688a1e02ed14832da525a25decc1859f