### PR TITLE
fix: unify adaptive detection threshold formula

### DIFF
--- a/track.py
+++ b/track.py
@@ -70,15 +70,24 @@ def _adaptive_detect(clip, markers_per_frame, base_threshold, report=None):
                     ),
                     0.0001,
                 )
+                if report:
+                    report(
+                        {'INFO'},
+                        f"Threshold angepasst auf: {detection_threshold:.4f}",
+                    )
         else:
             detection_threshold = max(
                 min(
-                    detection_threshold
-                    * ((marker_adapt + 0.1) / (count_new + 0.1)),
+                    detection_threshold * ((count_new + 0.1) / marker_adapt),
                     1.0,
                 ),
                 0.0001,
             )
+            if report:
+                report(
+                    {'INFO'},
+                    f"Threshold angepasst auf: {detection_threshold:.4f}",
+                )
     else:
         if report:
             report(


### PR DESCRIPTION
## Summary
- use identical threshold scaling formula for too many or too few markers
- log threshold adjustments for easier debugging

## Testing
- `python -m py_compile track.py`


------
https://chatgpt.com/codex/tasks/task_e_6890dcbc4aac832da597beda28e3fba3