### PR TITLE
Add tracking configuration debug logs and per-track motion model

### DIFF
--- a/track.py
+++ b/track.py
@@ -18,10 +18,10 @@ class TrackingConfig:
     pattern_size: int = 21
     search_size: int = 96
     motion_model: str = "Loc"
-    use_norm: bool = True
-    channel_r: bool = True
-    channel_g: bool = False
-    channel_b: bool = False
+    use_normalization: bool = True
+    use_red: bool = True
+    use_green: bool = False
+    use_blue: bool = False
     use_mask: bool = False
 
 
@@ -241,12 +241,23 @@ def run_tracking(
     # Vorgabewerte setzen
     settings.default_pattern_size = config.pattern_size
     settings.default_search_size = config.search_size
-    settings.use_default_red_channel = config.channel_r
-    settings.use_default_green_channel = config.channel_g
-    settings.use_default_blue_channel = config.channel_b
-    settings.motion_model = config.motion_model
-    settings.use_normalization = config.use_norm
+    settings.use_default_red_channel = config.use_red
+    settings.use_default_green_channel = config.use_green
+    settings.use_default_blue_channel = config.use_blue
+    settings.use_normalization = config.use_normalization
     settings.use_mask = config.use_mask
+
+    print(f"[KaiserlichTracker] Tracking-Konfiguration:")
+    print(f"  Pattern Size: {settings.default_pattern_size}")
+    print(f"  Search Size: {settings.default_search_size}")
+    print(
+        f"  Channels: R={settings.use_default_red_channel}, "
+        f"G={settings.use_default_green_channel}, "
+        f"B={settings.use_default_blue_channel}"
+    )
+    print(f"  Normalization: {settings.use_normalization}")
+    print(f"  Use Mask: {settings.use_mask}")
+    print(f"  Motion Model (pro Track): {config.motion_model}")
 
     markers_per_frame = config.markers_per_frame
     min_track_length = config.min_frames
@@ -258,21 +269,6 @@ def run_tracking(
         f"  markers_per_frame: {markers_per_frame}, min_frames: {min_track_length}"
     )
     print(f"  threshold_base: {base_threshold}")
-    print(
-        f"  pattern_size: {settings.default_pattern_size}, "
-        f"search_size: {settings.default_search_size}"
-    )
-    print(
-        "  channel usage: "
-        f"R={settings.use_default_red_channel}, "
-        f"G={settings.use_default_green_channel}, "
-        f"B={settings.use_default_blue_channel}"
-    )
-    print(
-        f"  motion_model: {settings.motion_model}, "
-        f"use_normalization: {settings.use_normalization}"
-    )
-    print(f"  use_mask: {settings.use_mask}")
 
     start = clip.frame_start
     end = start + clip.frame_duration
@@ -284,26 +280,29 @@ def run_tracking(
         clip.use_proxy = False
         while tracking.tracks:
             tracking.tracks.remove(tracking.tracks[0])
-        print("[KaiserlichTracker] All existing tracks removed before detection.")
+        print("[KaiserlichTracker] Bestehende Tracks vollständig entfernt.")
 
         # Step 1: Adaptive Marker Detection
         new_tracks, last_threshold, status = _adaptive_detect(
             clip, markers_per_frame, base_threshold, report=report_func
         )
         context.scene["kaiserlich_last_threshold"] = last_threshold
-        print(f"[KaiserlichTracker] {new_tracks} Marker erfolgreich gesetzt.")
-        if new_tracks == 0:
+        for track in tracking.tracks:
+            track.motion_model = config.motion_model
+        total_tracks = len(tracking.tracks)
+        print(f"[KaiserlichTracker] Marker gesetzt: {total_tracks}")
+        if total_tracks == 0:
             print(
-                "[KaiserlichTracker] WARNUNG: Keine Marker erkannt – prüfen Sie Threshold oder Quellmaterial."
+                "[KaiserlichTracker] ⚠️ Warnung: Keine Marker erkannt. Prüfe Threshold oder Bildmaterial."
             )
         if report_func:
-            report_func({'INFO'}, f"{new_tracks} neue Marker gesetzt")
+            report_func({'INFO'}, f"{total_tracks} neue Marker gesetzt")
 
-        if not (new_tracks > min_marker and new_tracks < max_marker):
+        if not (total_tracks > min_marker and total_tracks < max_marker):
             if report_func:
                 report_func(
                     {'WARNING'},
-                    f"Markeranzahl außerhalb des gültigen Bereichs ({new_tracks})",
+                    f"Markeranzahl außerhalb des gültigen Bereichs ({total_tracks})",
                 )
             continue
 


### PR DESCRIPTION
## Summary
- log tracking configuration settings before tracking
- remove old tracks before detection and warn if no markers found
- set motion model on each track instead of tracking settings

## Testing
- `python -m py_compile track.py ui.py cleanup.py error_value.py settings.py __init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68911a91cb58832d859bb302cb5ba9a5