### PR TITLE
Add quantization levels for repeat scope overlay

### DIFF
--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -51,6 +51,7 @@ class KAISERLICH_PT_repeat_scope(bpy.types.Panel):
         col.prop(s, "kc_repeat_scope_bottom")
         col.prop(s, "kc_repeat_scope_margin_x")
         col.prop(s, "kc_repeat_scope_show_cursor")
+        col.prop(s, "kc_repeat_scope_levels", slider=True)
 
 
 # --- Registrierung ---

--- a/ui/repeat_scope.py
+++ b/ui/repeat_scope.py
@@ -3,11 +3,19 @@
 
 import bpy
 import gpu
+import math
 from gpu_extras.batch import batch_for_shader
+from ..Helper.properties import get_repeat_map  # zentrale Datenquelle
 
 # interner Handler
 _HDL = None
 
+def _series_from_map(scene: bpy.types.Scene) -> list[int]:
+    """Konvertiert die Repeat-Map (abs. Frames) in eine dichte Liste für fs..fe."""
+    fs, fe = int(scene.frame_start), int(scene.frame_end)
+    n = max(1, fe - fs + 1)
+    m = get_repeat_map(scene)
+    return [int(m.get(fs + i, 0)) for i in range(n)]
 
 def _draw_scope() -> None:
     ctx = bpy.context
@@ -45,26 +53,46 @@ def _draw_scope() -> None:
     sh.uniform_float("color", (1, 1, 1, 0.5))
     batch.draw(sh)
 
-    # Datenserie
-    fs, fe = s.frame_start, s.frame_end
-    seq = list(s.get("_kc_repeat_series", []))
+    # Datenserie (aus Map-API)
+    fs, fe = int(s.frame_start), int(s.frame_end)
+    seq = _series_from_map(s)
     n = max(1, fe - fs + 1)
-    if len(seq) != n:
-        seq = [0] * n
     vmax = max(1, max(seq) if seq else 1)
     width, height_px = x1 - x0, y1 - y0
 
+    # Quantisierung der Werte
+    levels = max(2, int(getattr(s, "kc_repeat_scope_levels", 36)))
+    denom = float(levels - 1)
+    norm = [(v / vmax) if vmax else 0.0 for v in seq]
+    qnorm = []
+    for v in norm:
+        vn = 0.0 if v < 0.0 else (1.0 if v > 1.0 else v)
+        step = math.floor(vn * levels)
+        if step >= levels:
+            step = levels - 1
+        qnorm.append(step / denom)
+
+    # Punkt-Liste aus quantisierten Werten
     pts = []
-    L = max(1, len(seq) - 1)
-    for i, v in enumerate(seq):
-        t = i / L
+    Ln = max(1, len(qnorm) - 1)
+    for i, qv in enumerate(qnorm):
+        t = i / Ln
         px = x0 + t * width
-        py = y0 + (v / vmax) * height_px
+        py = y0 + qv * height_px
         pts.append((px, py))
     batch = batch_for_shader(sh, "LINE_STRIP", {"pos": pts})
     sh.bind()
     sh.uniform_float("color", (0.8, 0.9, 1.0, 1.0))
     batch.draw(sh)
+
+    # horizontale Hilfslinien gemäß Quantisierung
+    tick_step = max(1, int(math.ceil(levels / 10)))
+    for k in range(0, levels, tick_step):
+        y = y0 + (k / denom) * height_px
+        batch = batch_for_shader(sh, "LINES", {"pos": [(x0, y), (x1, y)]})
+        sh.bind()
+        sh.uniform_float("color", (1, 1, 1, 0.15))
+        batch.draw(sh)
 
     # Cursor
     if show_cur:


### PR DESCRIPTION
## Summary
- integrate repeat scope overlay with centralized repeat map data
- trigger overlay redraw when the quantization level property changes
- keep repeat map in sync when recording counts

## Testing
- `python -m py_compile Helper/properties.py ui/__init__.py ui/repeat_scope.py`
- `flake8 Helper/properties.py ui/__init__.py ui/repeat_scope.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c58d6ad608832d971aa00087ba4286