### PR TITLE
Fix delete_track context

### DIFF
--- a/operators/bidirectional_tracking_operator.py
+++ b/operators/bidirectional_tracking_operator.py
@@ -1,5 +1,5 @@
 import bpy
-from ..helpers import invoke_clip_operator_safely
+from ..helpers.invoke_clip_operator_safely import invoke_clip_operator_safely
 
 
 class TrackingController:
@@ -69,7 +69,7 @@ class TrackingController:
         if short_tracks:
             for t in short_tracks:
                 t.select = True
-            bpy.ops.clip.delete_track()
+            invoke_clip_operator_safely("delete_track")
             print(f"{len(short_tracks)} kurze Tracks gel\u00f6scht (< {min_length} Frames).")
         else:
             print("Keine kurzen Tracks gefunden.")


### PR DESCRIPTION
## Summary
- ensure delete_track operator is invoked with valid CLIP_EDITOR context
- import invoke_clip_operator_safely directly from helpers

## Testing
- `python -m py_compile operators/bidirectional_tracking_operator.py`

------
https://chatgpt.com/codex/tasks/task_e_688a8b0ede98832da804f2ca010d81da