### PR TITLE
Add marker valuation operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ Seit Version 1.199 werden NEW_-Marker nur noch im Schritt "Rename" von Track Nr.
 in TRACK_ umbenannt. Dabei wird ausschließlich das Präfix ersetzt.
 Seit Version 1.200 besitzt das Stufen-Panel einen Button "Cleanup Tracks", der
 das Skript `cleanup_operator` ausführt.
+Seit Version 1.201 startet der Operator "Marker Valurierung" einen Tracking-Zyklus, wenn zu wenige Marker vorhanden sind.
 
 ## Tracker Lifecycle & Naming
 

--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -39,3 +39,9 @@ from .error_value_operator import (
     calculate_clip_error,
     operator_classes as error_value_operator_classes,
 )
+from .test_marker_base import test_marker_base
+from .place_marker_operator import place_marker_operator
+from .track_markers_until_end import track_markers_until_end
+from .error_value import error_value
+from .get_tracking_lengths import get_tracking_lengths
+from .set_tracking_channels import set_tracking_channels

--- a/helpers/error_value.py
+++ b/helpers/error_value.py
@@ -1,0 +1,6 @@
+from .error_value_operator import calculate_clip_error
+
+
+def error_value(clip):
+    """Return summed error of all marker positions."""
+    return calculate_clip_error(clip)

--- a/helpers/get_tracking_lengths.py
+++ b/helpers/get_tracking_lengths.py
@@ -1,0 +1,9 @@
+
+def get_tracking_lengths(clip):
+    """Return a list with the length of each track in frames."""
+    lengths = []
+    for track in clip.tracking.tracks:
+        frames = [m.frame for m in track.markers if not m.mute and m.co.length_squared != 0.0]
+        if frames:
+            lengths.append(max(frames) - min(frames) + 1)
+    return lengths

--- a/helpers/place_marker_operator.py
+++ b/helpers/place_marker_operator.py
@@ -1,0 +1,9 @@
+import bpy
+
+
+def place_marker_operator(frame=None):
+    """Add a marker on all selected tracks at the given frame."""
+    if frame is not None:
+        bpy.context.scene.frame_current = frame
+    if bpy.ops.clip.add_marker_slide.poll():
+        bpy.ops.clip.add_marker_slide()

--- a/helpers/set_tracking_channels.py
+++ b/helpers/set_tracking_channels.py
@@ -1,0 +1,6 @@
+
+def set_tracking_channels(settings, red=True, green=True, blue=True):
+    """Set active color channels for tracking settings."""
+    settings.use_default_red_channel = red
+    settings.use_default_green_channel = green
+    settings.use_default_blue_channel = blue

--- a/helpers/test_marker_base.py
+++ b/helpers/test_marker_base.py
@@ -1,0 +1,6 @@
+import bpy
+
+
+def test_marker_base(scene):
+    """Return marker target value for the scene."""
+    return getattr(scene, "marker_frame", 0)

--- a/helpers/track_markers_until_end.py
+++ b/helpers/track_markers_until_end.py
@@ -1,0 +1,14 @@
+import bpy
+
+
+def track_markers_until_end(scene, backwards=False):
+    """Track selected markers from the current frame until the scene end."""
+    start = scene.frame_current
+    end = scene.frame_end
+    original_start = scene.frame_start
+    original_end = scene.frame_end
+    scene.frame_start = start
+    scene.frame_end = end
+    bpy.ops.clip.track_markers(backwards=backwards, sequence=True)
+    scene.frame_start = original_start
+    scene.frame_end = original_end

--- a/operators/__init__.py
+++ b/operators/__init__.py
@@ -6,6 +6,7 @@ from . import (
     cleanup_operator,
     test_setup_defaults,
     test_variants,
+    marker_valurierung,
 )
 
 from ..helpers import (
@@ -22,4 +23,5 @@ operator_classes = (
     *test_variants.operator_classes,
     *track_default_settings.operator_classes,
     *error_value_operator.operator_classes,
+    *marker_valurierung.operator_classes,
 )

--- a/operators/marker_valurierung.py
+++ b/operators/marker_valurierung.py
@@ -1,0 +1,62 @@
+import bpy
+
+from ..helpers import (
+    test_marker_base,
+    place_marker_operator,
+    track_markers_until_end,
+    error_value,
+    get_tracking_lengths,
+    cycle_motion_model,
+    set_tracking_channels,
+)
+
+
+class CLIP_OT_marker_valurierung(bpy.types.Operator):
+    bl_idname = "clip.marker_valurierung"
+    bl_label = "Marker Valurierung"
+    bl_description = (
+        "Pr\u00fcft die Markeranzahl pro Frame und startet bei Bedarf einen Tracking-Zyklus"
+    )
+
+    _repeat: int = 0
+
+    def execute(self, context):
+        scene = context.scene
+        clip = context.space_data.clip
+        if clip is None:
+            self.report({'WARNING'}, "Kein Clip geladen")
+            return {'CANCELLED'}
+
+        threshold = test_marker_base(scene)
+
+        for frame in range(scene.frame_start, scene.frame_end + 1):
+            scene.frame_current = frame
+            count = sum(
+                1
+                for t in clip.tracking.tracks
+                if not t.hide
+                and (m := t.markers.find_frame(frame))
+                and not m.mute
+                and m.co.length_squared != 0.0
+            )
+            if count < threshold:
+                self._repeat += 1
+                if self._repeat >= 10:
+                    cycle_motion_model(clip.tracking.settings, clip, reset_size=False)
+                    set_tracking_channels(clip.tracking.settings, True, True, True)
+                    place_marker_operator(frame)
+                    track_markers_until_end(scene)
+                    err = error_value(clip)
+                    lengths = get_tracking_lengths(clip)
+                    print(
+                        f"[Marker Valurierung] L\u00e4ngen={lengths} Error={err:.4f}"
+                    )
+                    self._repeat = 0
+            else:
+                self._repeat = 0
+        return {'FINISHED'}
+
+
+operator_classes = (
+    CLIP_OT_marker_valurierung,
+)

--- a/ui/panels/test_panels.py
+++ b/ui/panels/test_panels.py
@@ -74,6 +74,11 @@ class CLIP_PT_test_detail_panel(bpy.types.Panel):
         layout.operator('clip.prefix_test', text='TEST Name')
         layout.operator('clip.select_test_tracks', text='TEST select')
         layout.operator('clip.error_value', text='Error Value')
+        layout.operator(
+            'clip.marker_valurierung',
+            text='Marker Valuierung',
+            icon='VIEWZOOM'
+        )
 
 
 panel_classes = (


### PR DESCRIPTION
## Summary
- add marker valuation helper functions and expose them in helpers
- implement `CLIP_OT_marker_valurierung` operator
- register the new operator
- hook operator into the test panel UI
- document Marker Valurierung operator

## Testing
- `python -m py_compile $(git ls-files "*.py")`


------
https://chatgpt.com/codex/tasks/task_e_688a35acd2e8832dab2e83d009326654