### PR TITLE
Avoid duplicate solve logs and log once per evaluation cycle

### DIFF
--- a/Operator/tracking_coordinator.py
+++ b/Operator/tracking_coordinator.py
@@ -813,18 +813,14 @@ class CLIP_OT_tracking_coordinator(bpy.types.Operator):
 
             # 1) aktuellen Fehler messen & loggen
             avg_err = get_avg_reprojection_error(context)
-            # NEU: Solve-Error in Log/Overlay schreiben (NaN/Inf werden intern gefiltert)
-            try:
-                _solve_log(context, avg_err)
-            except Exception:
-                pass
+            # Exakt EINE Log-Auslösung pro Eval-Zyklus:
+            try: _solve_log(context, avg_err)
+            except Exception: pass
 
             # Erfolgskriterium (Eval #1): Ziel erreicht â†’ harter Exit
             try:
                 if (avg_err is not None) and (float(avg_err) < float(target_err)):
-                    # Erfolg ebenfalls mitloggen (damit die Kurve den finalen Punkt enthält)
-                    try: _solve_log(context, avg_err)
-                    except Exception: pass
+                    # Kein zweites Logging hier – bereits oben geloggt.
                     self.report({'INFO'}, f"Solve OK: avg={float(avg_err):.4f} < target={float(target_err):.4f}")
                     return self._finish(context, info="Sequenz abgeschlossen (Solve-Ziel erreicht).", cancelled=False)
             except Exception:
@@ -840,9 +836,7 @@ class CLIP_OT_tracking_coordinator(bpy.types.Operator):
             except Exception:
                 is_regression = False
             if is_regression:
-                # Regression protokollieren, bevor wir auf Worst-Frame springen
-                try: _solve_log(context, avg_err)
-                except Exception: pass
+                # Kein zweites Logging – bereits oben geloggt.
                 if run_find_max_error_frame is not None:
                     try:
                         min_cov = int(scn.get("min_tracks_per_frame_for_max_error", 10))

--- a/ui/solve_log.py
+++ b/ui/solve_log.py
@@ -15,6 +15,26 @@ def kaiserlich_solve_log_add(context: bpy.types.Context, value: float | None) ->
     if (v != v) or math.isinf(v):  # NaN/Inf rausfiltern
         return
 
+    # ---- Entprellung/Dedupe -----------------------------------------------
+    # 1) Pro Attempt nur einen Eintrag (falls Property existiert)
+    try:
+        attempt = int(getattr(scn, "kaiserlich_solve_attempts", -1))
+    except Exception:
+        attempt = -1
+    last_attempt = scn.get("_kaiserlich_last_attempt_logged", None) if scn else None
+    # 2) Zeitfenster-Entprellung (Back-to-back Doppelcalls)
+    now = time.time()
+    last_ts = scn.get("_kaiserlich_last_log_ts", 0.0) if scn else 0.0
+    last_v = scn.get("_kaiserlich_last_log_v", None) if scn else None
+
+    # Gleicher Attempt bereits verbucht? -> verwerfen
+    if attempt is not None and last_attempt is not None and attempt == last_attempt:
+        return
+    # Falls kein Attempt-Tracking verfügbar: innerhalb 0.5s denselben Wert (±1e-6) nicht doppelt loggen
+    if attempt == -1:
+        if (now - float(last_ts) < 0.5) and (last_v is not None) and (abs(float(last_v) - v) <= 1e-6):
+            return
+
     scn = context.scene
     try:
         scn.kaiserlich_solve_attempts += 1
@@ -40,3 +60,11 @@ def kaiserlich_solve_log_add(context: bpy.types.Context, value: float | None) ->
         coll.remove(len(coll) - 1)
 
     tag_clip_redraw()
+
+    # Metadaten für Dedupe aktualisieren
+    try:
+        scn["_kaiserlich_last_attempt_logged"] = attempt
+        scn["_kaiserlich_last_log_ts"] = now
+        scn["_kaiserlich_last_log_v"] = v
+    except Exception:
+        pass


### PR DESCRIPTION
## Summary
- prevent duplicate solve log entries by deduping attempts and time window
- ensure tracking coordinator triggers solve log only once per evaluation cycle

## Testing
- `python -m py_compile ui/solve_log.py Operator/tracking_coordinator.py`
- `flake8 ui/solve_log.py Operator/tracking_coordinator.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bce01530bc832d9d6f0a7b9b8be65d