### PR TITLE
Add compatibility shim for repeat scope handler

### DIFF
--- a/ui/repeat_scope.py
+++ b/ui/repeat_scope.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Kaiserlich Repeat-Scope – robuste Handler-API + Fallback-Zeichnung
+# Kaiserlich Repeat-Scope – robuste Handler-API + Fallback-Zeichnung + Kompatibilitäts-Shim
 import bpy, gpu
 try:
     from gpu_extras.batch import batch_for_shader
@@ -90,3 +90,8 @@ def enable_repeat_scope(enable: bool = True):
             globals()["_REPEAT_SCOPE_HANDLE"] = None
         print("[RepeatScope] handler removed")
         _tag_redraw()
+
+
+def disable_repeat_scope():
+    """Kompatibilitäts-Shim für ui/__init__.py."""
+    enable_repeat_scope(False)


### PR DESCRIPTION
## Summary
- extend repeat scope module with a compatibility shim to allow disabling the handler via `disable_repeat_scope`
- clarify module header to mention compatibility shim

## Testing
- `python -m py_compile ui/repeat_scope.py`


------
https://chatgpt.com/codex/tasks/task_e_68c4266ae078832d989eac6bc80c254b