### PR TITLE
Add proxy button to UI panel

### DIFF
--- a/ui/panels/api_panel.py
+++ b/ui/panels/api_panel.py
@@ -13,6 +13,7 @@ class TRACKING_PT_api_functions(bpy.types.Panel):
         layout.prop(context.scene, 'marker_basis', text='Marker/Frame')
         layout.prop(context.scene, 'frames_per_track', text='Frames/Track')
         layout.prop(context.scene, 'error_per_track', text='Error/Track')
+        layout.operator('clip.proxy_build', text='Proxy')
         layout.operator('tracking.marker_basis_values')
         layout.operator('tracking.place_marker')
         layout.operator('tracking.set_default_settings', text='Track Default')


### PR DESCRIPTION
## Summary
- add Proxy button to the API panel above existing buttons

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688a1f0ac6d0832d96872577b5e487b0