### PR TITLE
Update tracking config for Blender 4.4.3 API

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -1,6 +1,24 @@
 import bpy
+from dataclasses import dataclass
 from bpy.types import PropertyGroup
 from bpy.props import BoolProperty, FloatProperty, IntProperty
+
+
+@dataclass
+class TrackingConfig:
+    """Bündelt alle konfigurierbaren Tracking-Parameter."""
+
+    markers_per_frame: int = 10
+    min_frames: int = 10
+    base_threshold: float = 0.5
+    pattern_size: int = 21
+    search_size: int = 96
+    motion_model: str = "Loc"
+    use_default_normalization: bool = True
+    use_red: bool = True
+    use_green: bool = False
+    use_blue: bool = False
+    use_default_mask: bool = False
 
 
 class KaiserlichSettings(PropertyGroup):
@@ -58,4 +76,4 @@ class KaiserlichSettings(PropertyGroup):
     )
 
 
-__all__ = ["KaiserlichSettings"]
+__all__ = ["KaiserlichSettings", "TrackingConfig"]

--- a/track.py
+++ b/track.py
@@ -1,28 +1,11 @@
 import bpy
 import json
 import statistics
-from dataclasses import dataclass
 from typing import Optional
 
 from .cleanup import clean_tracks
 from .error_value import compute_marker_error_std
-
-
-@dataclass
-class TrackingConfig:
-    """Bündelt alle konfigurierbaren Tracking-Parameter."""
-
-    markers_per_frame: int = 10
-    min_frames: int = 10
-    base_threshold: float = 0.5
-    pattern_size: int = 21
-    search_size: int = 96
-    motion_model: str = "Loc"
-    use_normalization: bool = True
-    use_red: bool = True
-    use_green: bool = False
-    use_blue: bool = False
-    use_mask: bool = False
+from .settings import TrackingConfig
 
 
 def delete_selected_tracks(tracking):
@@ -266,10 +249,14 @@ def run_tracking(
         settings.use_default_red_channel = config.use_red
         settings.use_default_green_channel = config.use_green
         settings.use_default_blue_channel = config.use_blue
-        settings.use_normalization = config.use_normalization
-        settings.use_mask = config.use_mask
+        settings.use_default_normalization = config.use_default_normalization
+        settings.use_default_mask = config.use_default_mask
 
-        print("[KaiserlichTracker] Tracking-Einstellungen angewendet:")
+        print("[KaiserlichTracker] Tracking-Konfiguration angewendet:")
+        print(
+            f"  use_default_normalization: {settings.use_default_normalization}"
+        )
+        print(f"  use_default_mask: {settings.use_default_mask}")
         print(f"  Pattern Size:       {settings.default_pattern_size}")
         print(f"  Search Size:        {settings.default_search_size}")
         print(
@@ -277,8 +264,6 @@ def run_tracking(
             f"G={settings.use_default_green_channel}, "
             f"B={settings.use_default_blue_channel}"
         )
-        print(f"  Normalization:      {settings.use_normalization}")
-        print(f"  Maskenverwendung:   {settings.use_mask}")
         print(
             f"  Motion Model:       {config.motion_model} (wird pro Track gesetzt)"
         )

--- a/ui.py
+++ b/ui.py
@@ -2,8 +2,8 @@ import bpy
 import json
 from bpy.types import Operator, Panel
 from bpy.props import PointerProperty
-from .settings import KaiserlichSettings
-from .track import TrackingConfig, run_tracking
+from .settings import KaiserlichSettings, TrackingConfig
+from .track import run_tracking
 from .cleanup import compute_error_value
 
 


### PR DESCRIPTION
## Summary
- Replace deprecated normalization and mask settings with `use_default_normalization` and `use_default_mask`.
- Log applied tracking configuration for easier debugging.
- Centralize `TrackingConfig` dataclass in settings module and adjust UI import.

## Testing
- `python -m py_compile __init__.py cleanup.py error_value.py settings.py track.py ui.py`

------
https://chatgpt.com/codex/tasks/task_e_68913301bc7c832db53237e6bf7bdb5b