### PR TITLE
Implement adaptive tracking loop with fallback and retries

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -52,13 +52,10 @@ class KaiserlichTrackingOperator(Operator):
             return {"CANCELLED"}
         markers = wm.kaiserlich_settings.markers_per_frame
         min_frames = wm.kaiserlich_settings.min_track_length
-        error_limit = wm.kaiserlich_settings.error_limit
-
         print(
-            f"Starting run_tracking with markers={markers}, min_frames={min_frames}, "
-            f"error_limit={error_limit}"
+            f"Starting run_tracking with markers={markers}, min_frames={min_frames}"
         )
-        run_tracking(context, markers, min_frames, error_limit)
+        run_tracking(context, markers, min_frames)
 
         tracking = clip.tracking
         tracking_obj = tracking.objects.active


### PR DESCRIPTION
## Summary
- add fallback logic in `_adaptive_detect` using low threshold and track reset when markers per frame are insufficient
- implement new `run_tracking` workflow with adaptive detection, bidirectional tracking, cleanup, and automatic retries
- update UI operator to call new tracking workflow

## Testing
- `python -m py_compile track.py cleanup.py settings.py ui.py`


------
https://chatgpt.com/codex/tasks/task_e_6890d0ae1d4c832dbff7f580aff036e6