### PR TITLE
Fix property name in marker base helper

### DIFF
--- a/helpers/test_marker_base.py
+++ b/helpers/test_marker_base.py
@@ -5,7 +5,7 @@ def test_marker_base(context):
     """Berechnet Marker-Basiswerte aus dem Eingabefeld 'marker/Frame'."""
 
     scene = context.scene
-    marker_basis = scene.get("marker_per_frame", 12)
+    marker_basis = scene.get("marker_basis", 12)
 
     marker_plus = marker_basis / 3
     marker_adapt = marker_plus


### PR DESCRIPTION
## Summary
- fix inconsistent property name in `test_marker_base`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_688a338dedcc832db6c1eeed537f6f1c