### PR TITLE
Add repeat scope properties and overlay helpers

### DIFF
--- a/Helper/properties.py
+++ b/Helper/properties.py
@@ -1,23 +1,65 @@
 """Scene properties for Repeat Scope overlay."""
 
 import bpy
-from typing import Dict, List, Tuple, Any
+from bpy.props import BoolProperty, IntProperty
+from importlib import import_module
 
 
-# ---------------------------------------------------------------------------
-# Szene-Properties werden exklusiv in ui/__init__.py registriert.
-# Diese No-Op-Funktion bleibt erhalten, falls ältere Aufrufer sie noch callen.
-# ---------------------------------------------------------------------------
-def register_scene_properties() -> None:
-    """No-op: Properties owned by ui.__init__.py."""
-    pass
+# ---- Update-Callback: toggle handler lazily to avoid import cycles ----
+def _kc_update_repeat_scope(self, context):
+    try:
+        base = __package__.split('.')[0]  # z.B. "tracking" oder "tracking-add-scope"
+        mod = import_module(f"{base}.ui.repeat_scope")
+        mod.enable_repeat_scope(bool(getattr(self, "kc_show_repeat_scope", False)))
+    except Exception as e:
+        # Kein hartes Fail beim Laden/Prefs; nur ausgeben.
+        print("[RepeatScope] update skipped:", e)
 
 
-def unregister_scene_properties() -> None:
-    """No-op: Properties are removed by ui.__init__.unregister()."""
-    pass
+def register():
+    sc = bpy.types.Scene
+    sc.kc_show_repeat_scope = BoolProperty(
+        name="Repeat-Scope anzeigen",
+        description="Overlay für Repeat-Scope ein-/ausschalten",
+        default=False,
+        update=_kc_update_repeat_scope,
+    )
+    sc.kc_repeat_scope_height = IntProperty(
+        name="Höhe",
+        description="Höhe des Repeat-Scope im Viewport",
+        default=140, min=80, max=600,
+    )
+    sc.kc_repeat_scope_bottom = BoolProperty(
+        name="Unten andocken",
+        description="Overlay am unteren Rand andocken",
+        default=True,
+    )
+    sc.kc_repeat_scope_margin_x = IntProperty(
+        name="Rand X",
+        description="Horizontaler Innenabstand",
+        default=12, min=0, max=400,
+    )
+    sc.kc_repeat_scope_show_cursor = BoolProperty(
+        name="Cursorlinie",
+        description="Aktuellen Frame als Linie anzeigen",
+        default=True,
+    )
 
 
+def unregister():
+    sc = bpy.types.Scene
+    for attr in (
+        "kc_show_repeat_scope",
+        "kc_repeat_scope_height",
+        "kc_repeat_scope_bottom",
+        "kc_repeat_scope_margin_x",
+        "kc_repeat_scope_show_cursor",
+    ):
+        if hasattr(sc, attr):
+            delattr(sc, attr)
+
+
+# ---- Helper: Serie für Repeats (für das Overlay) ---------------------------
 def _tag_redraw():
     try:
         for w in bpy.context.window_manager.windows:
@@ -55,5 +97,5 @@ def record_repeat_count(scene, frame, value):
             fval = 0.0
         series[idx] = float(max(0.0, fval))
         scene["_kc_repeat_series"] = series
-        _tag_redraw()
+    _tag_redraw()
 


### PR DESCRIPTION
## Summary
- add scene properties for repeat scope overlay
- provide callbacks and registration helpers

## Testing
- `python -m py_compile Helper/properties.py`
- `flake8 Helper/properties.py` *(fails: command not found)*
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4a6c54288832db0eb7a0d31c9a650