### PR TITLE
Add operator to delete short tracks

### DIFF
--- a/operators/__init__.py
+++ b/operators/__init__.py
@@ -12,6 +12,7 @@ from .proxy_toggle_operators import (
 from .marker_validierung import CLIP_OT_marker_valurierung
 from ..ui.ui_helpers import CLIP_OT_marker_status_popup
 from .bidirectional_tracking_operator import TRACKING_OT_bidirectional_tracking
+from .delete_short_tracks_operator import TRACKING_OT_delete_short_tracks
 from .track_default_settings import TRACKING_OT_set_default_settings
 from .test_panel_operators import (
     TRACKING_OT_test_cycle,
@@ -42,6 +43,7 @@ operator_classes = (
     CLIP_OT_proxy_build,
     CLIP_OT_proxy_enable,
     CLIP_OT_proxy_disable,
+    TRACKING_OT_delete_short_tracks,
     TRACKING_OT_bidirectional_tracking,
     TRACKING_OT_set_default_settings,
     CLIP_OT_marker_valurierung,

--- a/operators/bidirectional_tracking_operator.py
+++ b/operators/bidirectional_tracking_operator.py
@@ -65,7 +65,7 @@ class TrackingController:
                 self.step = 4
         elif self.step == 4:
             print("→ Starte Bereinigung kurzer Tracks...")
-            self.cleanup_short_tracks()
+            bpy.ops.tracking.delete_short_tracks()
             print("✓ Tracking und Cleanup abgeschlossen.")
             return None
         return 0.5

--- a/operators/delete_short_tracks_operator.py
+++ b/operators/delete_short_tracks_operator.py
@@ -1,0 +1,20 @@
+import bpy
+
+from .bidirectional_tracking_operator import TrackingController
+
+
+class TRACKING_OT_delete_short_tracks(bpy.types.Operator):
+    """Löscht kurze Tracks anhand des Frames/Track-Werts"""
+
+    bl_idname = "tracking.delete_short_tracks"
+    bl_label = "Kurze Tracks löschen"
+    bl_options = {'UNDO'}
+
+    @classmethod
+    def poll(cls, context):
+        return context.space_data and getattr(context.space_data, 'clip', None)
+
+    def execute(self, context):
+        controller = TrackingController(context)
+        controller.cleanup_short_tracks()
+        return {'FINISHED'}

--- a/ui/panels/api_panel.py
+++ b/ui/panels/api_panel.py
@@ -20,6 +20,7 @@ class TRACKING_PT_api_functions(bpy.types.Panel):
         layout.operator("clip.proxy_enable", text="Proxy on")
         layout.operator("tracking.set_default_settings", text="Track Default")
         layout.operator("tracking.bidirectional_tracking")
+        layout.operator("tracking.delete_short_tracks", text="Delete Short Tracks")
         layout.operator("clip.cleanup_tracks", text="Cleanup Tracks")
         layout.operator("clip.low_marker_frame", text="Low Marker Frame")
         layout.operator(


### PR DESCRIPTION
## Summary
- create operator `tracking.delete_short_tracks` to remove short tracks
- call this operator at the end of the bidirectional tracking timer
- expose new operator in operator registration and UI panel

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688aaaeeb338832dbb5415b9a536ee59