### PR TITLE
Fix clip tracking context

### DIFF
--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -15,3 +15,4 @@ from .test_cyclus import (
     run_tracking_optimization,
 )
 from .low_marker_frame import low_marker_frame
+from .invoke_clip_operator_safely import invoke_clip_operator_safely

--- a/helpers/invoke_clip_operator_safely.py
+++ b/helpers/invoke_clip_operator_safely.py
@@ -1,0 +1,14 @@
+import bpy
+
+
+def invoke_clip_operator_safely(operator: str, **kwargs):
+    """Call a clip operator with a valid CLIP_EDITOR context."""
+    for window in bpy.context.window_manager.windows:
+        for area in window.screen.areas:
+            if area.type == 'CLIP_EDITOR':
+                for region in area.regions:
+                    if region.type == 'WINDOW':
+                        with bpy.context.temp_override(window=window, area=area, region=region):
+                            return getattr(bpy.ops.clip, operator)(**kwargs)
+    print(f"\u274c Kein g\u00fcltiger CLIP_EDITOR-Kontext f\u00fcr {operator}")
+    return {'CANCELLED'}

--- a/operators/bidirectional_tracking_operator.py
+++ b/operators/bidirectional_tracking_operator.py
@@ -1,4 +1,5 @@
 import bpy
+from ..helpers import invoke_clip_operator_safely
 
 
 class TrackingController:
@@ -25,16 +26,22 @@ class TrackingController:
 
     def run(self):
         if self.step == 0:
-            bpy.ops.clip.track_markers(
-                "INVOKE_DEFAULT", backwards=False, sequence=True
+            invoke_clip_operator_safely(
+                "track_markers",
+                invoke="INVOKE_DEFAULT",
+                backwards=False,
+                sequence=True,
             )
             self.step = 1
         elif self.step == 1:
             if self.is_tracking_done():
                 self.step = 2
         elif self.step == 2:
-            bpy.ops.clip.track_markers(
-                "INVOKE_DEFAULT", backwards=True, sequence=True
+            invoke_clip_operator_safely(
+                "track_markers",
+                invoke="INVOKE_DEFAULT",
+                backwards=True,
+                sequence=True,
             )
             self.step = 3
         elif self.step == 3:


### PR DESCRIPTION
## Summary
- add helper to safely invoke clip ops with context override
- use helper for tracking in timer callback

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688a87201e04832d8b6e12e420506322