### PR TITLE
Use temp override for deleting tracks

### DIFF
--- a/operators/test_panel_operators.py
+++ b/operators/test_panel_operators.py
@@ -36,19 +36,21 @@ def clear_tracks(tracking_data):
     for track in tracking_data.tracks:
         track.select = True
 
-    override = bpy.context.copy()
-    for area in bpy.context.window.screen.areas:
-        if area.type == "CLIP_EDITOR":
-            override["area"] = area
-            override["region"] = area.regions[-1]
-            override["space_data"] = area.spaces.active
+    found = False
+    for area in bpy.context.screen.areas:
+        if area.type == 'CLIP_EDITOR':
+            for region in area.regions:
+                if region.type == 'WINDOW':
+                    with bpy.context.temp_override(area=area, region=region):
+                        bpy.ops.clip.delete_track(confirm=False)
+                    found = True
+                    break
             break
-    else:
+
+    if not found:
         raise RuntimeError(
             "Movie Clip Editor not found. Open a Movie Clip Editor and try again."
         )
-
-    bpy.ops.clip.delete_track(override, confirm=False)
 
 
 class TRACKING_OT_test_cycle(bpy.types.Operator):


### PR DESCRIPTION
## Summary
- replace override-dictionary approach in `clear_tracks` with `context.temp_override` to match Blender 4.4 API

## Testing
- `python -m py_compile operators/test_panel_operators.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'bpy')*
- `pip install bpy` *(fails: Could not find a version that satisfies the requirement bpy)*
- `flake8 operators/test_panel_operators.py` *(command not found; pip install flake8 fails)*

------
https://chatgpt.com/codex/tasks/task_e_688e8bc507c4832d9d8f9f92ec8c1834