### PR TITLE
Refactor track access for Blender 4.4.3

### DIFF
--- a/helpers/get_tracking_lengths.py
+++ b/helpers/get_tracking_lengths.py
@@ -11,7 +11,7 @@ def get_tracking_lengths():
         return {}
 
     results = {}
-    for track in clip.tracking.tracks:
+    for track in clip.tracking.objects.active.tracks:
         if not track.select:
             continue
 

--- a/helpers/low_marker_frame.py
+++ b/helpers/low_marker_frame.py
@@ -16,7 +16,7 @@ def low_marker_frame(
 
     for frame in range(scene.frame_start, scene.frame_end + 1):
         count = 0
-        for track in clip.tracking.tracks:
+        for track in clip.tracking.objects.active.tracks:
             marker = track.markers.find_frame(frame, exact=True)
             if marker and not marker.mute:
                 count += 1

--- a/operators/bidirectional_tracking_operator.py
+++ b/operators/bidirectional_tracking_operator.py
@@ -9,11 +9,12 @@ class TrackingController:
         self.context = context
         self.clip = context.space_data.clip
         self.tracking = self.clip.tracking
+        self.tracks = self.tracking.objects.active.tracks
         self.step = 0  # 0 = forward, 1 = wait, 2 = backward, 3 = wait, 4 = cleanup
         self.prev_frame = context.scene.frame_current
         self.initial_frame = context.scene.frame_current  # Speichert den Start-Frame für Rücksetzen
         self.frame_stable_counter = 0
-        self.marker_counts_prev = [len(t.markers) for t in self.tracking.tracks]
+        self.marker_counts_prev = [len(t.markers) for t in self.tracks]
         self.tracking_done_delay = 0
 
         print("Bidirektionales Tracking initialisiert.")
@@ -29,7 +30,7 @@ class TrackingController:
 
         self.prev_frame = current_frame
 
-        marker_counts_now = [len(t.markers) for t in self.tracking.tracks]
+        marker_counts_now = [len(t.markers) for t in self.tracks]
         new_markers = any(now > prev for now, prev in zip(marker_counts_now, self.marker_counts_prev))
         self.marker_counts_prev = marker_counts_now
 
@@ -78,7 +79,7 @@ class TrackingController:
         min_length = scene.get("frames_per_track", 10)
         short_tracks: list[bpy.types.MovieTrackingTrack] = []
 
-        for track in self.tracking.tracks:
+        for track in self.tracks:
             if not track.select or all(m.mute for m in track.markers):
                 continue
 

--- a/operators/cleanup_tracks.py
+++ b/operators/cleanup_tracks.py
@@ -10,7 +10,7 @@ def cleanup_tracks(context):
     scene = context.scene
     clip = context.space_data.clip
     tracking = clip.tracking
-    tracks = tracking.tracks
+    tracks = tracking.objects.active.tracks
 
     # Alle Marker deselektieren
     for track in tracks:

--- a/operators/marker_validierung.py
+++ b/operators/marker_validierung.py
@@ -41,7 +41,7 @@ class CLIP_OT_marker_validierung(bpy.types.Operator):
         for frame in range(start, end + 1):
             scene.frame_set(frame)
             count = 0
-            for track in clip.tracking.tracks:
+            for track in clip.tracking.objects.active.tracks:
                 marker = track.markers.find_frame(frame, exact=True)
                 if marker and not marker.mute:
                     count += 1


### PR DESCRIPTION
## Summary
- update operators and helpers to use `clip.tracking.objects.active.tracks`
- ensure marker placement, validation, cleanup and helper utilities work with Blender 4.4 API

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68907deca040832da93094da3a3502b7