### PR TITLE
Reorder class registration and scene property setup

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -182,20 +182,24 @@ _CLASSES = (
 
 def register() -> None:
     from .ui import register as _ui_register
-    _register_scene_props()
+    # 1) Klassen zuerst registrieren (damit bl_rna existiert)
     for cls in _CLASSES:
         bpy.utils.register_class(cls)
+    # 2) Dann Scene-Properties anlegen (nutzt registrierte PropertyGroups)
+    _register_scene_props()
     _ui_register()  # Panels/Menus/Overlay
 
 def unregister() -> None:
     from .ui import unregister as _ui_unregister
     _ui_unregister()
+    # 1) Scene-Properties zuerst sauber entfernen (lösen Referenzen)
+    _unregister_scene_props()
+    # 2) Dann Klassen deregistrieren
     for cls in reversed(_CLASSES):
         try:
             bpy.utils.unregister_class(cls)
         except Exception:
             pass
-    _unregister_scene_props()
 
 if __name__ == "__main__":
     register()


### PR DESCRIPTION
## Summary
- register classes before scene properties so PropertyGroups are initialized
- unregister scene properties prior to deregistering classes

## Testing
- `python -m py_compile __init__.py`
- `pip install pycodestyle` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc3442878832d9277b8e0fe5ad75f