### PR TITLE
refactor: delegate scene property registration

### DIFF
--- a/Helper/properties.py
+++ b/Helper/properties.py
@@ -1,65 +1,21 @@
 """Scene properties for Repeat Scope overlay."""
 
 import bpy
-from bpy.props import BoolProperty, IntProperty
-from importlib import import_module
+from typing import Dict, List, Tuple, Any
 
 
-# ---- Update-Callback: toggle handler lazily to avoid import cycles ----
-def _kc_update_repeat_scope(self, context):
-    try:
-        base = __package__.split('.')[0]  # e.g. "tracking"
-        mod = import_module(f"{base}.ui.repeat_scope")
-        mod.enable_repeat_scope(bool(getattr(self, "kc_show_repeat_scope", False)))
-    except Exception as e:
-        print("[RepeatScope] update skipped:", e)
+# ---------------------------------------------------------------------------
+# Szene-Properties werden exklusiv in ui/__init__.py registriert.
+# Diese No-Op-Funktion bleibt erhalten, falls ältere Aufrufer sie noch callen.
+# ---------------------------------------------------------------------------
+def register_scene_properties() -> None:
+    """No-op: Properties owned by ui.__init__.py."""
+    pass
 
 
-def register():
-    sc = bpy.types.Scene
-    sc.kc_show_repeat_scope = BoolProperty(
-        name="Repeat-Scope anzeigen",
-        description="Overlay für Repeat-Scope ein-/ausschalten",
-        default=False,
-        update=_kc_update_repeat_scope,
-    )
-    sc.kc_repeat_scope_height = IntProperty(
-        name="Höhe",
-        description="Höhe des Repeat-Scope im Viewport",
-        default=140,
-        min=80,
-        max=600,
-    )
-    sc.kc_repeat_scope_bottom = BoolProperty(
-        name="Unten andocken",
-        description="Overlay am unteren Rand andocken",
-        default=True,
-    )
-    sc.kc_repeat_scope_margin_x = IntProperty(
-        name="Rand X",
-        description="Horizontaler Innenabstand",
-        default=12,
-        min=0,
-        max=400,
-    )
-    sc.kc_repeat_scope_show_cursor = BoolProperty(
-        name="Cursorlinie",
-        description="Aktuellen Frame als Linie anzeigen",
-        default=True,
-    )
-
-
-def unregister():
-    sc = bpy.types.Scene
-    for attr in (
-        "kc_show_repeat_scope",
-        "kc_repeat_scope_height",
-        "kc_repeat_scope_bottom",
-        "kc_repeat_scope_margin_x",
-        "kc_repeat_scope_show_cursor",
-    ):
-        if hasattr(sc, attr):
-            delattr(sc, attr)
+def unregister_scene_properties() -> None:
+    """No-op: Properties are removed by ui.__init__.unregister()."""
+    pass
 
 
 def _tag_redraw():


### PR DESCRIPTION
## Summary
- remove Scene property registration from `Helper.properties`
- add no-op registration helpers; UI owns property lifecycle

## Testing
- `python -m py_compile Helper/properties.py`
- `pip install flake8` *(fails: Tunnel connection failed 403)*
- `blender --version` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4a2a61fe8832d932b03d96c122388