### PR TITLE
Fix test panel button to call place_marker operator

### DIFF
--- a/ui/panels/test_panel.py
+++ b/ui/panels/test_panel.py
@@ -25,9 +25,9 @@ class TRACKING_PT_test_details(bpy.types.Panel):
     def draw(self, context):
         layout = self.layout
         layout.operator('tracking.test_marker_base')
-        layout.operator("tracking.test_place_marker", text="Place Marker")
+        layout.operator("tracking.place_marker", text="Place Marker")
         layout.operator("tracking.test_track_markers", text="Track Markers")
-        layout.operator("tracking.test_error_value", text="Error Value")
+        layout.operator("clip.error_value", text="Error Value")
         layout.operator("tracking.test_tracking_lengths", text="Tracking Lengths")
         layout.operator("tracking.test_cycle_motion", text="Cycle Motion")
         layout.operator("tracking.test_tracking_channels", text="Tracking Channels")


### PR DESCRIPTION
## Summary
- connect the "Place Marker" button in the test panel to the real operator
- connect the "Error Value" button in the test panel to the real operator

## Testing
- `python -m py_compile ui/panels/test_panel.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688c9217807c832d9c816148b4e23dc4