### PR TITLE
Handle invalid detect thresholds to prevent loops

### DIFF
--- a/Helper/detect.py
+++ b/Helper/detect.py
@@ -284,7 +284,13 @@ def run_detect_basic(
             pass
 
         # Threshold persistieren (nur Threshold, keine margin/min_dist Persistenz)
-        scn[DETECT_LAST_THRESHOLD_KEY] = float(thr)
+        thr = float(thr)
+        if thr <= 1e-6:
+            thr = 0.75
+        try:
+            bpy.context.scene[DETECT_LAST_THRESHOLD_KEY] = thr
+        except Exception:
+            pass
 
         return {
             "status": "READY",


### PR DESCRIPTION
## Summary
- add retry counter for detect calls and reset it in relevant phases
- sanitize detection threshold inputs and outputs with retry limiter and safe scene synchronization
- clamp detect threshold before persisting to scene to avoid zero-value loops

## Testing
- `python -m py_compile Helper/detect.py Operator/tracking_coordinator.py`
- `pip install flake8` *(failed: Could not find a version that satisfies the requirement flake8)*
- `flake8 Helper/detect.py Operator/tracking_coordinator.py` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba4207d34c832d9b8686fe2f85e2aa