### PR TITLE
Update invoke_clip_operator helper

### DIFF
--- a/helpers/invoke_clip_operator_safely.py
+++ b/helpers/invoke_clip_operator_safely.py
@@ -1,14 +1,27 @@
 import bpy
 
 
-def invoke_clip_operator_safely(operator: str, **kwargs):
-    """Call a clip operator with a valid CLIP_EDITOR context."""
-    for window in bpy.context.window_manager.windows:
+def invoke_clip_operator_safely(operator_name: str, **kwargs):
+    """Call ``bpy.ops.clip.<operator_name>('INVOKE_DEFAULT', ...)`` in a valid
+    ``CLIP_EDITOR`` context.
+    """
+    wm = bpy.context.window_manager
+
+    for window in wm.windows:
         for area in window.screen.areas:
-            if area.type == 'CLIP_EDITOR':
+            if area.type == "CLIP_EDITOR":
                 for region in area.regions:
-                    if region.type == 'WINDOW':
-                        with bpy.context.temp_override(window=window, area=area, region=region):
-                            return getattr(bpy.ops.clip, operator)(**kwargs)
-    print(f"\u274c Kein g\u00fcltiger CLIP_EDITOR-Kontext f\u00fcr {operator}")
-    return {'CANCELLED'}
+                    if region.type == "WINDOW":
+                        with bpy.context.temp_override(
+                            window=window,
+                            area=area,
+                            region=region,
+                        ):
+                            return getattr(bpy.ops.clip, operator_name)(
+                                "INVOKE_DEFAULT", **kwargs
+                            )
+
+    print(
+        f"[WARNUNG] Kein g\u00fcltiger CLIP_EDITOR-Kontext gefunden f\u00fcr {operator_name}"
+    )
+    return {"CANCELLED"}

--- a/helpers/track_markers_until_end.py
+++ b/helpers/track_markers_until_end.py
@@ -1,5 +1,7 @@
 import bpy
 
+from .invoke_clip_operator_safely import invoke_clip_operator_safely
+
 
 def track_markers_until_end() -> None:
     """Track selected markers forward until the end frame."""
@@ -11,8 +13,8 @@ def track_markers_until_end() -> None:
         print("❌ Kein Clip aktiv oder falscher Editor.")
         return
 
-    result = bpy.ops.clip.track_markers(
-        'INVOKE_DEFAULT',
+    result = invoke_clip_operator_safely(
+        "track_markers",
         backwards=False,
         sequence=True,
     )

--- a/operators/bidirectional_tracking_operator.py
+++ b/operators/bidirectional_tracking_operator.py
@@ -28,7 +28,6 @@ class TrackingController:
         if self.step == 0:
             invoke_clip_operator_safely(
                 "track_markers",
-                invoke="INVOKE_DEFAULT",
                 backwards=False,
                 sequence=True,
             )
@@ -39,7 +38,6 @@ class TrackingController:
         elif self.step == 2:
             invoke_clip_operator_safely(
                 "track_markers",
-                invoke="INVOKE_DEFAULT",
                 backwards=True,
                 sequence=True,
             )


### PR DESCRIPTION
## Summary
- update invoke_clip_operator_safely implementation
- use the helper in track_markers_until_end
- adjust bidirectional_tracking_operator to use new signature

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688a88d9f2a8832dbe7981b92d2e89ef