### PR TITLE
Add marker error std analysis to tracking cycle

### DIFF
--- a/error_value.py
+++ b/error_value.py
@@ -1,0 +1,22 @@
+import math
+
+
+def compute_marker_error_std(tracking):
+    """Compute sum of marker position standard deviations."""
+    std_sums = []
+    for track in tracking.tracks:
+        if len(track.markers) < 2:
+            continue
+        xs = [m.co[0] for m in track.markers if not m.mute]
+        ys = [m.co[1] for m in track.markers if not m.mute]
+        if len(xs) < 2:
+            continue
+        mean_x = sum(xs) / len(xs)
+        mean_y = sum(ys) / len(ys)
+        std_x = math.sqrt(sum((x - mean_x) ** 2 for x in xs) / len(xs))
+        std_y = math.sqrt(sum((y - mean_y) ** 2 for y in ys) / len(ys))
+        std_sums.append(std_x + std_y)
+    return sum(std_sums)
+
+
+__all__ = ["compute_marker_error_std"]

--- a/track.py
+++ b/track.py
@@ -1,6 +1,7 @@
 import bpy
 import statistics
 from .cleanup import clean_tracks
+from .error_value import compute_marker_error_std
 
 
 def delete_selected_tracks(tracking):
@@ -209,6 +210,13 @@ def run_tracking(
         clean_tracks(tracking.objects.active, min_track_length, 2.0)
         if report_func:
             report_func({'INFO'}, "clean_tracks() aufgerufen")
+        error_value = compute_marker_error_std(tracking)
+        context.scene["kaiserlich_error_std"] = error_value
+        if report_func:
+            report_func(
+                {'INFO'},
+                f"Fehlerwert (STD-Summe): {error_value:.4f}",
+            )
 
         counts = _marker_counts(tracking, start, end)
         if counts and min(counts.values()) >= markers_per_frame:

--- a/ui.py
+++ b/ui.py
@@ -28,6 +28,11 @@ class KaiserlichPanel(Panel):
         layout.prop(settings, "bidirectional")
         layout.prop(settings, "enable_debug_overlay")
         layout.operator("clip.kaiserlich_tracking", text="Track")
+        error_std = context.scene.get("kaiserlich_error_std")
+        if error_std is not None:
+            layout.label(
+                text=f"Fehlerwert (STD-Summe): {error_std:.4f}"
+            )
         layout.separator()
         layout.label(text="Diagnose")
         layout.operator("clip.error_value", text="Error Value")


### PR DESCRIPTION
## Summary
- add compute_marker_error_std utility to evaluate track quality
- integrate error standard deviation into run_tracking and show in UI panel

## Testing
- `python -m py_compile __init__.py cleanup.py error_value.py settings.py track.py ui.py`


------
https://chatgpt.com/codex/tasks/task_e_6890f1972470832d98bf2350eae94814