### PR TITLE
fix: replace invalid reset call with manual track clearing

### DIFF
--- a/track.py
+++ b/track.py
@@ -166,7 +166,8 @@ def run_tracking(
     max_marker = markers_per_frame * 4
     for attempt in range(max_attempts):
         clip.use_proxy = False
-        tracking.reset()
+        while tracking.tracks:
+            tracking.tracks.remove(tracking.tracks[0])
 
         # Step 1: Adaptive Marker Detection
         new_tracks, last_threshold, status = _adaptive_detect(


### PR DESCRIPTION
## Summary
- clear tracking data by iteratively removing existing tracks instead of calling unsupported `tracking.reset()`

## Testing
- `python -m py_compile track.py`


------
https://chatgpt.com/codex/tasks/task_e_6890e956375c832d9ebb74924b5bb04c