### PR TITLE
Use baseline pointers for distance cleanup

### DIFF
--- a/Operator/tracking_coordinator.py
+++ b/Operator/tracking_coordinator.py
@@ -560,7 +560,7 @@ class CLIP_OT_tracking_coordinator(bpy.types.Operator):
             try:
                 info = run_distance_cleanup(
                     context,
-                    pre_ptrs=self.pre_ptrs,
+                    baseline_ptrs=self.pre_ptrs,
                     frame=int(self.target_frame),
                     # min_distance=None â†’ Auto-Ableitung in distanze.py (aus Threshold & scene-base)
                     min_distance=None,
@@ -781,7 +781,7 @@ class CLIP_OT_tracking_coordinator(bpy.types.Operator):
                                 if cur_frame is not None:
                                     dist_res = run_distance_cleanup(
                                         context,
-                                        pre_ptrs=current_ptrs,
+                                        baseline_ptrs=current_ptrs,
                                         frame=cur_frame,
                                         min_distance=None,
                                         distance_unit="pixel",


### PR DESCRIPTION
## Summary
- Support baseline pointer snapshots in `run_distance_cleanup` to split old vs. new tracks reliably
- Track coordinator now forwards the pre-detection pointer set via `baseline_ptrs` when invoking distance cleanup

## Testing
- `python -m py_compile Helper/distanze.py Operator/tracking_coordinator.py`
- ⚠️ `flake8 Helper/distanze.py Operator/tracking_coordinator.py` *(failed: command not found; pip install blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5fd4528c832da94e5a2c19e22d5a