### PR TITLE
Add explicit high-error refine operator and coordinator integration

### DIFF
--- a/Helper/__init__.py
+++ b/Helper/__init__.py
@@ -15,7 +15,11 @@ from .tracking_helper import track_to_scene_end_fn  # noqa: F401
 
 # Feste Operatoren
 from .bidirectional_track import CLIP_OT_bidirectional_track
-from .refine_high_error import KAISERLICH_OT_refine_high_error
+from .refine_high_error import (
+    CLIP_OT_refine_high_error,
+    run_refine_on_high_error,
+    compute_high_error_frames,
+)
 
 # Optionale Operatoren
 try:
@@ -34,7 +38,9 @@ __all__ = [
     "register",
     "unregister",
     "CLIP_OT_bidirectional_track",
-    "KAISERLICH_OT_refine_high_error",
+    "CLIP_OT_refine_high_error",
+    "run_refine_on_high_error",
+    "compute_high_error_frames",
 ]
 
 _optional_classes = []
@@ -46,7 +52,7 @@ if CLIP_OT_marker_helper_main is not None:
 
 def register() -> None:
     """Registriert feste Operatoren + optionale Operatoren."""
-    for cls in (CLIP_OT_bidirectional_track, KAISERLICH_OT_refine_high_error):
+    for cls in (CLIP_OT_bidirectional_track, CLIP_OT_refine_high_error):
         try:
             bpy.utils.register_class(cls)
         except ValueError:
@@ -67,7 +73,7 @@ def unregister() -> None:
             bpy.utils.unregister_class(cls)
         except Exception:
             pass
-    for cls in (KAISERLICH_OT_refine_high_error, CLIP_OT_bidirectional_track):
+    for cls in (CLIP_OT_refine_high_error, CLIP_OT_bidirectional_track):
         try:
             bpy.utils.unregister_class(cls)
         except Exception:


### PR DESCRIPTION
## Summary
- handle ESC in modal refine operator and execute clean tracks without invoking
- compute per-frame error using active clip fallback and marker search
- log when no frames exceed threshold during refine setup
- avoid re-filtering preselected frames in frame selection utility

## Testing
- `python -m py_compile Helper/refine_high_error.py Helper/__init__.py Operator/tracking_coordinator.py`
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*
- `flake8 Helper/refine_high_error.py Operator/tracking_coordinator.py` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4c623bbc832da1f3c5a3a6ab8217