### PR TITLE
Implement marker valurierung operator

### DIFF
--- a/operators/__init__.py
+++ b/operators/__init__.py
@@ -8,6 +8,7 @@ from .proxy_toggle_operators import (
     CLIP_OT_proxy_enable,
     CLIP_OT_proxy_disable,
 )
+from .marker_valurierung import CLIP_OT_marker_valurierung
 from .test_panel_operators import (
     TRACKING_OT_test_cycle,
     TRACKING_OT_test_base,
@@ -36,4 +37,5 @@ operator_classes = (
     CLIP_OT_proxy_build,
     CLIP_OT_proxy_enable,
     CLIP_OT_proxy_disable,
+    CLIP_OT_marker_valurierung,
 )

--- a/operators/marker_valurierung.py
+++ b/operators/marker_valurierung.py
@@ -1,0 +1,53 @@
+import bpy
+
+from ..helpers.test_marker_base import test_marker_base
+from .place_marker_operator import TRACKING_OT_place_marker
+from ..helpers.track_markers_until_end import track_markers_until_end
+from .error_value_operator import error_value
+from ..helpers.get_tracking_lengths import get_tracking_lengths
+from ..helpers.cycle_motion_model import cycle_motion_model
+from ..helpers.set_tracking_channels import set_tracking_channels
+from ..helpers.test_cyclus import run_tracking_optimization
+
+
+class CLIP_OT_marker_valurierung(bpy.types.Operator):
+    """Validiert die Markeranzahl pro Frame."""
+
+    bl_idname = "clip.marker_valurierung"
+    bl_label = "Marker Valurierung"
+    bl_description = "\u00dcberpr\u00fcft die Markeranzahl pro Frame und startet bei Bedarf den Tracking-Zyklus"
+
+    def execute(self, context):
+        scene = context.scene
+        clip = context.space_data.clip
+        if clip is None:
+            self.report({"WARNING"}, "Kein Clip geladen")
+            return {"CANCELLED"}
+
+        values = test_marker_base(context)
+        min_marker = int(values.get("min_marker", 0))
+
+        repeat = 0
+        start = scene.frame_start
+        end = scene.frame_end
+
+        for frame in range(start, end + 1):
+            scene.frame_set(frame)
+            count = 0
+            for track in clip.tracking.tracks:
+                marker = track.markers.find_frame(frame, exact=True)
+                if marker and not marker.mute:
+                    count += 1
+
+            if count < min_marker:
+                repeat += 1
+            else:
+                repeat = 0
+
+            if repeat >= 10:
+                self.report({"INFO"}, "Starte Tracking-Zyklus")
+                run_tracking_optimization(context)
+                repeat = 0
+
+        self.report({"INFO"}, "Marker Valuierung abgeschlossen")
+        return {"FINISHED"}

--- a/ui/panels/api_panel.py
+++ b/ui/panels/api_panel.py
@@ -4,20 +4,25 @@ import bpy
 class TRACKING_PT_api_functions(bpy.types.Panel):
     bl_label = "API Funktionen"
     bl_idname = "TRACKING_PT_api_functions"
-    bl_space_type = 'CLIP_EDITOR'
-    bl_region_type = 'UI'
+    bl_space_type = "CLIP_EDITOR"
+    bl_region_type = "UI"
     bl_category = "Tracking Tools"
 
     def draw(self, context):
         layout = self.layout
-        layout.prop(context.scene, 'marker_basis', text='Marker/Frame')
-        layout.prop(context.scene, 'frames_per_track', text='Frames/Track')
-        layout.prop(context.scene, 'error_per_track', text='Error/Track')
-        layout.operator('clip.proxy_build', text='Proxy')
-        layout.operator('clip.proxy_disable', text='Proxy off')
-        layout.operator('tracking.marker_basis_values')
-        layout.operator('tracking.place_marker')
-        layout.operator('clip.proxy_enable', text='Proxy on')
-        layout.operator('tracking.set_default_settings', text='Track Default')
-        layout.operator('tracking.bidirectional_tracking')
+        layout.prop(context.scene, "marker_basis", text="Marker/Frame")
+        layout.prop(context.scene, "frames_per_track", text="Frames/Track")
+        layout.prop(context.scene, "error_per_track", text="Error/Track")
+        layout.operator("clip.proxy_build", text="Proxy")
+        layout.operator("clip.proxy_disable", text="Proxy off")
+        layout.operator("tracking.marker_basis_values")
+        layout.operator("tracking.place_marker")
+        layout.operator("clip.proxy_enable", text="Proxy on")
+        layout.operator("tracking.set_default_settings", text="Track Default")
+        layout.operator("tracking.bidirectional_tracking")
         layout.operator("clip.cleanup_tracks", text="Cleanup Tracks")
+        layout.operator(
+            "clip.marker_valurierung",
+            text="Marker Valuierung",
+            icon="VIEWZOOM",
+        )


### PR DESCRIPTION
## Summary
- add `CLIP_OT_marker_valurierung` operator to validate marker count over frames
- register new operator
- expose operator in API panel UI

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688a3d2b3444832daa15880028ed647b