### PR TITLE
Fix import of error_value

### DIFF
--- a/operators/error_value_operator.py
+++ b/operators/error_value_operator.py
@@ -41,3 +41,7 @@ class CLIP_OT_error_value(Operator):
         print(f"[Error Value] error_x={error_x:.6f}, error_y={error_y:.6f}, total={total_error:.6f}")
 
         return {'FINISHED'}
+
+
+# Alias for backward compatibility
+error_value = CLIP_OT_error_value

--- a/operators/marker_valurierung.py
+++ b/operators/marker_valurierung.py
@@ -3,7 +3,7 @@ import bpy
 from ..helpers.test_marker_base import test_marker_base
 from .place_marker_operator import TRACKING_OT_place_marker
 from ..helpers.track_markers_until_end import track_markers_until_end
-from .error_value_operator import error_value
+from .error_value_operator import CLIP_OT_error_value
 from ..helpers.get_tracking_lengths import get_tracking_lengths
 from ..helpers.cycle_motion_model import cycle_motion_model
 from ..helpers.set_tracking_channels import set_tracking_channels


### PR DESCRIPTION
## Summary
- update import of `CLIP_OT_error_value`
- alias `error_value` to `CLIP_OT_error_value` for backwards compatibility

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688a43b1bf00832d81f88485e2108c05