### PR TITLE
Add registration helpers to tracking coordinator

### DIFF
--- a/Operator/tracking_coordinator.py
+++ b/Operator/tracking_coordinator.py
@@ -948,7 +948,20 @@ class CLIP_OT_tracking_coordinator(bpy.types.Operator):
 
 
 
-# Alias-Klasse für Kompatibilität: erlaubt Aufruf über bpy.ops.CLIP_OT_tracking_coordinator
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+def register() -> None:
+    """Register operator and related scene state."""
+    register_scene_state()
+    bpy.utils.register_class(CLIP_OT_tracking_coordinator)
+
+
+def unregister() -> None:
+    """Unregister operator and clean up scene state."""
     bpy.utils.unregister_class(CLIP_OT_tracking_coordinator)
     unregister_scene_state()
 


### PR DESCRIPTION
## Summary
- define register and unregister functions for CLIP_OT_tracking_coordinator
- remove erroneous class-level unregister call

## Testing
- `python -m py_compile Operator/tracking_coordinator.py && echo done`


------
https://chatgpt.com/codex/tasks/task_e_68b19e4aa10c832db8eedd855cd70480