### PR TITLE
Use add-on frame range settings

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -27,6 +27,18 @@ class KaiserlichSettings(PropertyGroup):
         min=0.0,
     )
 
+    start_frame: IntProperty(
+        name="Start Frame",
+        default=1,
+        min=1,
+    )
+
+    end_frame: IntProperty(
+        name="End Frame",
+        default=250,
+        min=1,
+    )
+
     enable_debug_overlay: BoolProperty(
         name="Debug Overlay",
         description="Markerabdeckung im UI anzeigen",

--- a/ui.py
+++ b/ui.py
@@ -22,6 +22,8 @@ class KaiserlichPanel(Panel):
         layout.prop(settings, "markers_per_frame")
         layout.prop(settings, "min_track_length")
         layout.prop(settings, "error_limit")
+        layout.prop(settings, "start_frame")
+        layout.prop(settings, "end_frame")
         layout.prop(settings, "auto_keyframes")
         layout.prop(settings, "bidirectional")
         layout.prop(settings, "enable_debug_overlay")
@@ -55,8 +57,8 @@ class KaiserlichTrackingOperator(Operator):
             self.report({"ERROR"}, "Kein aktiver Clip gefunden.")
             return {"CANCELLED"}
         tracking = clip.tracking
-        tracking.settings.keyframe_a = int(scene.frame_start)
-        tracking.settings.keyframe_b = int(scene.frame_end)
+        key_a = wm.kaiserlich_settings.start_frame
+        key_b = wm.kaiserlich_settings.end_frame
         markers = wm.kaiserlich_settings.markers_per_frame
         min_frames = wm.kaiserlich_settings.min_track_length
         print(


### PR DESCRIPTION
## Summary
- Define `start_frame` and `end_frame` properties on `KaiserlichSettings`
- Expose frame range controls in Kaiserlich panel
- Retrieve frame range from add-on settings instead of unsupported `tracking.settings.keyframe_*`

## Testing
- `python -m py_compile __init__.py cleanup.py settings.py track.py ui.py`

------
https://chatgpt.com/codex/tasks/task_e_6890e05f0200832db5ae028527fd2242