### PR TITLE
Add tracking feedback popup

### DIFF
--- a/operators/__init__.py
+++ b/operators/__init__.py
@@ -10,6 +10,7 @@ from .proxy_toggle_operators import (
     CLIP_OT_proxy_disable,
 )
 from .marker_validierung import CLIP_OT_marker_valurierung
+from ..ui.ui_helpers import CLIP_OT_marker_status_popup
 from .bidirectional_tracking_operator import TRACKING_OT_bidirectional_tracking
 from .track_default_settings import TRACKING_OT_set_default_settings
 from .test_panel_operators import (
@@ -44,4 +45,5 @@ operator_classes = (
     TRACKING_OT_bidirectional_tracking,
     TRACKING_OT_set_default_settings,
     CLIP_OT_marker_valurierung,
+    CLIP_OT_marker_status_popup,
 )

--- a/operators/place_marker_operator.py
+++ b/operators/place_marker_operator.py
@@ -59,6 +59,16 @@ class TRACKING_OT_place_marker(bpy.types.Operator):
             selected_tracks = [t for t in tracking.tracks if t.select]
             anzahl_neu = len(selected_tracks)
 
+            meldung = f"Versuch {attempt + 1}:\nGesetzte Marker: {anzahl_neu}"
+            if anzahl_neu < min_marker:
+                meldung += "\nMarkeranzahl zu niedrig.\nMarker werden gel\u00f6scht."
+            elif anzahl_neu > max_marker:
+                meldung += "\nMarkeranzahl ausreichend. Vorgang wird beendet."
+            else:
+                meldung += "\nMarkeranzahl im mittleren Bereich.\nErneuter Versuch folgt."
+
+            bpy.ops.clip.marker_status_popup('INVOKE_DEFAULT', message=meldung)
+
             if anzahl_neu > min_marker:
                 if anzahl_neu > max_marker:
                     self.report({'INFO'}, f"Marker erfolgreich gesetzt: {anzahl_neu}")

--- a/ui/ui_helpers.py
+++ b/ui/ui_helpers.py
@@ -1,0 +1,24 @@
+import bpy
+
+
+class CLIP_OT_marker_status_popup(bpy.types.Operator):
+    """Zeigt Statusmeldungen zum Tracking als Popup"""
+
+    bl_idname = "clip.marker_status_popup"
+    bl_label = "Tracking Feedback"
+
+    message: bpy.props.StringProperty()
+
+    def execute(self, context):
+        return {'FINISHED'}
+
+    def invoke(self, context, event):
+        wm = context.window_manager
+        return wm.invoke_popup(self, width=300)
+
+    def draw(self, context):
+        layout = self.layout
+        layout.label(text="🔍 Tracking Feedback:")
+        for line in self.message.split("\n"):
+            layout.label(text=line)
+


### PR DESCRIPTION
## Summary
- add `CLIP_OT_marker_status_popup` in `ui_helpers.py`
- register the new popup operator
- display a feedback popup during `TRACKING_OT_place_marker` execution

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688a7a9d15bc832d996b9523aba84239