### PR TITLE
Disable legacy overlay and refine type hints

### DIFF
--- a/Operator/tracking_coordinator.py
+++ b/Operator/tracking_coordinator.py
@@ -1,15 +1,12 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-"""
-tracking_coordinator.py â€“ Streng sequentieller, MODALER Orchestrator
-- Phasen: FIND_LOW â†’ JUMP â†’ DETECT â†’ DISTANZE (hart getrennt, seriell)
-- Integration von Anzahl/Aâ‚..Aâ‚‰ + Abbruch bei 10 + A_k-Schreiben in BIDI
-- Jede Phase startet erst, wenn die vorherige abgeschlossen wurde.
+""" tracking_coordinator.py – Streng sequentieller, MODALER Orchestrator
+    Hinweis: Typisierungen verwenden KEINE in Anführungszeichen gesetzten
+    ForwardRefs mit „| None“, um Probleme mit typing.get_type_hints zu vermeiden.
 """
 
 from __future__ import annotations
 
-import gc
-import time
+import gc, time
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Iterable, Optional, Tuple
@@ -132,9 +129,7 @@ def solve_eval_back_to_back(
 # Finaler Voll-Solve mit Intrinsics-Refine (fokal/principal/radial = True)
 # ---------------------------------------------------------------------------
 def solve_final_refine(
-    *,
-    context: bpy.types.Context,
-    model: Any,
+    *, context: bpy.types.Context, model: Any,
     apply_model: Callable[[Any], None],
     solve_full: Optional[Callable[..., float]] = None,
 ) -> float:
@@ -189,8 +184,7 @@ def solve_final_refine(
 # Kombi-Wrapper: 3×-Eval + finaler Voll-Solve (alle refine_intrinsics = True)
 # ---------------------------------------------------------------------------
 def solve_eval_with_final_refine(
-    *,
-    clip,
+    *, clip,
     candidate_models: Iterable[Any],
     apply_model: Callable[[Any], None],
     do_solve_quick: Callable[..., float],
@@ -297,7 +291,7 @@ except Exception:
 
 
 # ---- Solve-Logger: robust auflÃ¶sen, ohne auf Paketstruktur zu vertrauen ----
-def _solve_log(context, value):
+def _solve_log(context: bpy.types.Context | None, value: float | None):
     """Laufzeit-sicherer Aufruf von __init__.kaiserlich_solve_log_add()."""
     try:
         import sys, importlib

--- a/__init__.py
+++ b/__init__.py
@@ -86,8 +86,8 @@ def _register_scene_props() -> None:
         sc.kaiserlich_solve_attempts = IntProperty(name="Solve Attempts", default=0, min=0)
     if not hasattr(sc, "kaiserlich_solve_graph_enabled"):
         sc.kaiserlich_solve_graph_enabled = BoolProperty(
-            name="Overlay Graph", default=True,
-            description="Sparkline-Overlay des Avg-Errors im CLIP-Editor anzeigen"
+            name="Overlay Graph", default=False,
+            description="(Legacy) Sparkline-Overlay des Avg-Errors – standardmäßig aus"
         )
     if not hasattr(sc, "kaiserlich_debug_graph"):
         sc.kaiserlich_debug_graph = BoolProperty(

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -25,7 +25,8 @@ class KC_PT_OverlayPanel(bpy.types.Panel):
     def draw(self, context):
         layout = self.layout
         col = layout.column(align=True)
-        col.operator("kc.overlay_toggle", text="Standard-Overlay umschalten")
+        # Legacy-Overlay-Button entfernen (Overlay ist deaktiviert)
+        # col.operator("kc.overlay_toggle", text="Standard-Overlay umschalten")
         col.separator()
         # Defensiv (Register-Phase in Preferences liefert eingeschränkten Kontext)
         if hasattr(bpy.types.Scene, "kc_show_repeat_scope") and hasattr(context.scene, "kc_show_repeat_scope"):

--- a/ui/overlay.py
+++ b/ui/overlay.py
@@ -1,29 +1,6 @@
-import bpy
-
-# Draw-Handler-Handle
-_handle = None
-
-# Wir nutzen die bestehende Overlay-Zeichnung aus dem alten __init__.py,
-# aber kapseln sie in ein Modul. Import erst zur Laufzeit, damit gpu verfügbar ist.
-def _draw_solve_graph_proxy():
-    from .overlay_impl import draw_solve_graph_impl
-    draw_solve_graph_impl()
-
-def register():
-    global _handle
-    if _handle is None:
-        try:
-            _handle = bpy.types.SpaceClipEditor.draw_handler_add(
-                _draw_solve_graph_proxy, (), 'WINDOW', 'POST_PIXEL'
-            )
-        except Exception:
-            _handle = None
-
-def unregister():
-    global _handle
-    if _handle is not None:
-        try:
-            bpy.types.SpaceClipEditor.draw_handler_remove(_handle, 'WINDOW')
-        except Exception:
-            pass
-        _handle = None
+# Legacy Solve-Error-Overlay vollständig deaktiviert.
+# Dieses Modul bleibt als Stub bestehen, registriert aber KEINE Draw-Handler mehr.
+def register():  # no-op
+    return None
+def unregister():  # no-op
+    return None

--- a/ui/overlay_impl.py
+++ b/ui/overlay_impl.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# (c) Kaiserlich Overlay
+# (c) Kaiserlich Overlay (legacy – deaktiviert, nur noch Utils)
 import bpy
-
 _HANDLE = None
 
 
@@ -229,22 +228,10 @@ def draw_solve_graph_impl():
 
 
 def ensure_overlay_handlers(_scene=None):
-    global _HANDLE
-    if _HANDLE is None:
-        try:
-            _HANDLE = bpy.types.SpaceClipEditor.draw_handler_add(draw_solve_graph_impl, (), 'WINDOW', 'POST_PIXEL')
-        except Exception:
-            _HANDLE = None
-    return _HANDLE
+    # Legacy-Overlay nicht mehr automatisch aktivieren
+    return None
 
 
 def remove_overlay_handlers(_handle=None):
-    global _HANDLE
-    if _HANDLE is not None:
-        try:
-            bpy.types.SpaceClipEditor.draw_handler_remove(_HANDLE, 'WINDOW')
-        except Exception:
-            pass
-        _HANDLE = None
-        return True
-    return False
+    # Nichts zu entfernen – Handler wird nicht mehr gesetzt.
+    return True


### PR DESCRIPTION
## Summary
- refine type hints and docstring in tracking_coordinator
- disable legacy solve-error overlay stubs
- default solve graph overlay to off

## Testing
- `python -m py_compile Operator/tracking_coordinator.py ui/overlay.py ui/overlay_impl.py __init__.py ui/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68c40f352464832d811e79c120af4f53