### PR TITLE
Link test buttons to helpers

### DIFF
--- a/operators/test_panel_operators.py
+++ b/operators/test_panel_operators.py
@@ -1,11 +1,25 @@
 import bpy
 
+from ..helpers import (
+    run_tracking_optimization,
+    track_markers_until_end,
+    get_tracking_lengths,
+    cycle_motion_model,
+    set_tracking_channels,
+)
+from ..helpers.test_cyclus import error_value
+
 
 class TRACKING_OT_test_cycle(bpy.types.Operator):
     bl_idname = "tracking.test_cycle"
     bl_label = "Test Cycle"
 
     def execute(self, context):
+        result = run_tracking_optimization(context)
+        self.report(
+            {'INFO'},
+            f"pattern={result.get('pattern')} motion={result.get('motion')} channels={result.get('channels')}"
+        )
         return {'FINISHED'}
 
 
@@ -30,6 +44,8 @@ class TRACKING_OT_test_track_markers(bpy.types.Operator):
     bl_label = "Track Markers"
 
     def execute(self, context):
+        track_markers_until_end()
+        self.report({'INFO'}, "Tracking gestartet")
         return {'FINISHED'}
 
 
@@ -38,6 +54,8 @@ class TRACKING_OT_test_error_value(bpy.types.Operator):
     bl_label = "Error Value"
 
     def execute(self, context):
+        value = error_value(context)
+        self.report({'INFO'}, f"Error: {value:.4f}")
         return {'FINISHED'}
 
 
@@ -46,6 +64,13 @@ class TRACKING_OT_test_tracking_lengths(bpy.types.Operator):
     bl_label = "Tracking Lengths"
 
     def execute(self, context):
+        lengths = get_tracking_lengths()
+        if not lengths:
+            self.report({'WARNING'}, "Keine Tracks ausgewählt")
+        else:
+            for name, data in lengths.items():
+                print(f"{name}: {data['length']} Frames")
+            self.report({'INFO'}, "Längen ausgegeben")
         return {'FINISHED'}
 
 
@@ -54,6 +79,8 @@ class TRACKING_OT_test_cycle_motion(bpy.types.Operator):
     bl_label = "Cycle Motion"
 
     def execute(self, context):
+        cycle_motion_model()
+        self.report({'INFO'}, "Motion Model gewechselt")
         return {'FINISHED'}
 
 
@@ -62,6 +89,8 @@ class TRACKING_OT_test_tracking_channels(bpy.types.Operator):
     bl_label = "Tracking Channels"
 
     def execute(self, context):
+        set_tracking_channels()
+        self.report({'INFO'}, "Tracking-Kanäle gesetzt")
         return {'FINISHED'}
 
 


### PR DESCRIPTION
## Summary
- wire up test operators with their corresponding helper functions
- report results for each helper call

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a32127200832da0cb0c3b1cbcf84f