### PR TITLE
Register error threshold property

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -27,6 +27,12 @@ def register():
     if bpy is None:
         return
     register_properties()
+    bpy.types.Scene.error_threshold = bpy.props.FloatProperty(
+        name="Fehlertoleranz",
+        description="Maximal erlaubter Trackingfehler",
+        default=0.1,
+        min=0.0,
+    )
     for cls in classes:
         bpy.utils.register_class(cls)
 
@@ -36,6 +42,8 @@ def unregister():
         return
     for cls in reversed(classes):
         bpy.utils.unregister_class(cls)
+    if hasattr(bpy.types.Scene, "error_threshold"):
+        del bpy.types.Scene.error_threshold
     unregister_properties()
 
 


### PR DESCRIPTION
## Summary
- register a new `error_threshold` scene property

## Testing
- `BLENDER_TEST=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'bpy')*

------
https://chatgpt.com/codex/tasks/task_e_688a60d7a090832d9aee022ac0032734