### PR TITLE
Scale cleanup threshold before track cleanup

### DIFF
--- a/Helper/projection_cleanup_builtin.py
+++ b/Helper/projection_cleanup_builtin.py
@@ -245,6 +245,8 @@ def run_projection_cleanup_builtin(
         return {"status": "SKIPPED", "reason": "no_error", "used_error": None, "action": action,
                 "before": None, "after": None, "deleted": None, "selected": None, "disabled": None}
 
+    # Wert vor Verwendung mit Faktor 1.1 multiplizieren
+    used_error = float(used_error) * 1.1
     print(f"[Cleanup] Starte clean_tracks mit Grenzwert {used_error:.4f}px, action={action}")
 
     # 2) Vorher-Count, Operator aufrufen, Nachher-Count/Statistiken berechnen


### PR DESCRIPTION
## Summary
- scale solve error threshold by 1.1 before running built-in track cleanup

## Testing
- `python -m py_compile Helper/projection_cleanup_builtin.py`
- `pytest`
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*
- `flake8 Helper/projection_cleanup_builtin.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae79cbefa0832d9b4bc3709e0aaf26