### PR TITLE
Fix marker operator references

### DIFF
--- a/helpers/test_cyclus.py
+++ b/helpers/test_cyclus.py
@@ -50,9 +50,12 @@ def evaluate_tracking(context: bpy.types.Context):
     if hasattr(place_marker_operator, "detect"):
         place_marker_operator.detect(context)
     else:
-        # Fallback: Operator instanziieren
-        operator = place_marker_operator.TRACKING_OT_place_marker()
-        operator.execute(context)
+        operator_start = place_marker_operator.TRACKING_OT_place_marker_start()
+        operator_start.execute(context)
+        operator_continue = (
+            place_marker_operator.TRACKING_OT_place_marker_continue()
+        )
+        operator_continue.execute(context)
 
     track_markers_until_end()
     error = error_value(context)

--- a/operators/__init__.py
+++ b/operators/__init__.py
@@ -1,5 +1,8 @@
 from .tracking_marker_basis_operator import TRACKING_OT_marker_basis_values
-from .place_marker_operator import TRACKING_OT_place_marker
+from .place_marker_operator import (
+    TRACKING_OT_place_marker_start,
+    TRACKING_OT_place_marker_continue,
+)
 from .cleanup_operator import CLIP_OT_cleanup_tracks
 from .low_marker_frame_operator import CLIP_OT_low_marker_frame
 from ..helpers.test_marker_base_operator import TRACKING_OT_test_marker_base
@@ -26,7 +29,8 @@ from .test_panel_operators import (
 
 operator_classes = (
     TRACKING_OT_marker_basis_values,
-    TRACKING_OT_place_marker,
+    TRACKING_OT_place_marker_start,
+    TRACKING_OT_place_marker_continue,
     CLIP_OT_cleanup_tracks,
     CLIP_OT_low_marker_frame,
     TRACKING_OT_test_marker_base,

--- a/operators/marker_validierung.py
+++ b/operators/marker_validierung.py
@@ -1,7 +1,6 @@
 import bpy
 
 from ..helpers.test_marker_base import test_marker_base
-from .place_marker_operator import TRACKING_OT_place_marker
 from ..helpers.track_markers_until_end import track_markers_until_end
 from .error_value_operator import CLIP_OT_error_value
 from ..helpers.get_tracking_lengths import get_tracking_lengths

--- a/ui/panels/api_panel.py
+++ b/ui/panels/api_panel.py
@@ -16,7 +16,7 @@ class TRACKING_PT_api_functions(bpy.types.Panel):
         layout.operator("clip.proxy_build", text="Proxy")
         layout.operator("clip.proxy_disable", text="Proxy off")
         layout.operator("tracking.marker_basis_values")
-        layout.operator("tracking.place_marker")
+        layout.operator("tracking.place_marker_start")
         layout.operator("clip.proxy_enable", text="Proxy on")
         layout.operator("tracking.set_default_settings", text="Track Default")
         layout.operator("tracking.bidirectional_tracking")


### PR DESCRIPTION
## Summary
- use new marker operator names in operator package
- update operator class list
- adapt UI panel to call new marker operator
- remove unused old import from marker validation
- invoke new start/continue operator in test cycle helper

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688b69f15bb0832d89eaa6b16b74ad60