### PR TITLE
Limit max error frame search to scene range

### DIFF
--- a/Operator/tracking_coordinator.py
+++ b/Operator/tracking_coordinator.py
@@ -831,7 +831,8 @@ class CLIP_OT_tracking_coordinator(bpy.types.Operator):
                         min_cov = 10
                     try:
                         r = run_find_max_error_frame(context, include_muted=False, min_tracks_per_frame=min_cov,
-                                                     frame_min=None, frame_max=None, return_top_k=5, verbose=True)
+                                                     frame_min=int(scn.frame_start), frame_max=int(scn.frame_end),
+                                                     return_top_k=5, verbose=True)
                     except Exception as _exc:
                         r = {"status": "ERROR", "reason": str(_exc)}
                     if r.get("status") == "FOUND":


### PR DESCRIPTION
## Summary
- restrict `run_find_max_error_frame` search to the scene's start and end frames

## Testing
- `python -m py_compile $(git ls-files '*.py') && echo 'py_compile passed'`


------
https://chatgpt.com/codex/tasks/task_e_68ba56e5be78832d996bd95c661752aa