### PR TITLE
Add marker count property and improve tracking debug output

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -11,16 +11,25 @@ bl_info = {
     "category": "Tracking",
 }
 
+import bpy
+from bpy.props import StringProperty
+
 from . import ui
 
 
 def register():
     print("Registering Kaiserlich Tracking Optimizer")
+    bpy.types.Scene.kaiserlich_marker_counts = StringProperty(
+        name="Kaiserlich Marker Counts",
+        description="JSON-kodierte Markerzählung für Debugging-Zwecke",
+        default="",
+    )
     ui.register()
 
 
 def unregister():
     print("Unregistering Kaiserlich Tracking Optimizer")
+    del bpy.types.Scene.kaiserlich_marker_counts
     ui.unregister()
 
 

--- a/cleanup.py
+++ b/cleanup.py
@@ -4,9 +4,10 @@ import bpy
 def clean_tracks(tracking_obj, min_frames, error_limit):
     """Entfernt zu kurze oder fehlerhafte Tracks."""
     print(
-        f"Cleaning tracks: min_frames={min_frames}, error_limit={error_limit}"
+        f"[DEBUG] Cleaning tracks: min_frames={min_frames}, error_limit={error_limit}"
     )
     tracks = tracking_obj.tracks
+    print(f"[DEBUG] Verbleibende Marker vor Cleanup: {len(tracks)}")
     for track in tracks:
         valid_markers = [m for m in track.markers if not m.mute]
         track.select = len(valid_markers) < min_frames

--- a/ui.py
+++ b/ui.py
@@ -1,4 +1,5 @@
 import bpy
+import json
 from bpy.types import Operator, Panel
 from bpy.props import PointerProperty
 from .settings import KaiserlichSettings
@@ -38,12 +39,21 @@ class KaiserlichPanel(Panel):
         layout.operator("clip.error_value", text="Error Value")
 
         if settings.enable_debug_overlay:
-            counts = getattr(context.scene, "kaiserlich_marker_counts", {})
+            counts_raw = getattr(context.scene, "kaiserlich_marker_counts", "")
+            try:
+                counts = json.loads(counts_raw) if counts_raw else {}
+            except Exception:
+                counts = {}
             frame = context.scene.frame_current
-            layout.label(text=f"Frame {frame}: {counts.get(frame, 0)} marker")
+            layout.label(
+                text=f"Frame {frame}: {counts.get(str(frame), 0)} marker"
+            )
             layout.label(
                 text=f"Letzter Threshold: {context.scene.get('kaiserlich_last_threshold', '-') }"
             )
+            clip = getattr(context.space_data, "clip", None)
+            if clip is not None:
+                layout.label(text=f"Gesamtmarker: {len(clip.tracking.tracks)}")
 
 
 class KaiserlichTrackingOperator(Operator):


### PR DESCRIPTION
## Summary
- Register `kaiserlich_marker_counts` scene property for JSON marker data
- Safely remove tracks and enhance debug logging for adaptive threshold and cleanup steps
- Show marker counts in UI panel and persist results

## Testing
- `python -m py_compile __init__.py track.py cleanup.py ui.py`


------
https://chatgpt.com/codex/tasks/task_e_6890fea1f620832dbfc8199e1c8296e8