### PR TITLE
Handle registration failures to keep tracking coordinator available

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -134,8 +134,14 @@ def register() -> None:
     _register_scene_props()
 
     # 3) Externe Registrare: zuerst Helper (diverse Operatoren), dann Coordinator
-    _reg_helper()
-    _reg_coord()
+    try:
+        _reg_helper()
+    except Exception as ex:  # noqa: BLE001
+        print(f"[Kaiserlich Tracker] helper registration failed: {ex!r}")
+    try:
+        _reg_coord()
+    except Exception as ex:  # noqa: BLE001
+        print(f"[Kaiserlich Tracker] coordinator registration failed: {ex!r}")
 
     # 4) UI-Panels GANZ ZUM SCHLUSS
     for cls in _CLASSES_UI:
@@ -151,8 +157,14 @@ def unregister() -> None:
             pass
 
     # 2) Externe Unregister
-    _unreg_coord()
-    _unreg_helper()
+    try:
+        _unreg_coord()
+    except Exception as ex:  # noqa: BLE001
+        print(f"[Kaiserlich Tracker] coordinator unregister failed: {ex!r}")
+    try:
+        _unreg_helper()
+    except Exception as ex:  # noqa: BLE001
+        print(f"[Kaiserlich Tracker] helper unregister failed: {ex!r}")
 
     # 3) Scene-Properties
     _unregister_scene_props()


### PR DESCRIPTION
## Summary
- Register tracking helper and coordinator defensively so one failure doesn't block the other
- Mirror the same defensive checks during unregistration

## Testing
- `python -m py_compile __init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68b19f36f7a0832d8b2df6b33ddc316b