### PR TITLE
Revert removal of early cleanup and pruning

### DIFF
--- a/Helper/detect.py
+++ b/Helper/detect.py
@@ -260,8 +260,6 @@ def run_detect_basic(
             min_distance_px=min_dist,
         )
 
-        # Entfernt: kein sofortiges Clean nach DETECT
-
         # Nach der Marker-Detection: neu erzeugte Spuren als â€žneuâ€œ markieren
         # Ermitteln Sie alle Tracks, die im Vergleich zu pre_ptrs neu sind. Diese
         # werden als ausgewÃ¤hlt markiert, damit nachfolgende DistanzprÃ¼fungen

--- a/Helper/multi.py
+++ b/Helper/multi.py
@@ -267,8 +267,6 @@ def _run_multi_core(
             placement="FRAME",
         )
 
-        # Entfernt: kein Früh-Cleanup mehr. Neue Tracks dürfen Länge aufbauen.
-
         created = [t for t in tracking.tracks if t.as_pointer() not in before]
         return len(created), eff
 
@@ -333,8 +331,6 @@ def run_multi_pass(context: bpy.types.Context, *, frame: Optional[int] = None, *
 
     post_all_ptrs = _snapshot_all_ptrs(clip)
     new_multi_ptrs = list(post_all_ptrs.difference(pre_all_ptrs))
-
-    # Entfernt: kein Post-Pruning in MULTI
 
     _clear_selection_at_frame(clip, frame)
     _select_ptrs_at_frame(clip, frame, pre_selected_ptrs.union(new_multi_ptrs))

--- a/Operator/tracking_coordinator.py
+++ b/Operator/tracking_coordinator.py
@@ -558,7 +558,6 @@ class CLIP_OT_tracking_coordinator(bpy.types.Operator):
             if self.pre_ptrs is None or self.target_frame is None:
                 return self._finish(context, info="DISTANZE: Pre-Snapshot oder Ziel-Frame fehlt.", cancelled=True)
             try:
-                # Phase: DISTANZE -> harte Löschung (entfällt)
                 info = run_distance_cleanup(
                     context,
                     pre_ptrs=self.pre_ptrs,
@@ -570,7 +569,6 @@ class CLIP_OT_tracking_coordinator(bpy.types.Operator):
                     include_muted_old=False,
                     select_remaining_new=True,
                     verbose=True,
-                    apply_delete=False,
                 )
             except Exception as exc:
                 return self._finish(context, info=f"DISTANZE FAILED â†’ {exc}", cancelled=True)
@@ -778,7 +776,6 @@ class CLIP_OT_tracking_coordinator(bpy.types.Operator):
                                 f"selected={mp_res.get('selected')}"
                             ))
                             # Nach dem Multiâ€‘Pass eine DistanzprÃ¼fung durchfÃ¼hren.
-                            # Entfernt: kein Short-Pruning im MULTI-Zyklus
                             try:
                                 cur_frame = int(self.target_frame) if self.target_frame is not None else None
                                 if cur_frame is not None:
@@ -792,7 +789,6 @@ class CLIP_OT_tracking_coordinator(bpy.types.Operator):
                                         include_muted_old=False,
                                         select_remaining_new=True,
                                         verbose=True,
-                                        apply_delete=False,
                                     )
                                     try:
                                         context.scene["tco_last_multi_distance_cleanup"] = dist_res  # type: ignore


### PR DESCRIPTION
## Summary
- revert merge that disabled automatic track pruning and dry-run distance cleanup

## Testing
- `python -m py_compile Helper/detect.py Helper/distanze.py Helper/multi.py Operator/tracking_coordinator.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf57225910832d965b6c0550c8b2bc