### PR TITLE
Add test default operator addon

### DIFF
--- a/t/__init__.py
+++ b/t/__init__.py
@@ -1,0 +1,25 @@
+bl_info = {
+    "name": "Test Tracking Addon",
+    "author": "Addon Author",
+    "version": (1, 0, 0),
+    "blender": (4, 4, 0),
+    "location": "Clip Editor",
+    "description": "Addon für Testfunktionen",
+    "category": "Tracking",
+}
+
+import bpy
+from .operators import operator_classes
+from .ui.panels import panel_classes
+
+classes = operator_classes + panel_classes
+
+
+def register() -> None:
+    for cls in classes:
+        bpy.utils.register_class(cls)
+
+
+def unregister() -> None:
+    for cls in reversed(classes):
+        bpy.utils.unregister_class(cls)

--- a/t/operators/__init__.py
+++ b/t/operators/__init__.py
@@ -1,0 +1,5 @@
+from .test_track_default_operator import TRACK_OT_test_default
+
+operator_classes = (
+    TRACK_OT_test_default,
+)

--- a/t/operators/test_track_default_operator.py
+++ b/t/operators/test_track_default_operator.py
@@ -1,0 +1,12 @@
+import bpy
+from . import test_track_default_settings
+
+
+class TRACK_OT_test_default(bpy.types.Operator):
+    bl_idname = "track.test_default"
+    bl_label = "Test Default"
+    bl_description = "Führe Test Default Settings aus"
+
+    def execute(self, context):
+        test_track_default_settings.main()
+        return {'FINISHED'}

--- a/t/operators/test_track_default_settings.py
+++ b/t/operators/test_track_default_settings.py
@@ -1,0 +1,32 @@
+"""Utility to set default Blender tracking settings."""
+
+import bpy
+
+
+def main() -> None:
+    """Set tracking defaults based on clip width."""
+    clip = getattr(bpy.context.space_data, "clip", None)
+    if clip is None:
+        print("Kein aktiver Movie Clip gefunden")
+        return
+
+    settings = clip.tracking.settings
+
+    width = clip.size[0]
+    pattern_size = int(width / 100)
+    search_size = pattern_size * 2
+
+    settings.default_pattern_size = pattern_size
+    settings.default_search_size = search_size
+    settings.default_motion_model = 'Loc'
+    settings.default_pattern_match = 'KEYFRAME'
+    settings.use_default_brute = True
+    settings.use_default_normalization = True
+    settings.use_default_red_channel = True
+    settings.use_default_green_channel = True
+    settings.use_default_blue_channel = True
+    settings.default_weight = 1.0
+    settings.default_correlation_min = 0.9
+    settings.default_margin = 10
+
+    print(f"Tracking-Defaults gesetzt (Pattern: {pattern_size}, Search: {search_size})")

--- a/t/operators/track_default_settings.py
+++ b/t/operators/track_default_settings.py
@@ -1,0 +1,32 @@
+"""Utility to set default Blender tracking settings."""
+
+import bpy
+
+
+def main() -> None:
+    """Set tracking defaults based on clip width."""
+    clip = getattr(bpy.context.space_data, "clip", None)
+    if clip is None:
+        print("Kein aktiver Movie Clip gefunden")
+        return
+
+    settings = clip.tracking.settings
+
+    width = clip.size[0]
+    pattern_size = int(width / 100)
+    search_size = pattern_size * 2
+
+    settings.default_pattern_size = pattern_size
+    settings.default_search_size = search_size
+    settings.default_motion_model = 'Loc'
+    settings.default_pattern_match = 'KEYFRAME'
+    settings.use_default_brute = True
+    settings.use_default_normalization = True
+    settings.use_default_red_channel = True
+    settings.use_default_green_channel = True
+    settings.use_default_blue_channel = True
+    settings.default_weight = 1.0
+    settings.default_correlation_min = 0.9
+    settings.default_margin = 10
+
+    print(f"Tracking-Defaults gesetzt (Pattern: {pattern_size}, Search: {search_size})")

--- a/t/ui/panels/__init__.py
+++ b/t/ui/panels/__init__.py
@@ -1,0 +1,9 @@
+from .test_panel import (
+    TRACK_PT_test,
+    TRACK_PT_test_details,
+)
+
+panel_classes = (
+    TRACK_PT_test,
+    TRACK_PT_test_details,
+)

--- a/t/ui/panels/test_panel.py
+++ b/t/ui/panels/test_panel.py
@@ -1,0 +1,31 @@
+import bpy
+
+
+class TRACK_PT_test(bpy.types.Panel):
+    bl_label = "Test"
+    bl_idname = "TRACK_PT_test"
+    bl_space_type = 'CLIP_EDITOR'
+    bl_region_type = 'UI'
+    bl_category = "Tracking Tools"
+
+    def draw(self, context):
+        pass
+
+
+class TRACK_PT_test_details(bpy.types.Panel):
+    bl_label = "Test Details"
+    bl_idname = "TRACK_PT_test_details"
+    bl_space_type = 'CLIP_EDITOR'
+    bl_region_type = 'UI'
+    bl_category = "Tracking Tools"
+    bl_parent_id = "TRACK_PT_test"
+
+    def draw(self, context):
+        layout = self.layout
+        layout.operator("track.test_default", text="Test Default")
+
+
+panel_classes = (
+    TRACK_PT_test,
+    TRACK_PT_test_details,
+)


### PR DESCRIPTION
## Summary
- introduce new addon `t` for test purposes
- add utility for setting default tracking parameters
- add test operator to call the utility
- register operator and panel in new addon
- show button in test details panel

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688cb05c4574832dbeadaccf85cd11eb