### PR TITLE
Simplify distance cleanup logging

### DIFF
--- a/Helper/distanze.py
+++ b/Helper/distanze.py
@@ -12,13 +12,8 @@ import bpy
 from mathutils import Vector
 
 __all__ = ("run_distance_cleanup",)
-LOG_PREFIX = "DISTANZE"
 DETECT_LAST_THRESHOLD_KEY = "last_detection_threshold"  # Fallback-Key, ohne Modulimport
-
-def _log(msg: str, *, verbose: bool):
-    """Lightweight logger; suppressed when verbose=False."""
-    if verbose:
-        print(f"[{LOG_PREFIX}] {msg}")
+LOG_PREFIX = "DISTANZE"
 
 def _resolve_clip(context: bpy.types.Context) -> Optional[bpy.types.MovieClip]:
     scn = getattr(context, "scene", None)
@@ -68,7 +63,7 @@ def _dist2(a: Vector, b: Vector, *, unit: str, clip_size: Optional[Tuple[float, 
     dy = a.y - b.y
     return dx * dx + dy * dy
 
-def _compute_detect_min_distance(context: bpy.types.Context, *, verbose: bool) -> tuple[int, float, float, int]:
+def _compute_detect_min_distance(context: bpy.types.Context) -> tuple[int, float, float, int]:
     scn = context.scene
     base_px = int(scn.get("min_distance_base", 8))
     thr = float(scn.get(DETECT_LAST_THRESHOLD_KEY, 0.75))
@@ -87,11 +82,9 @@ def cleanup_new_markers_at_frame(
     require_selected_new: bool = True,
     include_muted_old: bool = False,
     select_remaining_new: bool = True,
-    verbose: bool = True,
 ) -> Dict[str, Any]:
     clip = _resolve_clip(context)
     if not clip:
-        _log("No active clip found – aborting distance cleanup.", verbose=verbose)
         return {"status": "FAILED", "reason": "no_clip"}
 
     clip_size: Optional[Tuple[float, float]] = None
@@ -104,15 +97,13 @@ def cleanup_new_markers_at_frame(
     auto_min_used = False
     auto_info: Dict[str, Any] = {}
     if min_distance is None or float(min_distance) <= 0.0:
-        detect_min_px, thr, factor, base_px = _compute_detect_min_distance(context, verbose=verbose)
+        detect_min_px, thr, factor, base_px = _compute_detect_min_distance(context)
         min_distance = float(detect_min_px)
         distance_unit = "pixel"
         auto_min_used = True
         auto_info = {"auto_min_dist_px": int(detect_min_px), "thr": float(thr), "factor": float(factor), "base_px": int(base_px)}
-        _log(f"Using auto-derived minimum distance: {detect_min_px}px (thr={thr:.3f}, factor={factor:.4f}, base_px={base_px})", verbose=verbose)
 
     pre_ptrs_set: Set[int] = set(int(p) for p in (pre_ptrs or []))
-    _log(f"Starting cleanup on frame {frame} with min_distance={min_distance} {distance_unit}; old tracks={len(pre_ptrs_set)}", verbose=verbose)
 
     # Collect reference positions from OLD tracks (ignore muted/estimated)
     old_positions: list[Vector] = []
@@ -135,7 +126,6 @@ def cleanup_new_markers_at_frame(
 
     # New tracks = all tracks not in pre_ptrs
     new_tracks = [tr for tr in clip.tracking.tracks if int(tr.as_pointer()) not in pre_ptrs_set]
-    _log(f"Found {len(old_positions)} reference markers and {len(new_tracks)} new tracks to inspect.", verbose=verbose)
 
     min_d2 = float(min_distance) * float(min_distance)
     removed = 0
@@ -176,20 +166,31 @@ def cleanup_new_markers_at_frame(
             too_close = nearest_d2 < min_d2 if old_positions else False
 
             if too_close:
+                # Log NUR für zu nahe Marker
+                try:
+                    print(f"[{LOG_PREFIX}] TooClose track={getattr(tr, 'name', '')} frame={frame} d2={nearest_d2:.4f}")
+                except Exception:
+                    pass
                 # robustes Löschen: zuerst framegenau, dann Marker-Objekt
                 try:
                     tr.markers.delete_frame(int(frame))
                     removed += 1
-                    _log(f"Removed marker from track {getattr(tr, 'name', '')} at frame {frame} (too close to existing).", verbose=verbose)
+                    try:
+                        print(f"[{LOG_PREFIX}] Deleted track={getattr(tr, 'name', '')} frame={frame} method=delete_frame")
+                    except Exception:
+                        pass
                     continue
                 except Exception:
                     try:
                         tr.markers.delete(m)
                         removed += 1
-                        _log(f"Removed marker (fallback) from track {getattr(tr, 'name', '')} at frame {frame}.", verbose=verbose)
+                        try:
+                            print(f"[{LOG_PREFIX}] Deleted track={getattr(tr, 'name', '')} frame={frame} method=delete(marker)")
+                        except Exception:
+                            pass
                         continue
-                    except Exception as exc:
-                        _log(f"ERROR: Failed to remove marker on track {getattr(tr, 'name', '')} at frame {frame}: {exc}", verbose=verbose)
+                    except Exception:
+                        # Keine weiteren Logs (nur TooClose/Deleted gewünscht)
                         continue
 
             if select_remaining_new:
@@ -199,7 +200,6 @@ def cleanup_new_markers_at_frame(
                 except Exception:
                     pass
             kept += 1
-    _log(f"Cleanup complete: removed={removed}, kept={kept}, checked={checked}, skipped_no_marker={skipped_no_marker}, skipped_unselected={skipped_unselected}", verbose=verbose)
     return {
         "status": "OK",
         "frame": int(frame),
@@ -226,14 +226,7 @@ def run_distance_cleanup(
     require_selected_new: bool = True,
     include_muted_old: bool = False,
     select_remaining_new: bool = True,
-    verbose: bool = True,
 ) -> Dict[str, Any]:
-    _log(
-        f"run_distance_cleanup called: frame={frame}, min_distance={min_distance}, unit={distance_unit}, "
-        f"require_selected_new={require_selected_new}, include_muted_old={include_muted_old}, "
-        f"select_remaining_new={select_remaining_new}",
-        verbose=verbose,
-    )
     result = cleanup_new_markers_at_frame(
         context,
         pre_ptrs=pre_ptrs,
@@ -243,7 +236,5 @@ def run_distance_cleanup(
         require_selected_new=require_selected_new,
         include_muted_old=include_muted_old,
         select_remaining_new=select_remaining_new,
-        verbose=verbose,
     )
-    _log(f"run_distance_cleanup result: {result}", verbose=verbose)
     return result


### PR DESCRIPTION
## Summary
- remove `_log` helper and verbose flags from `distanze`
- report only distance conflicts via direct `print`

## Testing
- `python -m py_compile Helper/distanze.py`
- `flake8 Helper/distanze.py` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bd3f90c298832d92ad7a3b4af35134