### PR TITLE
Add Low Marker Frame button

### DIFF
--- a/operators/__init__.py
+++ b/operators/__init__.py
@@ -1,6 +1,7 @@
 from .tracking_marker_basis_operator import TRACKING_OT_marker_basis_values
 from .place_marker_operator import TRACKING_OT_place_marker
 from .cleanup_operator import CLIP_OT_cleanup_tracks
+from .low_marker_frame_operator import CLIP_OT_low_marker_frame
 from ..helpers.test_marker_base_operator import TRACKING_OT_test_marker_base
 from .error_value_operator import CLIP_OT_error_value
 from .proxy_builder import CLIP_OT_proxy_build
@@ -24,6 +25,7 @@ operator_classes = (
     TRACKING_OT_marker_basis_values,
     TRACKING_OT_place_marker,
     CLIP_OT_cleanup_tracks,
+    CLIP_OT_low_marker_frame,
     TRACKING_OT_test_marker_base,
     CLIP_OT_error_value,
     TRACKING_OT_test_cycle,

--- a/operators/low_marker_frame_operator.py
+++ b/operators/low_marker_frame_operator.py
@@ -1,0 +1,30 @@
+import bpy
+
+from ..helpers.low_marker_frame import low_marker_frame
+
+
+class CLIP_OT_low_marker_frame(bpy.types.Operator):
+    """Springt zum ersten Frame mit zu wenigen Markern"""
+
+    bl_idname = "clip.low_marker_frame"
+    bl_label = "Low Marker Frame"
+    bl_description = "Springe zum ersten Frame mit weniger Markern als Marker/Frame"
+
+    @classmethod
+    def poll(cls, context):
+        return context.space_data and context.space_data.clip
+
+    def execute(self, context):
+        scene = context.scene
+        clip = context.space_data.clip
+        threshold = scene.get("marker_basis", 20)
+
+        frames = low_marker_frame(scene, clip, threshold)
+        if not frames:
+            self.report({'INFO'}, "Kein Frame mit zu wenigen Markern gefunden")
+            return {'CANCELLED'}
+
+        frame, count = frames[0]
+        scene.frame_set(frame)
+        self.report({'INFO'}, f"Frame {frame} mit {count} Markern")
+        return {'FINISHED'}

--- a/ui/panels/api_panel.py
+++ b/ui/panels/api_panel.py
@@ -21,6 +21,7 @@ class TRACKING_PT_api_functions(bpy.types.Panel):
         layout.operator("tracking.set_default_settings", text="Track Default")
         layout.operator("tracking.bidirectional_tracking")
         layout.operator("clip.cleanup_tracks", text="Cleanup Tracks")
+        layout.operator("clip.low_marker_frame", text="Low Marker Frame")
         layout.operator(
             "clip.marker_valurierung",
             text="Marker Valuierung",


### PR DESCRIPTION
## Summary
- add Low Marker Frame operator to jump to frames with too few markers
- register new operator
- expose new operator in API panel after Cleanup Tracks

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688a413f6fb8832daee08b42b4c256d7