### PR TITLE
Fix tracking addon calculations and cleanup

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Tracking Tools",
     "author": "Addon Author",
-    "version": (1, 0, 0),
+    "version": (1, 97, 0),
     "blender": (4, 4, 0),
     "location": "Clip Editor",
     "description": "Beispiel Addon mit Marker Basis Value",
@@ -29,12 +29,6 @@ def register():
     if bpy is None:
         return
     register_properties()
-    bpy.types.Scene.error_threshold = bpy.props.FloatProperty(
-        name="Fehlertoleranz",
-        description="Maximal erlaubter Trackingfehler",
-        default=0.1,
-        min=0.0,
-    )
     for cls in classes:
         try:
             bpy.utils.register_class(cls)
@@ -50,8 +44,6 @@ def unregister():
             bpy.utils.unregister_class(cls)
         except ValueError:
             pass
-    if hasattr(bpy.types.Scene, "error_threshold"):
-        del bpy.types.Scene.error_threshold
     unregister_properties()
 
 

--- a/operators/cleanup_tracks.py
+++ b/operators/cleanup_tracks.py
@@ -16,7 +16,7 @@ def cleanup_tracks(context):
     for track in tracks:
         track.select = False
 
-    ee_initial = (context.scene.error_per_track + 0.1) / 100
+    ee_initial = context.scene.error_per_track
     threshold_factor = 0.9
     frame_range = (scene.frame_start, scene.frame_end)
 

--- a/operators/tracking_marker_basis_operator.py
+++ b/operators/tracking_marker_basis_operator.py
@@ -17,10 +17,10 @@ class TRACKING_OT_marker_basis_values(bpy.types.Operator):
 
         marker_basis = scene.get("marker_basis", 20)
 
-        marker_plus = marker_basis * 4
+        marker_plus = marker_basis / 3
         marker_adapt = marker_plus
-        max_marker = marker_adapt * 1.1
-        min_marker = marker_adapt * 0.9
+        max_marker = marker_adapt + 1
+        min_marker = marker_adapt - 1
 
         scene["marker_plus"] = marker_plus
         scene["marker_adapt"] = marker_adapt

--- a/ui/panels/api_panel.py
+++ b/ui/panels/api_panel.py
@@ -19,6 +19,6 @@ class TRACKING_PT_api_functions(bpy.types.Panel):
         layout.operator("clip.proxy_disable", text="Proxy off")
         layout.operator("tracking.place_marker")
         layout.operator("clip.proxy_enable", text="Proxy on")
-        layout.operator("clip.bidirectional_tracking")
+        layout.operator("tracking.bidirectional_tracking")
         layout.operator("clip.low_marker_frame", text="Low Marker Frame")
         layout.operator("clip.cleanup_tracks", text="Cleanup Tracks")


### PR DESCRIPTION
## Summary
- call bidirectional tracking operator with correct prefix
- unify marker_basis computations and remove unused error threshold property
- scale cleanup threshold directly from `error_per_track`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest` *(fails: No module named 'bpy')*


------
https://chatgpt.com/codex/tasks/task_e_688e39113f54832d848ef43e9d66733d