### PR TITLE
Add central reset utility for tracking cycles

### DIFF
--- a/Helper/__init__.py
+++ b/Helper/__init__.py
@@ -13,6 +13,10 @@ import bpy
 
 
 from .bidirectional_track import CLIP_OT_bidirectional_track
+from .reset_state import (
+    reset_for_new_cycle,
+    CLIP_OT_reset_runtime_state,
+)  # re-export
 
 # --- Optionale Operatoren ----------------------------------------------------
 try:
@@ -25,11 +29,14 @@ __all__ = [
     "register",
     "unregister",
     "CLIP_OT_bidirectional_track",
+    "reset_for_new_cycle",
+    "CLIP_OT_reset_runtime_state",
 ]
 
 # --- Registrierlisten --------------------------------------------------------
 _FIXED_CLASSES = [
     CLIP_OT_bidirectional_track,
+    CLIP_OT_reset_runtime_state,
 ]
 
 _OPTIONAL_CLASSES = []
@@ -51,11 +58,13 @@ def register() -> None:
             pass
 
 def unregister() -> None:
+    # Zuerst optionale Klassen rückwärts abmelden
     for cls in reversed(_OPTIONAL_CLASSES):
         try:
             bpy.utils.unregister_class(cls)
         except Exception:
             pass
+    # Danach fixe Klassen rückwärts abmelden (verhindert "already registered" beim Reload)
     for cls in reversed(_FIXED_CLASSES):
         try:
             bpy.utils.unregister_class(cls)

--- a/Helper/reset_state.py
+++ b/Helper/reset_state.py
@@ -207,7 +207,16 @@ def reset_for_new_cycle(context: bpy.types.Context) -> None:
     _wipe_clip_runtime(clip)
 
     # 2) Modulweite Solve-Logs/Caches bereinigen
-    caches_cleared = _reset_module_solve_log()
+    _reset_module_solve_log()
+
+    # 2b) Solve-Error Log (CollectionProperty) explizit zurücksetzen
+    try:
+        if hasattr(scene, "kaiserlich_solve_err_log"):
+            scene.kaiserlich_solve_err_log.clear()
+        if hasattr(scene, "kaiserlich_solve_attempts"):
+            scene.kaiserlich_solve_attempts = 0
+    except Exception:
+        pass
 
     # Optional: UI-Refresh, damit Panels frische Werte anzeigen
     try:
@@ -221,18 +230,9 @@ def reset_for_new_cycle(context: bpy.types.Context) -> None:
     try:
         clip = getattr(context, "edit_movieclip", None) or getattr(getattr(context, "space_data", None), "clip", None)
         cname = getattr(clip, "name", "<none>")
-        # Anzahl aktuell gesetzter kc_* Keys
         kc_count = sum(1 for k in scene.keys() if str(k).startswith("kc_"))
-        # Länge der Solve-Error-Liste reporten
-        err_len = 0
-        try:
-            err = scene.get("kc_error_solves", [])
-            err_len = len(err) if isinstance(err, list) else 0
-        except Exception:
-            pass
-        print(
-            f"[Reset] purged={purged} kc_count={kc_count} caches={caches_cleared} clip={cname} kc_error_solves_len={err_len}"
-        )
+        log_len = len(scene.kaiserlich_solve_err_log) if hasattr(scene, "kaiserlich_solve_err_log") else -1
+        print(f"[Reset] purged={purged} kc_count={kc_count} clip={cname} solve_log_len={log_len}")
     except Exception:
         pass
 

--- a/Helper/reset_state.py
+++ b/Helper/reset_state.py
@@ -23,6 +23,7 @@ RUNTIME_KEYS: Iterable[str] = (
     "kc_marker_counts",
     "kc_log_rows",
     "kc_last_frames_checked",
+    "kc_error_solves",        # Liste aller Solve-Errors → beim Reset leeren
     # Mappings/Dicts
     "kc_repeat_frame",
 )
@@ -63,7 +64,13 @@ def _set_default(scene: bpy.types.Scene, key: str) -> None:
         scene[key] = 2.0        # Zielwert für avg reprojection error
     elif key == "kc_refine_intrinsics_focal_length":
         scene[key] = False      # erster Solve ohne Refine
-    elif key in {"kc_avg_error_history", "kc_marker_counts", "kc_log_rows", "kc_last_frames_checked"}:
+    elif key in {
+        "kc_avg_error_history",
+        "kc_marker_counts",
+        "kc_log_rows",
+        "kc_last_frames_checked",
+        "kc_error_solves",
+    }:
         scene[key] = []         # Listen konsequent leeren
     elif key == "kc_repeat_frame":
         scene[key] = {}         # Wiederhol-Map (Frame -> Count)

--- a/Helper/reset_state.py
+++ b/Helper/reset_state.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+import bpy
+from typing import Iterable, Set
+
+__all__ = ("reset_for_new_cycle", "CLIP_OT_reset_runtime_state")
+
+# Einheitliche Präfixe für Runtime-Variablen dieses Add-ons.
+RUNTIME_KEYS: Iterable[str] = (
+    # Zähler/Indikatoren
+    "kc_cycle_index",
+    "kc_solve_attempts",
+    "kc_findlow_finished",
+    "kc_findmax_finished",
+    "kc_projection_cleanup_runs",
+    # Schwellwerte/Parameter
+    "kc_spike_threshold",
+    "kc_spike_floor",
+    "kc_spike_decay",
+    "kc_error_track_target",
+    "kc_refine_intrinsics_focal_length",
+    # Sammlungen/Listen
+    "kc_avg_error_history",
+    "kc_marker_counts",
+    "kc_log_rows",
+    "kc_last_frames_checked",
+    # Mappings/Dicts
+    "kc_repeat_frame",
+)
+
+def _purge_unknown_kc_keys(scene: bpy.types.Scene, allow: Set[str]) -> int:
+    """Entfernt verwaiste kc_* ID-Props, die nicht mehr in RUNTIME_KEYS gelistet sind."""
+    removed = 0
+    try:
+        # keys() liefert nur ID-Props, nicht RNA-Properties
+        for k in list(scene.keys()):
+            if isinstance(k, str) and k.startswith("kc_") and k not in allow:
+                try:
+                    del scene[k]
+                    removed += 1
+                except Exception:
+                    pass
+    except Exception:
+        pass
+    return removed
+
+def _set_default(scene: bpy.types.Scene, key: str) -> None:
+    """Definiert robuste Default-Werte pro Key (ID-Properties!)."""
+    if key == "kc_cycle_index":
+        scene[key] = 0
+    elif key == "kc_solve_attempts":
+        scene[key] = 0
+    elif key in {"kc_findlow_finished", "kc_findmax_finished"}:
+        scene[key] = False
+    elif key == "kc_projection_cleanup_runs":
+        scene[key] = 0
+    elif key == "kc_spike_threshold":
+        scene[key] = 100.0     # Startwert für SPIKE_CYCLE
+    elif key == "kc_spike_floor":
+        scene[key] = 10.0       # Abbruchschwelle
+    elif key == "kc_spike_decay":
+        scene[key] = 0.9        # Multiplikativer Decay
+    elif key == "kc_error_track_target":
+        scene[key] = 2.0        # Zielwert für avg reprojection error
+    elif key == "kc_refine_intrinsics_focal_length":
+        scene[key] = False      # erster Solve ohne Refine
+    elif key in {"kc_avg_error_history", "kc_marker_counts", "kc_log_rows", "kc_last_frames_checked"}:
+        scene[key] = []         # Listen konsequent leeren
+    elif key == "kc_repeat_frame":
+        scene[key] = {}         # Wiederhol-Map (Frame -> Count)
+    else:
+        # Fallback: entfernen, falls als ID-Prop gesetzt
+        try:
+            if key in scene.keys():
+                del scene[key]
+        except Exception:
+            scene[key] = None
+
+def _wipe_clip_runtime(clip: bpy.types.MovieClip | None) -> None:
+    """Clip-/Tracking-bezogene volatile Stati zurücksetzen (nicht: Tracks löschen!)."""
+    if not clip:
+        return
+    # Deselect all to start clean – wir verändern KEINE Daten-Inhalte.
+    try:
+        tr = clip.tracking
+        for track in tr.tracks:
+            track.select = False
+        for obj in tr.objects:
+            for t in obj.tracks:
+                t.select = False
+    except Exception:
+        pass
+
+def reset_for_new_cycle(context: bpy.types.Context) -> None:
+    """
+    Zentrale Reset-Funktion für den Neustart des Ablaufs.
+    - Setzt alle bekannten Runtime-Werte auf Defaults
+    - Bereinigt temporäre Selektionen am aktiven Clip
+    - Verändert keine persistenten Projektdaten (keine Marker-/Track-Löschungen)
+    """
+    scene = context.scene
+    # 0) Altlasten entfernen (verwaiste kc_* Keys)
+    purged = _purge_unknown_kc_keys(scene, allow=set(RUNTIME_KEYS))
+    # 1) Scene-Keys konsistent initialisieren/überschreiben
+    for k in RUNTIME_KEYS:
+        _set_default(scene, k)
+
+    # Aktiven Clip finden und temporäre Auswahlen zurücksetzen
+    clip = getattr(context, "edit_movieclip", None)
+    if not clip:
+        clip = getattr(getattr(context, "space_data", None), "clip", None)
+    if not clip and bpy.data.movieclips:
+        clip = next(iter(bpy.data.movieclips), None)
+    _wipe_clip_runtime(clip)
+
+    # Optional: UI-Refresh, damit Panels frische Werte anzeigen
+    try:
+        for area in context.window.screen.areas:
+            if area.type in {"CLIP_EDITOR", "VIEW_3D", "PROPERTIES"}:
+                area.tag_redraw()
+    except Exception:
+        pass
+
+    # 3) Minimaler Konsistenz-Log
+    try:
+        clip = getattr(context, "edit_movieclip", None) or getattr(getattr(context, "space_data", None), "clip", None)
+        cname = getattr(clip, "name", "<none>")
+        # Anzahl aktuell gesetzter kc_* Keys
+        kc_count = sum(1 for k in scene.keys() if str(k).startswith("kc_"))
+        print(f"[Reset] purged={purged} kc_count={kc_count} clip={cname}")
+    except Exception:
+        pass
+
+
+class CLIP_OT_reset_runtime_state(bpy.types.Operator):
+    """Setzt alle laufzeitgenerierten Kaiserlich-Tracker States zurück (ID-Props & Selektionen)."""
+    bl_idname = "clip.kc_reset_runtime_state"
+    bl_label = "Reset Runtime State"
+    bl_options = {"REGISTER", "UNDO"}
+
+    def execute(self, context: bpy.types.Context):  # type: ignore[override]
+        try:
+            reset_for_new_cycle(context)
+            self.report({"INFO"}, "Runtime-State zurückgesetzt.")
+            return {"FINISHED"}
+        except Exception as exc:  # pragma: no cover - defensive
+            self.report({"ERROR"}, f"Reset fehlgeschlagen: {exc}")
+            return {"CANCELLED"}

--- a/Operator/tracking_coordinator.py
+++ b/Operator/tracking_coordinator.py
@@ -18,6 +18,7 @@ from ..Helper.split_cleanup import recursive_split_cleanup
 from ..Helper.find_max_marker_frame import run_find_max_marker_frame  # type: ignore
 from ..Helper.solve_camera import solve_camera_only  # type: ignore
 from ..Helper.reduce_error_tracks import run_reduce_error_tracks, get_avg_reprojection_error  # type: ignore
+from ..Helper.reset_state import reset_for_new_cycle  # ← NEU: zentraler Reset
 
 # Versuche, die Auswertungsfunktion für die Markeranzahl zu importieren.
 # Diese Funktion soll nach dem Distanz-Cleanup ausgeführt werden und
@@ -267,6 +268,9 @@ class CLIP_OT_tracking_coordinator(bpy.types.Operator):
             self.report({'ERROR'}, f"Bootstrap failed: {exc}")
             return {'CANCELLED'}
         self.report({'INFO'}, "Coordinator: Bootstrap OK")
+
+        # Harter Neustart aller Runtime-Werte/Listen
+        reset_for_new_cycle(context)
 
         # Modal starten
         self.phase = PH_FIND_LOW
@@ -657,6 +661,7 @@ class CLIP_OT_tracking_coordinator(bpy.types.Operator):
                 except Exception as _exc:
                     self.report({'WARNING'}, f"ReduceErrorTracks(FORCE) Fehler: {_exc}")
                 # reset → neuer Zyklus
+                reset_for_new_cycle(context)
                 self.detection_threshold = None
                 self.pre_ptrs = None
                 self.target_frame = None
@@ -687,6 +692,7 @@ class CLIP_OT_tracking_coordinator(bpy.types.Operator):
             red = run_reduce_error_tracks(context, max_to_delete=x)
             self.report({'INFO'}, f"ReduceErrorTracks: avg={avg_err:.4f} target={t:.4f} → delete={x} → done={red.get('deleted')} {red.get('names')}")
             # 6) Reset & zurück in den Hauptzyklus
+            reset_for_new_cycle(context)
             self.detection_threshold = None
             self.pre_ptrs = None
             self.target_frame = None
@@ -728,6 +734,7 @@ class CLIP_OT_tracking_coordinator(bpy.types.Operator):
             rmax = run_find_max_marker_frame(context)
             if rmax.get("status") == "FOUND":
                 # Erfolg → regulären Zyklus neu starten
+                reset_for_new_cycle(context)
                 self.spike_threshold = None
                 scn["tco_spike_cycle_finished"] = False
                 self.phase = PH_FIND_LOW
@@ -809,6 +816,7 @@ class CLIP_OT_tracking_coordinator(bpy.types.Operator):
                     self.report({'INFO'}, "Cleanup nach Bidirectional-Track ausgeführt")
                 except Exception as exc:
                     self.report({'WARNING'}, f"Cleanup nach Bidirectional-Track fehlgeschlagen: {exc}")
+                reset_for_new_cycle(context)
                 self.detection_threshold = None
                 self.pre_ptrs = None
                 self.target_frame = None


### PR DESCRIPTION
## Summary
- expose a reset helper in Helper to clear runtime tracking variables and clip selections
- integrate the reset helper into the tracking coordinator so each cycle starts from a clean state
- provide an operator to manually reset runtime state and register it in the Helper package
- purge stray kc_* properties and log reset consistency information
- clarify unregister order so optional classes unload before fixed ones

## Testing
- `blender --version` *(fails: command not found)*
- `python -m pip install flake8` *(fails: Tunnel connection failed: 403 Forbidden)*
- `python -m flake8 Helper/reset_state.py Helper/__init__.py Operator/tracking_coordinator.py` *(fails: No module named flake8)*
- `python -m py_compile Helper/reset_state.py Helper/__init__.py Operator/tracking_coordinator.py`


------
https://chatgpt.com/codex/tasks/task_e_68b76e207fb0832d8b82477ee017b424