### PR TITLE
Refactor repeat scope property registration

### DIFF
--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -3,17 +3,14 @@
 
 import bpy
 from bpy.app.handlers import persistent
-from bpy.props import BoolProperty, IntProperty
 
 from .repeat_scope import enable_repeat_scope, disable_repeat_scope
 
 
-# --- Prop-Update: schaltet den Draw-Handler an/aus ---
-def _kc_update_scope(self, ctx):
-    try:
-        enable_repeat_scope(bool(ctx.scene.kc_show_repeat_scope), source="prop_update")
-    except Exception as e:  # pragma: no cover - defensive log
-        print("[KC] _kc_update_scope failed:", e)
+# Hinweis:
+# Die Repeat-Scope-Properties werden nun ausschließlich in Helper/properties.py
+# registriert (siehe addon __init__.py → _props.register()).
+# Dieses Modul registriert NUR noch Panels/Handler.
 
 
 # --- Beim Laden .blend: Zustand synchronisieren + evtl. TMP-Handler entsorgen ---
@@ -61,31 +58,7 @@ classes = (KAISERLICH_PT_repeat_scope,)
 
 
 def register() -> None:
-    """Register UI components and scene properties."""
-
-    # Scene-Properties (existieren vor Panel.draw -> keine rna_uiItemR-Fehler)
-    bpy.types.Scene.kc_show_repeat_scope = BoolProperty(
-        name="Repeat Scope",
-        description="Overlay anzeigen",
-        default=False,
-        update=_kc_update_scope,
-    )
-
-    bpy.types.Scene.kc_repeat_scope_height = IntProperty(
-        name="Höhe", default=140, min=40, max=800
-    )
-
-    bpy.types.Scene.kc_repeat_scope_bottom = IntProperty(
-        name="Abstand unten", default=24, min=0, max=2000
-    )
-
-    bpy.types.Scene.kc_repeat_scope_margin_x = IntProperty(
-        name="Rand X", default=12, min=0, max=2000
-    )
-
-    bpy.types.Scene.kc_repeat_scope_show_cursor = BoolProperty(
-        name="Cursor anzeigen", default=True
-    )
+    """Register UI components."""
 
     for cls in classes:
         bpy.utils.register_class(cls)
@@ -97,7 +70,8 @@ def register() -> None:
     # Erstregistrierung: Zustand initial synchronisieren
     try:
         enable_repeat_scope(
-            bool(bpy.context.scene.kc_show_repeat_scope), source="register"
+            bool(getattr(bpy.context.scene, "kc_show_repeat_scope", False)),
+            source="register",
         )
     except Exception:
         pass
@@ -117,17 +91,6 @@ def unregister() -> None:
             bpy.utils.unregister_class(cls)
         except Exception:
             pass
-
-    # Props entfernen (falls vorhanden)
-    for name in (
-        "kc_show_repeat_scope",
-        "kc_repeat_scope_height",
-        "kc_repeat_scope_bottom",
-        "kc_repeat_scope_margin_x",
-        "kc_repeat_scope_show_cursor",
-    ):
-        if hasattr(bpy.types.Scene, name):
-            delattr(bpy.types.Scene, name)
 
     # Handler abklemmen
     if _kc_load_post in bpy.app.handlers.load_post:


### PR DESCRIPTION
## Summary
- centralize Repeat-Scope scene properties in `Helper/properties.py`
- streamline `ui/__init__.py` to only handle panels and handlers
- widen layout property ranges and rename bottom offset property
- expose property helpers through `__all__` and add type hints

## Testing
- `blender -b --version` *(fails: command not found)*
- `python -m py_compile Helper/properties.py ui/__init__.py`
- `python -m pip install flake8` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c51b27c448832d84c0f9ea0bb13957