### PR TITLE
Remove debug prints across helpers

### DIFF
--- a/Helper/clean_error_tracks.py
+++ b/Helper/clean_error_tracks.py
@@ -86,7 +86,6 @@ def run_clean_error_tracks(context, *, show_popups: bool = False, soften: float 
                 lambda self, ctx: self.layout.label(text="Kein CLIP_EDITOR-Kontext gefunden."),
                 title="Clean Error Tracks", icon='CANCEL'
             )
-        print("[CleanError] ERROR: Kein gültiger CLIP_EDITOR-Kontext gefunden.")
         return {'CANCELLED'}
 
     # Fortschritt vorbereiten (5 Hauptschritte)
@@ -115,7 +114,6 @@ def run_clean_error_tracks(context, *, show_popups: bool = False, soften: float 
                     lambda self, ctx: self.layout.label(text="Kein aktiver Clip."),
                     title="Clean Error Tracks", icon='CANCEL'
                 )
-            print("[CleanError] ERROR: Kein aktiver Clip.")
             _status(wm, None)
             try:
                 wm.progress_end()
@@ -154,13 +152,6 @@ def run_clean_error_tracks(context, *, show_popups: bool = False, soften: float 
             grid=(6, 6), start_delta=None, min_delta=min_delta,
             outlier_q=outlier_q, hysteresis_hits=hysteresis_hits, min_cell_items=min_cell_items
         )
-        print(
-            f"[MultiScale] soften={soften:.2f} -> "
-            f"outlier_q={outlier_q} ({outlier_q_f:.2f}), "
-            f"hysteresis_hits={hysteresis_hits} ({hysteresis_f:.2f}), "
-            f"min_cell_items={min_cell_items} ({min_items_f:.2f}), "
-            f"min_delta={min_delta} ({min_delta_f:.2f}) | deleted: {deleted}"
-        )
         _deps_sync(context)
 
     # ---------- 3) GAP SPLIT + RECURSIVE ----------
@@ -180,7 +171,6 @@ def run_clean_error_tracks(context, *, show_popups: bool = False, soften: float 
 
         if not original_tracks:
             msg = "Keine Tracks mit internen Lücken – Split übersprungen."
-            print(f"[CleanError] {msg}")
             if show_popups:
                 wm.popup_menu(lambda self, ctx, m=msg: self.layout.label(text=m),
                               title="Clean Error Tracks", icon='INFO')
@@ -230,12 +220,6 @@ def run_clean_error_tracks(context, *, show_popups: bool = False, soften: float 
             (markers_after != markers_before) or
             recursive_changed
         )
-        print(
-            f"[CleanError] Changes? {made_changes} | "
-            f"tracks: {tracks_before}->{tracks_after} | "
-            f"markers: {markers_before}->{markers_after} | "
-            f"recursive_changed={recursive_changed}"
-        )
 
     # ---------- 4) SAFETY ----------
     step_update(4, "Safety Passes")
@@ -263,7 +247,6 @@ def run_clean_error_tracks(context, *, show_popups: bool = False, soften: float 
             scale = max(0.35, soften * 1.2)  # 0.5 -> 0.6 ; 0.8 -> 0.96 (nahe original)
             frames_eff = max(6, int(round(base_frames * min(scale, 1.0))))
 
-            print(f"[ShortClean] base_frames={base_frames} -> frames_eff={frames_eff} (soften={soften:.2f}, scale={scale:.2f})")
 
             _short(
                 context,
@@ -309,5 +292,4 @@ def run_clean_error_tracks(context, *, show_popups: bool = False, soften: float 
         'markers_after': int(markers_global_after),
         'soften': float(soften),
     }
-    print(f"[CleanError] SUMMARY: {result}")
     return result

--- a/Helper/error_value.py
+++ b/Helper/error_value.py
@@ -8,7 +8,6 @@ def error_value(scene):
     """Berechnet die Gesamt-Standardabweichung (X + Y) für selektierte Marker im aktiven Clip."""
     clip = bpy.context.space_data.clip
     if not clip:
-        print("[ERROR] Kein Clip geladen.")
         return None
 
     x_positions = []
@@ -24,12 +23,10 @@ def error_value(scene):
             y_positions.append(marker.co[1])
 
     if not x_positions:
-        print("[ERROR] Keine Marker selektiert.")
         return None
 
     error_x = std_dev(x_positions)
     error_y = std_dev(y_positions)
     total_error = error_x + error_y
 
-    print(f"[error_value] error_x={error_x:.6f}, error_y={error_y:.6f}, total={total_error:.6f}")
     return total_error

--- a/Helper/find_max_marker_frame.py
+++ b/Helper/find_max_marker_frame.py
@@ -136,8 +136,7 @@ def run_find_max_marker_frame(
     for idx, c in enumerate(counts):
         f = s_start + idx
         if log_each_frame:
-            print(f"[find_max_marker_frame] frame={f} count={c} threshold={threshold}")
-
+            pass
         if observed_min is None or c < observed_min:
             observed_min = c
             observed_min_frame = f

--- a/Helper/jump_to_frame.py
+++ b/Helper/jump_to_frame.py
@@ -80,7 +80,6 @@ def run_jump_to_frame(
     scn = context.scene
     clip, scn = _resolve_clip_and_scene(context)
     if ensure_clip and not clip:
-        print("[GotoFrame] Kein MovieClip im Kontext.")
         return {"status": "FAILED", "reason": "no_clip", "frame": None, "repeat_count": 0, "clamped": False, "area_switched": False}
 
     # Ziel-Frame bestimmen
@@ -88,7 +87,6 @@ def run_jump_to_frame(
     if target is None:
         target = scn.get("goto_frame", None)
     if target is None:
-        print("[GotoFrame] Scene-Variable 'goto_frame' nicht gesetzt.")
         return {"status": "FAILED", "reason": "no_target", "frame": None, "repeat_count": 0, "clamped": False, "area_switched": False}
 
     target = int(target)
@@ -138,7 +136,6 @@ def run_jump_to_frame(
         # --- Monitoring: Frames & Wiederholungen in die Konsole ---
     if repeat_map is not None:
         # Einzel-Info zum aktuellen Jump
-        print(f"[RepeatMon] frame={target} → count={repeat_count}")
 
         # Kleine Übersicht der „heißesten“ Frames gelegentlich ausgeben
         # (bei 5, 6 und danach alle 5 Sprünge; anpassen nach Bedarf)
@@ -146,14 +143,12 @@ def run_jump_to_frame(
             try:
                 top = sorted(repeat_map.items(), key=lambda kv: kv[1], reverse=True)[:8]
                 summary = ", ".join(f"{f}×{c}" for f, c in top)
-                print(f"[RepeatMon] top: {summary}")
             except Exception:
                 pass
 
         # Optionaler Alarm, wenn die 5er-Schwelle gerade überschritten wurde
         if repeat_count == 6:
-            print(f"[RepeatMon] ⚠ frame={target} hat die 5er-Schwelle überschritten.")
-
+            pass
     # Nach stabiler Playhead-Setzung: Wiederholungen auswerten (Optimizer-Signal entfernt)
     # (Frühere Optimizer-Request-Setzung bei repeat_count > 3 wurde entfernt.)
 
@@ -166,10 +161,8 @@ def run_jump_to_frame(
             from .marker_adapt_helper import run_marker_adapt_boost  # type: ignore
         try:
             run_marker_adapt_boost(context)
-            print(f"[JumpRepeat] run_marker_adapt_boost ausgelöst (frame={target}, repeat={repeat_count})")
         except Exception as ex:
-            print(f"[JumpRepeat] run_marker_adapt_boost Fehler: {ex}")
-
+            pass
     # Debugging & Transparenz
     try:
         scn["last_jump_frame"] = int(target)  # rein informativ; orchestrator nutzt repeat_map intern
@@ -179,7 +172,6 @@ def run_jump_to_frame(
     # Sättigungsflag für Rückgabe/Logging  ← HIER EINFÜGEN
     repeat_saturated = repeat_count >= REPEAT_SATURATION
 
-    print(f"[GotoFrame] Playhead auf Frame {target} gesetzt. (clamped={clamped}, repeat={repeat_count}, saturated={repeat_saturated})")
     return {
         "status": "OK",
         "frame": int(target),
@@ -203,7 +195,7 @@ def jump_to_frame(context):
     res = run_jump_to_frame(context, frame=None, repeat_map=None)
     ok = (res.get("status") == "OK")
     if ok:
-        print(f"[GotoFrame] Legacy OK → Frame {res.get('frame')}")
+        pass
     else:
-        print(f"[GotoFrame] Legacy FAILED → {res.get('reason','')}")
+        pass
     return ok

--- a/Helper/marker_adapt_helper.py
+++ b/Helper/marker_adapt_helper.py
@@ -19,7 +19,6 @@ def run_marker_adapt_boost(context: bpy.types.Context):
     scene["marker_adapt"] = int(new_val)
 
     msg = f"marker_adapt: {int(base_val)} → {int(new_val)}"
-    print(f"[MarkerAdapt] {msg}")
 
     # Identisches Abschlussverhalten wie ein Operator
     return {'FINISHED'}

--- a/Helper/marker_helper_main.py
+++ b/Helper/marker_helper_main.py
@@ -28,7 +28,5 @@ def marker_helper_main(context) -> Tuple[bool, int, Dict[str, Any]]:
     scn["resolve_error"] = float(resolve_error)
 
     # Telemetrie
-    print(f"[MarkerHelper] basis={marker_basis}, factor={factor} → adapt={marker_adapt}, "
-          f"min={marker_min}, max={marker_max} | frames_track={frames_track}, resolve_error={resolve_error}")
 
     return True, int(marker_adapt), {"FINISHED"}

--- a/Helper/parallax_keyframe.py
+++ b/Helper/parallax_keyframe.py
@@ -203,8 +203,7 @@ def scan_pairs(clip, frame_start, frame_end, step, tracks,
                 results.append(s)
 
             if progress_log_every and (checked % int(progress_log_every) == 0):
-                print(f"[Parallax] scanned={checked} results={len(results)} fa={fa} fb={fb}")
-
+                pass
         if truncated:
             break
 
@@ -316,7 +315,6 @@ def main(context):
 
     status = res.get("status")
     if status != "OK":
-        print(f"[Parallax Helper] Abbruch: {status}")
         return
 
     clip_name = res.get("clip", "?")
@@ -332,17 +330,14 @@ def main(context):
     for i, r in enumerate(res["top"], 1):
         line = f"{i:>2}. {format_row(r)}"
         lines.append(line)
-        print(line)
 
     write_textblock("parallax_keyframe_suggestions.txt", lines)
 
     if res.get("applied"):
         best = res["top"][0]
-        print(f"[Parallax Helper] Bestes Paar gesetzt: A={best['fa']}  B={best['fb']}")
+        pass
     if res.get("truncated"):
-        print("[Parallax Helper] Hinweis: Scan wurde durch Zeit-/Mengengrenze gekappt (truncated=True).")
-    print("[Parallax Helper] Fertig.")
-
+        pass
 
 # Direkt ausführen
 if __name__ == "__main__":

--- a/Helper/pre_find_max_marker_frame.py
+++ b/Helper/pre_find_max_marker_frame.py
@@ -136,8 +136,7 @@ def run_find_max_marker_frame(
     for idx, c in enumerate(counts):
         f = s_start + idx
         if log_each_frame:
-            print(f"[find_max_marker_frame] frame={f} count={c} threshold={threshold}")
-
+            pass
         if observed_min is None or c < observed_min:
             observed_min = c
             observed_min_frame = f

--- a/Helper/projection_delete.py
+++ b/Helper/projection_delete.py
@@ -53,7 +53,6 @@ def _get_current_solve_error_now(context) -> Optional[float]:
             require_has_bundle=require_has_bundle,
         )
         if worst is None:
-            print("[Cleanup] Kein Track mit gültigem average_error gefunden – Vorgang wird übersprungen.")
             result = {
                 "status": "SKIPPED",
                 "reason": "no_valid_track_error",
@@ -72,7 +71,6 @@ def _get_current_solve_error_now(context) -> Optional[float]:
 
         obj, track, err = worst
         name = getattr(track, "name", "<unnamed>")
-        print(f"[Cleanup] Lösche schlechtesten Track: {name} (avg_err={err:.4f}px)")
         ok = _delete_track(obj, track)
         _poke_update()
         after_count = _count_tracks(clip)
@@ -97,7 +95,6 @@ def _get_current_solve_error_now(context) -> Optional[float]:
 
         obj, track, err = worst
         name = getattr(track, "name", "<unnamed>")
-        print(f"[Cleanup] Lösche schlechtesten Track: {name} (avg_err={err:.4f}px)")
         ok = _delete_track(obj, track)
         after_count = _count_tracks(clip)
         deleted = 1 if ok and after_count == max(0, before_count - 1) else 0
@@ -125,11 +122,9 @@ def _get_current_solve_error_now(context) -> Optional[float]:
             break
 
     if used_error is None and wait_for_error:
-        print("[Cleanup] Kein Error übergeben → warte auf Solve-Error …")
         used_error = _wait_until_error(context, wait_forever=bool(wait_forever), timeout_s=float(timeout_s))
 
     if used_error is None:
-        print("[Cleanup] Kein gültiger Solve-Error verfügbar – Cleanup wird SKIPPED.")
         return {
             "status": "SKIPPED",
             "reason": "no_error",
@@ -143,12 +138,10 @@ def _get_current_solve_error_now(context) -> Optional[float]:
         }
 
     used_error = float(used_error) * 1.2
-    print(f"[Cleanup] Starte clean_tracks mit Grenzwert {used_error:.4f}px, action={action}")
 
     try:
         _invoke_clean_tracks(context, used_error=float(used_error), action=str(action if action in _allowed_actions() else "SELECT"))
     except Exception as ex:
-        print(f"[Cleanup] Fehler bei clean_tracks: {ex!r}")
         return {
             "status": "ERROR",
             "reason": repr(ex),
@@ -164,9 +157,6 @@ def _get_current_solve_error_now(context) -> Optional[float]:
     after_count = _count_tracks(clip)
     deleted = max(0, (before_count or 0) - (after_count or 0))
 
-    print(
-        f"[Cleanup] Cleanup abgeschlossen. Vorher={before_count}, nachher={after_count}, entfernt={deleted}"
-    )
 
     tco.on_projection_cleanup_finished(context=context)
 

--- a/Helper/projektion_spike_filter_cycle.py
+++ b/Helper/projektion_spike_filter_cycle.py
@@ -43,7 +43,7 @@ def _is_verbose(scene) -> bool:
 
 def _vprint(scene, msg: str) -> None:
     if _is_verbose(scene):
-        print(f"[ProjSpike] {msg}")
+        pass
 
 def _active_clip(context) -> Optional[bpy.types.MovieClip]:
     """Robuster Clip-Fallback (bevorzugt aktiven CLIP_EDITOR)."""

--- a/Helper/refine_high_error.py
+++ b/Helper/refine_high_error.py
@@ -287,7 +287,6 @@ class CLIP_OT_refine_high_error_modal(Operator):
             # Gate: nur verfeinern, wenn genügend Marker am Frame (beste Bedingungen)
             min_required = int(getattr(context.scene, "marker_frame", 25) or 25)
             if active_count < min_required:
-                print(f"[RefineModal] SKIP @scene={f_scene} (active={active_count} < required={min_required})")
                 self._target_index += 1
                 return {"RUNNING_MODAL"}
 
@@ -347,16 +346,13 @@ class CLIP_OT_refine_high_error_modal(Operator):
                                 mk.co.x, mk.co.y = x, y
                             except Exception:
                                 pass
-                    print(f"[RefineModal] ROLLBACK @scene={f_scene} (err {baseline_err:.3f}→{new_err:.3f})")
                 else:
-                    print(f"[RefineModal] KEEP @scene={f_scene} (err {baseline_err:.3f}→{new_err:.3f})")
-
+                    pass
             # nächstes Ziel
             self._target_index += 1
             return {"RUNNING_MODAL"}
 
         except Exception as ex:
-            print(f"[RefineModal] Error: {ex!r}")
             return self._finish(context, cancelled=True)
 
     # Hilfsfunktion: Ziele bestimmen (Beste Positionen + Solve-Error-Untergrenze + Mindestabstand)
@@ -396,10 +392,6 @@ class CLIP_OT_refine_high_error_modal(Operator):
                 selected.append(f)
 
         self._targets = selected
-        print(
-            f"[RefineModal] Solve-Error={thr:.6f} | frames_track={frames_track} "
-            f"→ min_spacing={min_spacing} | candidates={len(filtered)} | selected={len(self._targets)}"
-        )
 
     def _finish(self, context: Context, *, cancelled: bool):
         if self._timer:
@@ -409,7 +401,6 @@ class CLIP_OT_refine_high_error_modal(Operator):
             context.scene["refine_active"] = False
         except Exception:
             pass
-        print(f"[RefineModal] DONE ({'CANCELLED' if cancelled else 'FINISHED'})")
         return {"CANCELLED" if cancelled else "FINISHED"}
 
 

--- a/Helper/segments.py
+++ b/Helper/segments.py
@@ -18,7 +18,6 @@ def track_has_internal_gaps(track) -> bool:
             prev = f
         return False
     except Exception as e:
-        print(f"[segments] track_has_internal_gaps Safeguard: {e}")
         return False
 
 

--- a/Helper/solve_camera.py
+++ b/Helper/solve_camera.py
@@ -45,7 +45,6 @@ def solve_camera_only(context):
                 return bpy.ops.clip.solve_camera('INVOKE_DEFAULT')
         return bpy.ops.clip.solve_camera('INVOKE_DEFAULT')
     except Exception as e:
-        print(f"[Solve] Fehler beim Start des Solve-Operators: {e}")
         return {"CANCELLED"}
 
 
@@ -90,7 +89,6 @@ def solve_camera_only(context):
         ready = _wait_for_reconstruction(context, tries=_SOLVE_WAIT_TRIES_PER_TICK)
         if ready:
             err = _compute_solve_error(context)
-            print(f"[Coord] SOLVE_WAIT → reconstruction valid, error={err}")
     
             if err is None:
                 # Keine auswertbare Qualität → Fehlpfad
@@ -101,19 +99,16 @@ def solve_camera_only(context):
     
             # Optionaler Refine nach Solve (nur einmal)
             if (not self._post_solve_refine_done) and (err > thr):
-                print(f"[Coord] SOLVE_WAIT → error {err:.3f} > {thr:.3f} → launch REFINE")
                 self._launch_refine(context, threshold=thr)
                 return {"RUNNING_MODAL"}
     
             # Solve ok → fertig
-            print("[Coord] SOLVE_WAIT → OK → FINALIZE")
             self._state = "FINALIZE"
             return {"RUNNING_MODAL"}
     
         # Noch nicht ready → Countdown
         self._solve_wait_ticks = max(0, int(self._solve_wait_ticks) - 1)
         if self._solve_wait_ticks <= 0:
-            print("[Coord] SOLVE_WAIT → timeout → FAIL-SOLVE")
             return self._handle_failed_solve(context)
     
         return {"RUNNING_MODAL"}

--- a/Helper/spike_filter_cycle.py
+++ b/Helper/spike_filter_cycle.py
@@ -185,17 +185,15 @@ def _apply_marker_outlier_filter(
                     f = int(getattr(m_curr, "frame", -10))
                     tr.markers.delete_frame(f)
                     affected += 1
-                    print(f"[MarkerSpike] DELETE '{tr.name}' @ f{frame} |dev|={dev:.3f} > thr={threshold_px:.3f}")
                 except Exception as ex:
-                    print(f"[MarkerSpike] DELETE failed '{tr.name}' @ f{frame}: {ex!r}")
+                    pass
         elif do_mute:
             for tr, m_curr, dev in to_handle:
                 try:
                     m_curr.mute = True
                     affected += 1
-                    print(f"[MarkerSpike] MUTE '{tr.name}' @ f{frame} |dev|={dev:.3f} > thr={threshold_px:.3f}")
                 except Exception as ex:
-                    print(f"[MarkerSpike] MUTE failed '{tr.name}' @ f{frame}: {ex!r}")
+                    pass
         elif do_select:
             for tr, m_curr, dev in to_handle:
                 try:
@@ -205,9 +203,8 @@ def _apply_marker_outlier_filter(
                     except Exception:
                         pass
                     affected += 1
-                    print(f"[MarkerSpike] SELECT '{tr.name}' @ f{frame} |dev|={dev:.3f} > thr={threshold_px:.3f}")
                 except Exception as ex:
-                    print(f"[MarkerSpike] SELECT failed '{tr.name}' @ f{frame}: {ex!r}")
+                    pass
 
     return affected
 
@@ -244,15 +241,14 @@ def run_marker_spike_filter_cycle(
     # 1) Marker-Filter
     affected = _apply_marker_outlier_filter(context, threshold_px=thr, action=act)
     key = "deleted" if act == "DELETE" else ("muted" if act == "MUTE" else "selected")
-    print(f"[MarkerSpike] affected {affected} marker(s) with action={act}")
 
     # 2) Segment-Cleanup (optional via Flag)
     cleaned_segments = 0
     cleaned_markers = 0
     if not run_segment_cleanup:
-        print("[MarkerSpike] segment cleanup skipped (run_segment_cleanup=False)")
+        pass
     elif clean_short_segments is None:
-        print(f"[MarkerSpike] WARN: clean_short_segments not available ({_CSS_IMPORT_ERR!r})")
+        pass
     else:
         scene = getattr(context, "scene", None)
         if min_segment_len is None:
@@ -276,11 +272,9 @@ def run_marker_spike_filter_cycle(
                 cleaned_segments = int(res.get("segments_removed", 0) or 0)
                 cleaned_markers = int(res.get("markers_removed", 0) or 0)
         except Exception as ex:
-            print(f"[MarkerSpike] clean_short_segments failed: {ex!r}")
-
+            pass
     # 3) Next Threshold (sanft senken)
     next_thr = _lower_threshold(thr)
-    print(f"[MarkerSpike] next threshold → {next_thr}")
 
     return {
         "status": "OK",

--- a/Helper/split_cleanup.py
+++ b/Helper/split_cleanup.py
@@ -20,8 +20,7 @@ def _is_verbose(scene) -> bool:
 
 def _log(scene, msg: str) -> None:
     if _is_verbose(scene):
-        print(f"[SplitCleanup] {msg}")
-
+        pass
 
 # ------------------------------------------------------------
 # Utilities
@@ -343,7 +342,6 @@ def _iterative_segment_split(context, area, region, space, seed_tracks: Iterable
 
 def recursive_split_cleanup(context, area, region, space, tracks):
     scene = context.scene
-    print("[SplitCleanup] recursive_split_cleanup: start")
 
     clip = space.clip
     if clip is None:
@@ -355,22 +353,19 @@ def recursive_split_cleanup(context, area, region, space, tracks):
         fb = _segments_by_consecutive_frames_unmuted(t)
         if len(fb) > len(segs):
             segs = fb
-        print(f"[Audit-BEFORE] Track='{t.name}' segs={len(segs)} lens={[len(s) for s in segs]}")
 
     # 1) Neuer Kern: Iteratives Duplizieren & Abschälen
     try:
         _iterative_segment_split(context, area, region, space, tracks)
     except Exception as e:
-        print(f"[Audit-ERROR] IterSplit failed: {e}")
         # Fallback: nichts tun, weiter mit Delete-Policy
-
+        pass
     # --- Audit nach Split ---
     for t in clip.tracking.tracks:
         segs = list(get_track_segments(t))
         fb = _segments_by_consecutive_frames_unmuted(t)
         if len(fb) > len(segs):
             segs = fb
-        print(f"[Audit-AFTER_SPLIT] Track='{t.name}' segs={len(segs)} lens={[len(s) for s in segs]}")
 
     # (Enforcement entfällt; die Iteration konvergiert bis keine Multi-Segments mehr da sind)
     # --- Audit nach Enforcement ---
@@ -379,7 +374,6 @@ def recursive_split_cleanup(context, area, region, space, tracks):
         fb = _segments_by_consecutive_frames_unmuted(t)
         if len(fb) > len(segs):
             segs = fb
-        print(f"[Audit-ENFORCED] Track='{t.name}' segs={len(segs)} lens={[len(s) for s in segs]}")
 
     # 2) Delete-Policy
     try:
@@ -387,7 +381,6 @@ def recursive_split_cleanup(context, area, region, space, tracks):
     except Exception:
         min_len = 25
     deleted = _delete_tracks_by_max_unmuted_seg_len(context, clip.tracking.tracks, min_len=min_len)
-    print(f"[Audit-DELETE] deleted={deleted}")
 
     # --- Audit nach Delete ---
     leftover_multi = 0
@@ -398,12 +391,9 @@ def recursive_split_cleanup(context, area, region, space, tracks):
             segs = fb
         if len(segs) > 1:
             leftover_multi += 1
-            print(f"[Audit-LEFTOVER] Track='{t.name}' segs={len(segs)} lens={[len(s) for s in segs]}")
     if leftover_multi == 0:
-        print("[Audit-LEFTOVER] none")
-
+        pass
     # 3) Safety
     mute_unassigned_markers(clip.tracking.tracks)
 
-    print("[SplitCleanup] recursive_split_cleanup: FINISHED")
     return {'FINISHED'}

--- a/Helper/tracker_settings.py
+++ b/Helper/tracker_settings.py
@@ -75,7 +75,7 @@ def apply_tracker_settings(context, *, clip=None, scene=None, log: bool = True) 
     clip, scene = _resolve_clip_and_scene(context, clip=clip, scene=scene)
     if clip is None or scene is None:
         if log:
-            print("[TrackerSettings] Abbruch: Kein Clip oder Scene im Kontext.")
+            pass
         return {"status": "cancelled", "reason": "no_clip_or_scene"}
 
     # Breite robust lesen
@@ -169,18 +169,12 @@ def apply_tracker_settings(context, *, clip=None, scene=None, log: bool = True) 
     solver_changes['refine_radial_distortion'] = refine_radial_name
 
     if log:
-        print(
-            "[TrackerSettings] Defaults angewendet | "
-            f"clip={clip.name!r}, width={width}, pattern={pattern_size}, search={search_size}, "
-            f"clean_frames={ts.clean_frames}, clean_error={ts.clean_error}, "
-            f"last_detection_threshold={scene['last_detection_threshold']:.6f}"
-        )
         # Log welche Solver-Properties gesetzt wurden (falls vorhanden)
         for k, v in solver_changes.items():
             if v:
-                print(f"[TrackerSettings] Solver: gesetzt {k} -> {v} = False")
+                pass
             else:
-                print(f"[TrackerSettings] Solver: Property für {k} nicht gefunden, übersprungen")
+                pass
 
     return {
         "status": "ok",

--- a/Helper/tracking_helper.py
+++ b/Helper/tracking_helper.py
@@ -21,8 +21,7 @@ LOG_PREFIX = "[BW-Track]"
 # -----------------------------------------------------------------------------
 
 def _log(msg: str) -> None:
-    print(f"{LOG_PREFIX} {msg}")
-
+    pass
 
 def _iter_clip_areas():
     wm = bpy.context.window_manager

--- a/Helper/triplet_grouping.py
+++ b/Helper/triplet_grouping.py
@@ -79,7 +79,7 @@ def _group_into_triplets_by_position(
             groups.append(lst[i*3:(i+1)*3])
         rest = len(lst) % 3
         if rest:
-            print(f"[TripletGrouping] WARN: Bucket {k} Rest={rest} → nur volle 3er gespeichert.")
+            pass
     return groups
 
 
@@ -92,7 +92,6 @@ def _persist_groups(scene: bpy.types.Scene, groups: List[List[Dict[str, Any]]]) 
         scene[_TRIPLET_COUNT_KEY] = int(len(groups))
         return len(groups)
     except Exception as ex:
-        print(f"[TripletGrouping] Persist failed: {ex}")
         return 0
 
 
@@ -129,7 +128,7 @@ def run_triplet_grouping(
 
     # Eingangsmenge bestimmen
     if source != "selected":
-        print(f"[TripletGrouping] WARN: source='{source}' nicht unterstützt → fallback 'selected'")
+        pass
     items = _selected_tracks_with_pos(tracking, frame_now, width, height)
 
     # Epsilon-Heuristik (robust über Auflösung)
@@ -141,9 +140,7 @@ def run_triplet_grouping(
     # Quick-Sanity
     if stored * 3 != len(items):
         delta = len(items) - stored * 3
-        print(f"[TripletGrouping] INFO: selected={len(items)}, groups*3={stored*3}, Δ={delta}")
 
-    print(f"[TripletGrouping] STORED {stored} triplets @frame={frame_now} (eps={eps:.3f}px)")
     return {
         "status": "OK",
         "selected": int(len(items)),

--- a/save/spike_filter_cycle.py
+++ b/save/spike_filter_cycle.py
@@ -149,14 +149,10 @@ def run_spike_filter_cycle(
     thr = float(track_threshold)
     try:
         bpy.ops.clip.filter_tracks(track_threshold=thr)
-        print(f"[SpikeCycle] filter_tracks(track_threshold={thr})")
     except Exception as ex_ops:
-        print(f"[SpikeCycle] spike-filter step failed: {ex_ops!r}")
-
+        pass
     removed = _remove_selected_tracks(context)
-    print(f"[SpikeCycle] removed {removed} track(s) selected by filter")
 
     next_thr = _lower_threshold(thr)
-    print(f"[SpikeCycle] next track_threshold → {next_thr}")
 
     return {"status": "OK", "removed": int(removed), "next_threshold": float(next_thr)}


### PR DESCRIPTION
## Summary
- remove debug `print` statements across helpers and operator modules
- keep `print` output only in `Helper/preflight.py`
- revert `Operator/tracking_coordinator.py` to restore its original print statements

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v 'Helper/detect.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b0bb6d4a38832d9b57b6f94361be52