### PR TITLE
Add reducer telemetry logging

### DIFF
--- a/Helper/reduce_error_tracks.py
+++ b/Helper/reduce_error_tracks.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import Dict, Any, List, Tuple, Optional
 import sys
 import bpy
+import time
 try:
     # Einheitliche Fehler-Metrik wie in der Coordinator-Telemetrie
     from .count import error_value  # type: ignore
@@ -22,6 +23,85 @@ except Exception:
             return -1.0
 
 __all__ = ("run_reduce_error_tracks", "get_avg_reprojection_error")
+
+def _name(tr):
+    try:
+        return getattr(tr, "name", "<noname>")
+    except Exception:
+        return "<ex>"
+
+def _has_marker_on_frame(tr, frame):
+    try:
+        return any(m.frame == frame for m in tr.markers)
+    except Exception:
+        return False
+
+def _peek_clip_context(ctx, clip):
+    win = getattr(ctx, "window", None)
+    scr = getattr(ctx, "screen", None)
+    area_ok = region_ok = space_ok = False
+    area_type = region_type = space_type = None
+    has_clip_bound = False
+    if win and scr:
+        try:
+            area = next((a for a in scr.areas if a.type == 'CLIP_EDITOR'), None)
+            if area:
+                area_ok = True
+                area_type = area.type
+                region = next((r for r in area.regions if r.type == 'WINDOW'), None)
+                if region:
+                    region_ok = True
+                    region_type = region.type
+                space = area.spaces.active if hasattr(area, "spaces") else None
+                if space:
+                    space_ok = True
+                    space_type = getattr(space, "type", None)
+                    has_clip_bound = (getattr(space, "clip", None) == clip) and (clip is not None)
+        except Exception:
+            pass
+    print(f"[CtxDBG] window={'Y' if win else 'N'} screen={'Y' if scr else 'N'} "
+          f"area_ok={area_ok}({area_type}) region_ok={region_ok}({region_type}) "
+          f"space_ok={space_ok}({space_type}) clip_bound={'Y' if has_clip_bound else 'N'}")
+
+def _summarize_candidates(candidates, threshold_px, max_to_delete):
+    total = len(candidates) if candidates else 0
+    above = []
+    top10 = []
+    if candidates:
+        above = [(t, e) for (t, e) in candidates if e is not None and e > threshold_px]
+        try:
+            top10 = sorted(above, key=lambda x: (x[1] if x[1] is not None else -1), reverse=True)[:10]
+        except Exception:
+            top10 = above[:10]
+    print(f"[ReduceDBG] preselect: total={total} thr={threshold_px:.6f} above_thr={len(above)} "
+          f"max_to_delete={max_to_delete}")
+    if top10:
+        preview = [(_name(t), float(f"{e:.4f}") if e is not None else None) for (t, e) in top10]
+        print(f"[ReduceDBG] preselect top10={preview}")
+    return above
+
+def _count_flags(tracks, frame_hint=None):
+    sel = mut = hasf = 0
+    for t in tracks:
+        try:
+            if getattr(t, "select", False):
+                sel += 1
+            if getattr(t, "mute", False):
+                mut += 1
+            if frame_hint is not None and _has_marker_on_frame(t, frame_hint):
+                hasf += 1
+        except Exception:
+            pass
+    return sel, mut, hasf
+
+def _post_verify_exists(clip, targets_before):
+    try:
+        trk = getattr(clip, "tracking", None)
+        current = set(getattr(trk, "tracks", [])) if trk else set()
+        remaining = [t for t in targets_before if t in current]
+        return remaining
+    except Exception:
+        return []
 
 def _ensure_clip_context(context: bpy.types.Context) -> dict:
     """
@@ -89,18 +169,19 @@ def run_reduce_error_tracks(
     trk = getattr(clip, "tracking", None) if clip else None
     tracks = list(getattr(trk, "tracks", [])) if trk else []
 
-    cand: List[Tuple[str, float]] = []
+    cand: List[Tuple[bpy.types.MovieTrackingTrack, float]] = []
     for t in tracks:
         try:
             if getattr(t, "mute", False):
                 continue
             ev = float(error_value(t))
             if ev >= thr:
-                cand.append((t.name, ev))
+                cand.append((t, ev))
         except Exception:
             pass
     cand.sort(key=lambda x: x[1], reverse=True)
-    print(f"[ReduceDBG] reducer candidates: count={len(cand)} top10={[(n, round(e,4)) for n,e in cand[:10]]}")
+    print(f"[ReduceDBG] reducer candidates: count={len(cand)} top10={[( _name(n), round(e,4)) for n,e in cand[:10]]}")
+    _summarize_candidates(cand, thr, max_to_delete if max_to_delete is not None else 0)
     # Dynamische Default-Batchgröße, falls nicht vorgegeben:
     # 20 % der Kandidaten, min 5, max 50 (konservativ gegen Overkill)
     if max_to_delete is None:
@@ -109,7 +190,7 @@ def run_reduce_error_tracks(
 
     require_selected = bool(scn.get("reduce_only_selected", False))
     if require_selected:
-        cand = [(n, e) for (n, e) in cand if getattr(trk.tracks.get(n), "select", False)]
+        cand = [(t, e) for (t, e) in cand if getattr(t, "select", False)]
         print(f"[ReduceDBG] reducer policy: require_selected=True → remaining={len(cand)}")
     else:
         print(f"[ReduceDBG] reducer policy: require_selected=False")
@@ -122,25 +203,37 @@ def run_reduce_error_tracks(
     count = 0
     k = min(int(max_to_delete), max(1, len(cand)))
     to_process = cand[:k]
-    target_names = {name for name, _e in to_process}
+    target_tracks = [t for (t, _e) in to_process]
+    target_names = {_name(t) for t in target_tracks}
+
+    if target_tracks:
+        names = [_name(t) for t in target_tracks]
+        print(f"[ReduceDBG] target snapshot(count={len(target_tracks)}): {names}")
+    try:
+        sel_cnt, mut_cnt, hasf_cnt = _count_flags(target_tracks, frame_hint=None)
+        print(f"[SelDBG] before-op: selected={sel_cnt} muted={mut_cnt} has_marker@frame_hint={hasf_cnt}")
+    except Exception:
+        pass
+
+    _peek_clip_context(context, clip)
+    _t0 = time.perf_counter()
 
     if do_mute:
         # — Variante: MUTE pro Track (kein Operator nötig)
-        for name in list(target_names):
-            t = trk.tracks.get(name) if trk else None
-            if not t:
+        for tr in list(target_tracks):
+            if not tr:
                 continue
             try:
-                t.mute = True
-                deleted_names.append(name)
+                tr.mute = True
+                deleted_names.append(_name(tr))
                 count += 1
             except Exception as _exc:
-                print(f"[ReduceDBG] reducer failed (mute) for {name}: {_exc}")
+                print(f"[ReduceDBG] reducer failed (mute) for {_name(tr)}: {_exc}")
     elif use_clean_tracks:
         # — Variante: targeted DELETE via bpy.ops.clip.clean_tracks (ein Aufruf, kontext-sicher)
         # Ziel: genau k Top-Error-Tracks treffen, ohne Container mehrfach umzubauen.
         # 1) Schwelle zwischen k und k+1 (oder knapp unter err_k) berechnen
-        errs_sorted = [e for (_n, e) in to_process]  # top-k errors (desc)
+        errs_sorted = [e for (_t, e) in to_process]  # top-k errors (desc)
         err_k = float(errs_sorted[-1])  # kleinster der Top-K
         has_kp1 = len(cand) > k
         if has_kp1:
@@ -166,11 +259,11 @@ def run_reduce_error_tracks(
             except Exception:
                 pass
             # Alle, die vorab >= thr_clean lagen (d.h. Zielmenge), als gelöscht zählen
-            goal_set = {n for (n, e) in cand if e >= thr_clean}
-            for name in list(goal_set):
-                still_there = bool(trk.tracks.get(name)) if trk else False
+            goal_set = {t for (t, e) in cand if e >= thr_clean}
+            for tr in list(goal_set):
+                still_there = tr in getattr(trk, "tracks", []) if trk else False
                 if not still_there:
-                    deleted_names.append(name)
+                    deleted_names.append(_name(tr))
             count = len(deleted_names)
         except Exception as _chk_exc:
             print(f"[ReduceDBG] post-clean_tracks check failed: {_chk_exc}")
@@ -181,15 +274,15 @@ def run_reduce_error_tracks(
         # — Variante: DELETE via Operator (kontext-sicher)
         # 1) Auswahl vorbereiten
         try:
-            for t in tracks:
+            for tr in tracks:
                 try:
-                    t.select = False
+                    tr.select = False
                 except Exception:
                     pass
-            for t in tracks:
-                if t.name in target_names:
+            for tr in tracks:
+                if tr in target_tracks:
                     try:
-                        t.select = True
+                        tr.select = True
                     except Exception:
                         pass
         except Exception as _sel_exc:
@@ -213,26 +306,40 @@ def run_reduce_error_tracks(
                 bpy.context.view_layer.update()
             except Exception:
                 pass
-            for name in list(target_names):
-                still_there = bool(trk.tracks.get(name)) if trk else False
+            for tr in list(target_tracks):
+                still_there = tr in getattr(trk, "tracks", []) if trk else False
                 if not still_there:
-                    deleted_names.append(name)
+                    deleted_names.append(_name(tr))
                     count += 1
         except Exception as _chk_exc:
             print(f"[ReduceDBG] post-delete check failed: {_chk_exc}")
         # Falls der Operator nichts gelöscht hat, auf MUTE ausweichen (damit der Zyklus vorankommt).
         if count == 0:
             print("[ReduceDBG] operator deletion had no effect -> fallback to MUTE for targets")
-            for name in list(target_names):
-                t = trk.tracks.get(name) if trk else None
-                if not t:
+            for tr in list(target_tracks):
+                if not tr:
                     continue
                 try:
-                    t.mute = True
-                    deleted_names.append(name)
+                    tr.mute = True
+                    deleted_names.append(_name(tr))
                     count += 1
                 except Exception as _exc:
-                    print(f"[ReduceDBG] reducer failed (mute-fallback) for {name}: {_exc}")
+                    print(f"[ReduceDBG] reducer failed (mute-fallback) for {_name(tr)}: {_exc}")
+
+    _t1 = time.perf_counter()
+    print(f"[TimeDBG] reduce pass wall={(_t1 - _t0) * 1000:.2f}ms")
+    try:
+        remaining = _post_verify_exists(clip, target_tracks)
+        kept = len(remaining)
+        removed = len(target_tracks) - kept
+        if target_tracks:
+            rem_names = [_name(t) for t in remaining]
+            print(f"[VerifyDBG] post-op: expected_remove={len(target_tracks)} → removed={removed} kept={kept} kept_names={rem_names}")
+        else:
+            print("[VerifyDBG] post-op: no targets snapshot (nothing to verify)")
+    except Exception as ex:
+        print(f"[VerifyDBG] post-op verification failed: {ex!r}")
+
     print(f"[ReduceDBG] reducer summary: affected={count}")
     return {
         "deleted": count,  # Anzahl betroffener Tracks (deleted oder mute-fallback)
@@ -243,7 +350,7 @@ def run_reduce_error_tracks(
             "mute_instead_delete": do_mute,
             "use_clean_tracks": use_clean_tracks,
         },
-        "candidates": cand[:50],
+        "candidates": [(_name(t), e) for t, e in cand[:50]],
     }
 
 

--- a/Operator/tracking_coordinator.py
+++ b/Operator/tracking_coordinator.py
@@ -7,6 +7,7 @@ tracking_coordinator.py â€“ Streng sequentieller, MODALER Orchestrator
 
 from __future__ import annotations
 import bpy
+import time
 
 # ---------------------------------------------------------------------------
 # Console logging
@@ -29,6 +30,17 @@ from ..Helper.split_cleanup import recursive_split_cleanup
 from ..Helper.find_max_marker_frame import run_find_max_marker_frame  # type: ignore
 from ..Helper.solve_camera import solve_camera_only  # type: ignore
 from ..Helper.reduce_error_tracks import run_reduce_error_tracks, get_avg_reprojection_error  # type: ignore
+
+def _run_reducer(ctx, max_del):
+    print(f"[ReduceDBG] reducer call: max_del={max_del}")
+    _t0 = time.perf_counter()
+    res = run_reduce_error_tracks(ctx, max_to_delete=max_del)
+    _t1 = time.perf_counter()
+    try:
+        print(f"[ReduceDBG] reducer result: {res} (wall={( _t1 - _t0 )*1000:.2f}ms)")
+    except Exception:
+        print(f"[ReduceDBG] reducer result: <unprintable> (wall={( _t1 - _t0 )*1000:.2f}ms)")
+    return res
 # Worst-Error-Frame (optional vorhanden)
 try:
     from ..Helper.find_max_error_frame import run_find_max_error_frame  # type: ignore
@@ -1071,7 +1083,7 @@ class CLIP_OT_tracking_coordinator(bpy.types.Operator):
                     _k = max(1, min(5, int(_k_raw)))
                     _log(f"[ReduceDBG] delete-k formula: avg={_avg:.4f} / err_frame={_den:.4f} -> k_raw={_k_raw} -> k={_k} (clamp 1..10)")
 
-                    red = run_reduce_error_tracks(context, max_to_delete=_k)
+                    red = _run_reducer(context, _k)
                     deleted = int(red.get('deleted', 0) or 0)
                     names = red.get('names', [])
                     # Guard NUR setzen, wenn wirklich etwas entfernt wurde


### PR DESCRIPTION
## Summary
- add detailed telemetry helpers and timing to `run_reduce_error_tracks`
- wrap reducer calls in coordinator for entry/result logging

## Testing
- `python -m py_compile Helper/reduce_error_tracks.py Operator/tracking_coordinator.py`
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b8e504cc832d85869f9485dde321