### PR TITLE
Handle empty baseline track sets during distance cleanup

### DIFF
--- a/Helper/distanze.py
+++ b/Helper/distanze.py
@@ -159,16 +159,14 @@ def run_distance_cleanup(
         return {"status": "NO_CLIP", "frame": frame}
 
     # Alt/Neu bestimmen
-    if baseline_ptrs is None:
-        old_set, new_set, old_cnt_m, new_cnt_m = _collect_old_new_sets(
-            context,
-            frame,
-            require_selected_new=require_selected_new,
-            include_muted_old=include_muted_old,
-        )
-    else:
+    if baseline_ptrs is not None:
+        ptrs: Set[int] = set()
+        try:
+            ptrs = {int(p) for p in baseline_ptrs}
+        except Exception:
+            ptrs = set()
         # Strikte Alt/Neu-Trennung anhand des Snapshot-Sets
-        old_set, new_set, old_cnt_m, new_cnt_m = set(baseline_ptrs), set(), 0, 0
+        old_set, new_set, old_cnt_m, new_cnt_m = ptrs, set(), 0, 0
         for tr in clip.tracking.tracks:
             ok, m = _track_marker_at_frame(tr, frame)
             if not ok or not m:
@@ -181,6 +179,13 @@ def run_distance_cleanup(
             else:
                 new_set.add(ptr)
                 new_cnt_m += 1
+    else:
+        old_set, new_set, old_cnt_m, new_cnt_m = _collect_old_new_sets(
+            context,
+            frame,
+            require_selected_new=require_selected_new,
+            include_muted_old=include_muted_old,
+        )
 
     # Mindestabstand: Wert aus Koordinator robust übernehmen (Fallback 200)
     auto_min_used = False

--- a/Operator/tracking_coordinator.py
+++ b/Operator/tracking_coordinator.py
@@ -560,7 +560,7 @@ class CLIP_OT_tracking_coordinator(bpy.types.Operator):
             try:
                 info = run_distance_cleanup(
                     context,
-                    baseline_ptrs=self.pre_ptrs,
+                    baseline_ptrs=self.pre_ptrs,  # zwingt Distanz(e) auf Snapshot-Pfad (kein Selektion-Fallback)
                     frame=int(self.target_frame),
                     # min_distance=None â†’ Auto-Ableitung in distanze.py (aus Threshold & scene-base)
                     min_distance=None,
@@ -781,7 +781,7 @@ class CLIP_OT_tracking_coordinator(bpy.types.Operator):
                                 if cur_frame is not None:
                                     dist_res = run_distance_cleanup(
                                         context,
-                                        baseline_ptrs=current_ptrs,
+                                        baseline_ptrs=current_ptrs,  # zwingt Distanz(e) auf Snapshot-Pfad (kein Selektion-Fallback)
                                         frame=cur_frame,
                                         min_distance=None,
                                         distance_unit="pixel",


### PR DESCRIPTION
## Summary
- treat empty baseline track snapshots as valid and partition old/new tracks accordingly
- ensure tracking coordinator always passes snapshot pointers to distance cleanup

## Testing
- `python -m py_compile Helper/distanze.py Operator/tracking_coordinator.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf66d9cde8832d9281fecff5ed9702