### PR TITLE
Add Teilzyklus status and track cleanup helper

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -61,7 +61,7 @@ class KaiserlichTrackingOperator(Operator):
         print(
             f"Starting run_tracking with markers={markers}, min_frames={min_frames}"
         )
-        run_tracking(context, markers, min_frames)
+        run_tracking(context, markers, min_frames, report_func=self.report)
 
         tracking_obj = tracking.objects.active
         valid_tracks = [


### PR DESCRIPTION
## Summary
- add `delete_selected_tracks` helper to centralize removal of selected tracks
- return `zyklus_1_fertig` status from `_adaptive_detect` and warn UI when marker count stays low
- propagate UI reporting through `run_tracking` and operator call

## Testing
- `python -m py_compile track.py ui.py`


------
https://chatgpt.com/codex/tasks/task_e_6890d82e21dc832dbe1f740cdfa3771d