### PR TITLE
Expose error value operator in panel and update track API

### DIFF
--- a/operators/error_value_operator.py
+++ b/operators/error_value_operator.py
@@ -24,7 +24,10 @@ class CLIP_OT_error_value(Operator):
         x_positions = []
         y_positions = []
 
-        for track in clip.tracking.tracks:
+        tracking = clip.tracking
+        tracks = tracking.objects.active.tracks
+
+        for track in tracks:
             if not track.select:
                 continue
             for marker in track.markers:

--- a/ui/panels/api_panel.py
+++ b/ui/panels/api_panel.py
@@ -22,3 +22,4 @@ class TRACKING_PT_api_functions(bpy.types.Panel):
         layout.operator("tracking.bidirectional_tracking")
         layout.operator("clip.low_marker_frame", text="Low Marker Frame")
         layout.operator("clip.cleanup_tracks", text="Cleanup Tracks")
+        layout.operator("clip.error_value", text="Fehlerwert berechnen")


### PR DESCRIPTION
## Summary
- Update error value operator to iterate over `clip.tracking.objects.active.tracks` for Blender 4.4.3
- Add "Fehlerwert berechnen" button to API panel for easier access

## Testing
- `python -m py_compile operators/error_value_operator.py ui/panels/api_panel.py`

------
https://chatgpt.com/codex/tasks/task_e_68907cf86bdc832da904d0310f141f8c