### PR TITLE
Add tracking debug logging and config structure

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -3,7 +3,7 @@ import json
 from bpy.types import Operator, Panel
 from bpy.props import PointerProperty
 from .settings import KaiserlichSettings
-from .track import run_tracking
+from .track import TrackingConfig, run_tracking
 from .cleanup import compute_error_value
 
 
@@ -80,10 +80,13 @@ class KaiserlichTrackingOperator(Operator):
             f"Starting run_tracking with markers={markers}, min_frames={min_frames}"
         )
         bidirectional = wm.kaiserlich_settings.bidirectional
+        config = TrackingConfig(
+            markers_per_frame=markers,
+            min_frames=min_frames,
+        )
         run_tracking(
             context,
-            markers,
-            min_frames,
+            config,
             bidirectional=bidirectional,
             report_func=self.report,
         )


### PR DESCRIPTION
## Summary
- centralize tracking parameters in a `TrackingConfig` dataclass
- enhance `run_tracking` with mandatory defaults, cleanup, and structured debug output
- update UI operator to build and pass configuration to `run_tracking`

## Testing
- `python -m py_compile track.py ui.py settings.py`
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*

------
https://chatgpt.com/codex/tasks/task_e_6891117e0588832dbc8ce927cdcb8e13