### PR TITLE
Coordinate spike filter triggering after cleanup

### DIFF
--- a/Helper/projection_cleanup_builtin.py
+++ b/Helper/projection_cleanup_builtin.py
@@ -16,6 +16,7 @@ Hinweis:
 from typing import Optional, Tuple, Dict, Any, Iterable
 import bpy
 import time
+from ..Operator import tracking_coordinator as tco
 
 __all__ = ("run_projection_cleanup_builtin",)
 
@@ -277,6 +278,8 @@ def run_projection_cleanup_builtin(
 
     print(f"[Cleanup] Cleanup abgeschlossen. Vorher={before_count}, nachher={after_count}, "
           f"entfernt={deleted}, selektiert={selected}, deaktiviert={disabled}")
+
+    tco.on_projection_cleanup_finished(context=context)
 
     return {"status": "OK", "used_error": used_error, "action": action, "reason": None,
             "before": before_count, "after": after_count, "deleted": deleted,

--- a/Helper/spike_filter_cycle.py
+++ b/Helper/spike_filter_cycle.py
@@ -18,6 +18,7 @@ Rückgabe (dict):
 
 from typing import Optional, Dict, Any
 import bpy
+from ..Operator import tracking_coordinator as tco
 
 __all__ = ["run_spike_filter_cycle"]
 
@@ -159,5 +160,21 @@ def run_spike_filter_cycle(
     next_thr = _lower_threshold(thr)
     print(f"[SpikeCycle] next track_threshold → {next_thr}")
 
+    # Nur merken, wenn nicht vom Koordinator als "One-Shot" ausgelöst
+    suppress = bool(
+        getattr(context, "scene", None)
+        and context.scene.get("tco_spike_suppress_remember", False)
+    )
+    if not suppress:
+        # Falls *der verwendete* Wert gemerkt werden soll:
+        # tco.remember_spike_filter_value(thr, context=context)
+        # So wie hier: den vorgeschlagenen nächsten Wert merken
+        tco.remember_spike_filter_value(next_thr, context=context)
+
     return {"status": "OK", "removed": int(removed), "next_threshold": float(next_thr)}
+
+
+def run_with_value(context: bpy.types.Context, value: float) -> None:
+    """Ermöglicht dem Koordinator einen direkten Aufruf mit einem gegebenen Wert."""
+    run_spike_filter_cycle(context, track_threshold=float(value))
 


### PR DESCRIPTION
## Summary
- Track a pending spike filter value on the scene
- Remember spike threshold at the end of the spike filter cycle
- Fire the stored spike filter once projection cleanup finishes
- Guard against re-queuing a spike value when running the cycle one-shot

## Testing
- `python -m py_compile Operator/tracking_coordinator.py Helper/spike_filter_cycle.py Helper/projection_cleanup_builtin.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad28073c70832d85af31acd17fff84