### PR TITLE
Enable repeat scope by default and adjust typing

### DIFF
--- a/Helper/properties.py
+++ b/Helper/properties.py
@@ -8,7 +8,7 @@ def ensure_repeat_scope_props():
         bpy.types.Scene.kc_show_repeat_scope = bpy.props.BoolProperty(
             name="Repeat-Scope",
             description="Zeigt eine Box im Viewer mit der Wiederholungskurve über die Szenenlänge",
-            default=False,
+            default=True,
             update=lambda s, c: _toggle_repeat_scope(s),
         )
     if not hasattr(bpy.types.Scene, "kc_repeat_scope_height"):

--- a/Operator/tracking_coordinator.py
+++ b/Operator/tracking_coordinator.py
@@ -1,10 +1,8 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 """ tracking_coordinator.py – Streng sequentieller, MODALER Orchestrator
-    Hinweis: Typisierungen verwenden KEINE in Anführungszeichen gesetzten
-    ForwardRefs mit „| None“, um Probleme mit typing.get_type_hints zu vermeiden.
+    Hinweis: __future__.annotations entfernt, um typing.get_type_hints()-Fehler
+    mit dem „|“-Operator zu vermeiden. Bitte Optional[...] verwenden.
 """
-
-from __future__ import annotations
 
 import gc, time
 from contextlib import contextmanager
@@ -291,7 +289,7 @@ except Exception:
 
 
 # ---- Solve-Logger: robust auflÃ¶sen, ohne auf Paketstruktur zu vertrauen ----
-def _solve_log(context: bpy.types.Context | None, value: float | None):
+def _solve_log(context: Optional[bpy.types.Context], value: Optional[float]):
     """Laufzeit-sicherer Aufruf von __init__.kaiserlich_solve_log_add()."""
     try:
         import sys, importlib

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -45,6 +45,14 @@ def register():
     # Szene-Properties (nur RNAs, ohne auf bpy.context zuzugreifen)
     from ..Helper.properties import ensure_repeat_scope_props
     ensure_repeat_scope_props()
+    # Wenn Flag bereits aktiv ist (Default/Benutzer), Scope-Handler einschalten
+    try:
+        scn = getattr(bpy.context, "scene", None)
+        if scn and getattr(scn, "kc_show_repeat_scope", False):
+            from .repeat_scope import enable_repeat_scope
+            enable_repeat_scope()
+    except Exception:
+        pass
 
 
 def unregister():


### PR DESCRIPTION
## Summary
- Remove __future__.annotations and use Optional[...] to avoid typing issues in tracking coordinator
- Automatically enable repeat scope when registered if already set
- Show repeat scope by default

## Testing
- `python -m py_compile Operator/tracking_coordinator.py ui/__init__.py Helper/properties.py`


------
https://chatgpt.com/codex/tasks/task_e_68c412ba7c24832dba770203a77720c8