### PR TITLE
Avoid context usage during overlay registration

### DIFF
--- a/Helper/jump_to_frame.py
+++ b/Helper/jump_to_frame.py
@@ -2,7 +2,7 @@ import bpy
 from typing import Optional, Dict, Any, Tuple
 
 # Optionaler Hook: Repeat-Werte ins Overlay spiegeln
-def _kc_record_repeat(scene: bpy.types.Scene, frame: int, repeat_value: int | float):
+def _kc_record_repeat(scene: bpy.types.Scene, frame: int, repeat_value: float):
     try:
         from .properties import record_repeat_count
         record_repeat_count(scene, frame, float(repeat_value))

--- a/Helper/jump_to_frame.py
+++ b/Helper/jump_to_frame.py
@@ -2,7 +2,7 @@ import bpy
 from typing import Optional, Dict, Any, Tuple
 
 # Optionaler Hook: Repeat-Werte ins Overlay spiegeln
-def _kc_record_repeat(scene: bpy.types.Scene, frame: int, repeat_value: float):
+def _kc_record_repeat(scene, frame, repeat_value):
     try:
         from .properties import record_repeat_count
         record_repeat_count(scene, frame, float(repeat_value))

--- a/Helper/properties.py
+++ b/Helper/properties.py
@@ -71,5 +71,6 @@ def record_repeat_count(scene, frame, value):
             fval = float(value)
         except Exception:
             fval = 0.0
-        series[idx] = float(max(0.0, fval))        scene["_kc_repeat_series"] = series
+        series[idx] = float(max(0.0, fval))
+        scene["_kc_repeat_series"] = series
         _tag_redraw()

--- a/Helper/properties.py
+++ b/Helper/properties.py
@@ -29,7 +29,7 @@ def ensure_repeat_overlay_props():
         )
     # Kein Zugriff auf bpy.context.scene hier – ID-Properties werden lazy im Draw/Write angelegt.
 
-def _toggle_repeat_overlay(scene: bpy.types.Scene):
+def _toggle_repeat_overlay(scene):
     from ..ui.repeat_overlay import enable_repeat_overlay, disable_repeat_overlay
     if getattr(scene, "kc_show_repeat_overlay", False):
         enable_repeat_overlay()
@@ -49,7 +49,7 @@ def _tag_redraw():
         # Während Register/Preferences kann bpy.context eingeschränkt sein.
         pass
 
-def record_repeat_count(scene: bpy.types.Scene, frame: int, value: float):
+def record_repeat_count(scene, frame, value):
     """Schreibt einen Repeat-Wert für einen absoluten Frame in die Serien-ID-Property."""
     if scene is None:
         try:
@@ -67,6 +67,9 @@ def record_repeat_count(scene: bpy.types.Scene, frame: int, value: float):
     idx = int(frame) - int(fs)
     if 0 <= idx < n:
         series = list(scene["_kc_repeat_series"])
-        series[idx] = float(max(0.0, value))
-        scene["_kc_repeat_series"] = series
+        try:
+            fval = float(value)
+        except Exception:
+            fval = 0.0
+        series[idx] = float(max(0.0, fval))        scene["_kc_repeat_series"] = series
         _tag_redraw()

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -40,9 +40,14 @@ class KC_PT_OverlayPanel(bpy.types.Panel):
         layout = self.layout
         col = layout.column(align=True)
         col.operator("kc.overlay_toggle", text="Standard-Overlay umschalten")
-        col.separator()
-        col.prop(context.scene, "kc_show_repeat_overlay", text="Repeat-Kurve anzeigen")
-        col.prop(context.scene, "kc_repeat_overlay_height", text="Repeat-Kurvenhöhe")
+        # Defensiv: Panel wird manchmal gezeichnet, bevor RNA-Props existieren (Preferences/Register).
+        if hasattr(bpy.types.Scene, "kc_show_repeat_overlay") and hasattr(context.scene, "kc_show_repeat_overlay"):
+            col.separator()
+            col.prop(context.scene, "kc_show_repeat_overlay", text="Repeat-Kurve anzeigen")
+            col.prop(context.scene, "kc_repeat_overlay_height", text="Repeat-Kurvenhöhe")
+        else:
+            col.separator()
+            col.label(text="Repeat-Overlay initialisiert nach Register()")
 
 
 def register():

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -51,16 +51,18 @@ def register():
             m.register()
     bpy.utils.register_class(KC_PT_OverlayPanel)
     bpy.utils.register_class(KC_OT_OverlayToggle)
-    # Szene-Properties
+    # Szene-Properties registrieren (ohne auf bpy.context.scene zuzugreifen)
     from ..Helper.properties import ensure_repeat_overlay_props
     ensure_repeat_overlay_props()
-    # Auto-Handler je nach Flag
-    if bpy.context.scene and bpy.context.scene.get("kc_show_repeat_overlay", False):
-        enable_repeat_overlay()
+    # Kein Auto-Enable zur Register-Zeit – Kontext ist ggf. eingeschränkt (Preferences).
 
 
 def unregister():
-    disable_repeat_overlay()
+    # Beim Unregister sauber entfernen
+    try:
+        disable_repeat_overlay()
+    except Exception:
+        pass
     bpy.utils.unregister_class(KC_OT_OverlayToggle)
     bpy.utils.unregister_class(KC_PT_OverlayPanel)
     for m in reversed(_MODULES):

--- a/ui/repeat_overlay.py
+++ b/ui/repeat_overlay.py
@@ -1,8 +1,8 @@
-+# SPDX-License-Identifier: GPL-2.0-or-later
-+import bpy
-+from gpu.types import GPUBatch, GPUShader
-+import gpu
-+from math import isfinite
+# SPDX-License-Identifier: GPL-2.0-or-later
+import bpy
+from gpu.types import GPUBatch, GPUShader
+import gpu
+from math import isfinite
 
 _HANDLE = None
 

--- a/ui/repeat_overlay.py
+++ b/ui/repeat_overlay.py
@@ -1,11 +1,8 @@
-# SPDX-License-Identifier: GPL-2.0-or-later
-from __future__ import annotations
-import bpy
-from typing import List
-from bpy.types import SpaceClipEditor
-from gpu.types import GPUBatch, GPUShader
-import gpu
-from math import isfinite
++# SPDX-License-Identifier: GPL-2.0-or-later
++import bpy
++from gpu.types import GPUBatch, GPUShader
++import gpu
++from math import isfinite
 
 _HANDLE = None
 
@@ -19,11 +16,11 @@ out vec4 FragColor;
 void main() { FragColor = vec4(1.0, 1.0, 1.0, 1.0); }
 '''
 
-def _get_series(scene: bpy.types.Scene) -> List[float]:
+def _get_series(scene):
     data = scene.get("_kc_repeat_series")
     return list(data) if isinstance(data, list) else []
 
-def _ensure_series_len(scene: bpy.types.Scene) -> int:
+def _ensure_series_len(scene):
     fs, fe = scene.frame_start, scene.frame_end
     n = max(0, int(fe - fs + 1))
     series = _get_series(scene)
@@ -88,12 +85,12 @@ def draw_callback():
 def _add_handler():
     global _HANDLE
     if _HANDLE is None:
-        _HANDLE = SpaceClipEditor.draw_handler_add(draw_callback, (), 'WINDOW', 'POST_PIXEL')
+        _HANDLE = bpy.types.SpaceClipEditor.draw_handler_add(draw_callback, (), 'WINDOW', 'POST_PIXEL')
 
 def _remove_handler():
     global _HANDLE
     if _HANDLE is not None:
-        SpaceClipEditor.draw_handler_remove(_HANDLE, 'WINDOW')
+        bpy.types.SpaceClipEditor.draw_handler_remove(_HANDLE, 'WINDOW')
         _HANDLE = None
 
 def enable_repeat_overlay():


### PR DESCRIPTION
## Summary
- Register repeat overlay properties without touching `bpy.context` and guard redraw/tagging
- Safely disable overlay on unregister
- Narrow repeat recording hook signature

## Testing
- `python -m py_compile Helper/properties.py Helper/jump_to_frame.py ui/__init__.py ui/repeat_overlay.py`


------
https://chatgpt.com/codex/tasks/task_e_68c3f22c3a48832dbdd667415c40f40c