### PR TITLE
Reset detection distance baseline after jumps

### DIFF
--- a/Helper/detect.py
+++ b/Helper/detect.py
@@ -274,8 +274,23 @@ def run_detect_basic(
 # Thin Wrapper für Backward-Compat
 # -----------------------------
 def run_detect_once(context: bpy.types.Context, **kwargs) -> Dict[str, Any]:
-    # kwargs (inkl. select) werden 1:1 durchgereicht
-    res = run_detect_basic(context, **kwargs)
+    # kwargs kopieren, damit Aufrufer-Dict unverändert bleibt
+    kw = dict(kwargs)
+
+    # Schwelle hart fixieren – kein adaptives Tuning mehr
+    kw["threshold"] = 0.001
+
+    # min_distance: falls nicht gesetzt, Scene-Key verwenden
+    if "min_distance" not in kw or kw["min_distance"] is None:
+        kw["min_distance"] = bpy.context.scene.get("min_distance_base", None)
+
+    frame = kw.get("start_frame", bpy.context.scene.frame_current)
+    print(
+        f"[Detect] frame={int(frame)} thr={kw['threshold']:.3f} "
+        f"min_dist={kw['min_distance']}"
+    )
+
+    res = run_detect_basic(context, **kw)
     if res.get("status") != "READY":
         return res
     return {

--- a/Helper/jump_to_frame.py
+++ b/Helper/jump_to_frame.py
@@ -171,6 +171,20 @@ def run_jump_to_frame(
     else:
         scn.frame_current = target
 
+    # ---------------------------------------------------------------
+    # Reset der Distanzbasis nach jedem Jump:
+    # min_distance_base soll nach einem Sprung stets vom gleichen
+    # Ausgangswert starten. Heuristik: 2.5 % der Clipbreite
+    # (Fallback 150 px)
+    # ---------------------------------------------------------------
+    try:
+        width = int(getattr(clip, "size", (0, 0))[0]) if clip else 0
+        start_base = int(round(0.025 * width)) if width > 0 else 150
+        scn["min_distance_base"] = start_base
+        print(f"[Jump] Reset min_distance_base -> {start_base}px (frame={int(target)})")
+    except Exception as exc:
+        print(f"[Jump][WARN] Konnte min_distance_base nicht resetten: {exc!r}")
+
     # Besuchszählung je Ziel-Frame
     repeat_count = 1
     if repeat_map is not None:

--- a/Operator/tracking_coordinator.py
+++ b/Operator/tracking_coordinator.py
@@ -1081,6 +1081,17 @@ class CLIP_OT_tracking_coordinator(bpy.types.Operator):
             rj = run_jump_to_frame(context, frame=self.target_frame, repeat_map=self.repeat_map)
             if rj.get("status") != "OK":
                 return self._finish(context, info=f"JUMP FAILED â†’ {rj}", cancelled=True)
+
+            # HARDSYNC: Nach dem Jump min_distance_base immer neu initialisieren
+            try:
+                _clip = _resolve_clip(context)
+                w = int(getattr(_clip, "size", (0, 0))[0]) if _clip else 0
+                start_base = int(round(0.025 * w)) if w > 0 else 150
+                context.scene["min_distance_base"] = start_base
+                print(f"[Coordinator] Post-Jump reset min_distance_base -> {start_base}px")
+            except Exception as exc:
+                print(f"[Coordinator][WARN] Post-Jump Reset failed: {exc!r}")
+
             self.report({'INFO'}, f"Playhead gesetzt: f{rj.get('frame')} (repeat={rj.get('repeat_count')})")
 
             # NEU: Anzahl/Motion-Model orchestrieren und ggf. bei 10 abbrechen

--- a/Operator/tracking_coordinator.py
+++ b/Operator/tracking_coordinator.py
@@ -128,7 +128,7 @@ def solve_eval_back_to_back(
                 print(f"[SolveEval][#{trials+1}] rank_callable done in {t_rank:.3f}s → rank={rank_value:.6f}")
 
             # --- Summary for iteration
-           print(f"[SolveEval][#{trials+1}] timings: apply={t_apply:.3f}s solve={t_solve:.3f}s rank={t_rank:.3f}s")
+            print(f"[SolveEval][#{trials+1}] timings: apply={t_apply:.3f}s solve={t_solve:.3f}s rank={t_rank:.3f}s")
             if (best is None) or (rank_value < best[0]):
                 best = (rank_value, model, score)
             trials += 1


### PR DESCRIPTION
## Summary
- Reinitialize `min_distance_base` on every jump
- Hard-sync post-jump distance baseline in coordinator
- Fix detection logic to use fixed threshold and scene min-distance

## Testing
- `flake8` *(fails: command not found)*
- `pip install flake8` *(fails: Tunnel connection failed: 403 Forbidden)*
- `python -m py_compile Helper/detect.py Helper/jump_to_frame.py Operator/tracking_coordinator.py`


------
https://chatgpt.com/codex/tasks/task_e_68c36e995e48832d8b13a7eee9ee46e9