### PR TITLE
Add low_marker_frame helper

### DIFF
--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -14,3 +14,4 @@ from .test_cyclus import (
     find_best_channel_combination,
     run_tracking_optimization,
 )
+from .low_marker_frame import low_marker_frame

--- a/helpers/low_marker_frame.py
+++ b/helpers/low_marker_frame.py
@@ -1,0 +1,27 @@
+import bpy
+
+
+def low_marker_frame(
+    scene: bpy.types.Scene, clip: bpy.types.MovieClip, threshold: int
+) -> list[tuple[int, int]]:
+    """Return frames with too few unmuted markers.
+
+    Each tuple in the returned list consists of the frame number and the
+    detected marker count for that frame.
+    """
+    if clip is None:
+        return []
+
+    low_marker_frames: list[tuple[int, int]] = []
+
+    for frame in range(scene.frame_start, scene.frame_end + 1):
+        count = 0
+        for track in clip.tracking.tracks:
+            marker = track.markers.find_frame(frame, exact=True)
+            if marker and not marker.mute:
+                count += 1
+
+        if count < threshold:
+            low_marker_frames.append((frame, count))
+
+    return low_marker_frames


### PR DESCRIPTION
## Summary
- add helper to list frames with few markers
- export low_marker_frame via helpers package
- expand helper to return marker count per frame

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bpy')*

------
https://chatgpt.com/codex/tasks/task_e_688a3bef3090832da4f908439cfccb50