### PR TITLE
Add Kaiserlich tracking panel and tracking operator

### DIFF
--- a/operators/__init__.py
+++ b/operators/__init__.py
@@ -14,6 +14,7 @@ from .proxy_toggle_operators import (
 from .marker_validierung import CLIP_OT_marker_valurierung
 from ..ui.ui_helpers import CLIP_OT_marker_status_popup
 from .bidirectional_tracking_operator import TRACKING_OT_bidirectional_tracking
+from .kaiserlich_track_operator import CLIP_OT_kaiserlich_track
 from .test_panel_operators import (
     TRACKING_OT_test_cycle,
     TRACKING_OT_test_base,
@@ -50,5 +51,6 @@ operator_classes = (
     TRACK_OT_test_combined,
     CLIP_OT_marker_valurierung,
     CLIP_OT_marker_status_popup,
+    CLIP_OT_kaiserlich_track,
     CLIP_OT_set_tracking_channels,
 )

--- a/operators/kaiserlich_track_operator.py
+++ b/operators/kaiserlich_track_operator.py
@@ -1,0 +1,97 @@
+import bpy
+import math
+
+from ..helpers.invoke_clip_operator_safely import invoke_clip_operator_safely
+from ..helpers.proxy_disable import disable_proxy
+from ..helpers.proxy_enable import enable_proxy
+
+
+class CLIP_OT_kaiserlich_track(bpy.types.Operator):
+    bl_idname = "clip.kaiserlich_track"
+    bl_label = "Kaiserlich Track"
+    bl_description = "Automatisches Tracking mit Kaiserlich Einstellungen"
+
+    @classmethod
+    def poll(cls, context):
+        return (
+            context.area
+            and context.area.type == "CLIP_EDITOR"
+            and context.space_data.clip is not None
+        )
+
+    def execute(self, context):
+        scene = context.scene
+        clip = context.space_data.clip
+        tracking = clip.tracking
+        settings = tracking.settings
+
+        width = clip.size[0]
+        margin_base = int(width * 0.025)
+        min_distance_base = int(width * 0.05)
+        detection_threshold = 0.5
+
+        marker_basis = scene.marker_basis
+        marker_plus = marker_basis * 4
+        marker_adapt = marker_plus
+        min_marker = int(marker_adapt * 0.9)
+        max_marker = int(marker_adapt * 1.1)
+
+        scene.marker_plus = marker_plus
+        scene.marker_adapt = marker_adapt
+        scene.min_marker = min_marker
+        scene.max_marker = max_marker
+
+        settings.default_motion_model = 'Loc'
+        settings.default_pattern_match = 'KEYFRAME'
+        settings.default_correlation_min = 0.9
+        settings.use_default_red_channel = True
+        settings.use_default_green_channel = True
+        settings.use_default_blue_channel = True
+        settings.default_pattern_size = int(width / 100)
+        settings.default_search_size = int(width / 100)
+
+        disable_proxy(clip)
+
+        tracks = tracking.objects.active.tracks
+        for track in tracks:
+            track.select = False
+
+        anzahl_neu = 0
+        for _ in range(20):
+            factor = math.log10(detection_threshold * 100000000) / 8
+            margin = int(margin_base * factor)
+            distance = int(min_distance_base * factor)
+
+            invoke_clip_operator_safely(
+                "detect_features",
+                threshold=detection_threshold,
+                margin=margin,
+                min_distance=distance,
+            )
+
+            new_tracks = [t for t in tracks if t.select]
+            anzahl_neu = len(new_tracks)
+            if min_marker < anzahl_neu < max_marker:
+                break
+
+            detection_threshold = max(
+                detection_threshold * ((anzahl_neu + 0.1) / marker_adapt),
+                0.0001,
+            )
+            invoke_clip_operator_safely("delete_track")
+
+        enable_proxy(clip)
+
+        invoke_clip_operator_safely("track_markers", backwards=False, sequence=True)
+        invoke_clip_operator_safely("track_markers", backwards=True, sequence=True)
+
+        min_length = scene.frames_per_track
+        for track in list(tracks):
+            frames = [m.frame for m in track.markers if not m.mute]
+            if not frames or (max(frames) - min(frames) + 1) < min_length:
+                tracks.remove(track)
+
+        bpy.ops.clip.cleanup_tracks()
+
+        self.report({'INFO'}, f"{len(tracks)} Tracks nach Cleanup")
+        return {'FINISHED'}

--- a/ui/panels/__init__.py
+++ b/ui/panels/__init__.py
@@ -1,5 +1,7 @@
 from .api_panel import TRACKING_PT_api_functions
+from .kaiserlich_panel import CLIP_PT_kaiserlich
 
 panel_classes = (
     TRACKING_PT_api_functions,
+    CLIP_PT_kaiserlich,
 )

--- a/ui/panels/kaiserlich_panel.py
+++ b/ui/panels/kaiserlich_panel.py
@@ -1,0 +1,27 @@
+import bpy
+
+
+class CLIP_PT_kaiserlich(bpy.types.Panel):
+    bl_label = "Kaiserlich"
+    bl_idname = "CLIP_PT_kaiserlich"
+    bl_space_type = "CLIP_EDITOR"
+    bl_region_type = "UI"
+    bl_category = "Kaiserlich"
+
+    @classmethod
+    def poll(cls, context):
+        return (
+            context.area
+            and context.area.type == "CLIP_EDITOR"
+            and context.space_data.mode == 'TRACKING'
+        )
+
+    def draw(self, context):
+        layout = self.layout
+        scene = context.scene
+        layout.prop(scene, "marker_basis")
+        layout.prop(scene, "frames_per_track")
+        layout.prop(scene, "error_per_track")
+        row = layout.row()
+        row.enabled = context.space_data.clip is not None
+        row.operator("clip.kaiserlich_track", text="Track")


### PR DESCRIPTION
## Summary
- Add Kaiserlich panel in the Movie Clip Editor for tracking mode with marker, track length and error settings
- Implement `clip.kaiserlich_track` operator executing adaptive feature detection, bidirectional tracking and cleanup

## Testing
- `python -m py_compile ui/panels/kaiserlich_panel.py operators/kaiserlich_track_operator.py ui/panels/__init__.py operators/__init__.py`
- `python -m py_compile __init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68909d305c08832db354176378287fcf