### PR TITLE
Simplify tracking UI to a single button

### DIFF
--- a/ui/panels/__init__.py
+++ b/ui/panels/__init__.py
@@ -1,11 +1,5 @@
 from .api_panel import TRACKING_PT_api_functions
-from .test_panel import (
-    TRACKING_PT_test,
-    TRACKING_PT_test_details,
-)
 
 panel_classes = (
     TRACKING_PT_api_functions,
-    TRACKING_PT_test,
-    TRACKING_PT_test_details,
 )

--- a/ui/panels/api_panel.py
+++ b/ui/panels/api_panel.py
@@ -2,7 +2,7 @@ import bpy
 
 
 class TRACKING_PT_api_functions(bpy.types.Panel):
-    bl_label = "API Funktionen"
+    bl_label = "Tracking"
     bl_idname = "TRACKING_PT_api_functions"
     bl_space_type = "CLIP_EDITOR"
     bl_region_type = "UI"
@@ -10,16 +10,4 @@ class TRACKING_PT_api_functions(bpy.types.Panel):
 
     def draw(self, context):
         layout = self.layout
-        layout.prop(context.scene, "marker_basis", text="Marker/Frame")
-        layout.prop(context.scene, "frames_per_track", text="Frames/Track")
-        layout.prop(context.scene, "error_per_track", text="Error/Track")
-        layout.operator("clip.proxy_build", text="Proxy")
-        layout.operator("track.test_combined", text="Track Defaults setzen")
-        layout.operator("tracking.marker_basis_values")
-        layout.operator("clip.proxy_disable", text="Proxy off")
-        layout.operator("tracking.place_marker")
-        layout.operator("clip.proxy_enable", text="Proxy on")
-        layout.operator("tracking.bidirectional_tracking")
-        layout.operator("clip.low_marker_frame", text="Low Marker Frame")
-        layout.operator("clip.cleanup_tracks", text="Cleanup Tracks")
-        layout.operator("clip.error_value", text="Fehlerwert berechnen")
+        layout.operator("tracking.bidirectional_tracking", text="Track")


### PR DESCRIPTION
## Summary
- streamline the clip editor panel to a single **Track** button invoking bidirectional tracking
- drop registration of the test panels so no other buttons appear

## Testing
- `python -m py_compile ui/panels/api_panel.py ui/panels/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_689091f0363c832d97e1536df7a0c478