### PR TITLE
Improve repeat scope bulk updates and logging

### DIFF
--- a/Helper/properties.py
+++ b/Helper/properties.py
@@ -80,14 +80,14 @@ def register():
         min=2, max=200,
         update=lambda self, ctx: _kc_request_overlay_redraw(ctx),
     )
-    
-    # Optional: Fade-Stufe (wird von jump_to_frame.py gelesen; Default 5)
-    Scene.kc_repeat_fade_step = IntProperty(
-        name="Fade-Stufe (Frames)",
-        description="In so vielen Frame-Schritten fällt der Wiederholungswert um 1",
-        default=5, min=1, max=120,
-        update=lambda self, ctx: _kc_request_overlay_redraw(ctx),
-    )
+
+    # Optional: Fade-Step als Scene-Property (wird in Helper.jump_to_frame gelesen)
+    if not hasattr(Scene, "kc_repeat_fade_step"):
+        Scene.kc_repeat_fade_step = IntProperty(
+            name="Fade-Step (Frames)",
+            description="Stufiger Abfall der Wiederholungen: alle N Frames −1",
+            default=5, min=1, max=50,
+        )
 
 
 def unregister():
@@ -202,75 +202,66 @@ def record_repeat_count(scene, frame, value) -> None:
 
 
 def record_repeat_bulk_map(scene, repeat_map: dict[int, int]) -> None:
-    """Schreibt mehrere (frame -> repeat) Einträge in einem Rutsch.
-    - Clamp auf Szenenrange
-    - Pro Frame wird der MAX aus bestehendem Wert und neuem Wert übernommen
-    - Aktualisiert Serie UND Map konsistent
-    - Triggert Redraw genau einmal
+    """Bulk-Merge einer {frame->count} Map in Scene-Serie/Map.
+    Merge-Regel: MAX(Current, New). Out-of-range Frames werden ignoriert.
+    Loggt Statistik und triggert Redraw.
     """
-    if not repeat_map:
-        return
     if scene is None:
         try:
             scene = bpy.context.scene
         except Exception:
             return
-    if scene is None:
+    if scene is None or not isinstance(repeat_map, dict) or not repeat_map:
+        print("[RepeatMap] bulk_merge skipped (no scene or empty map)")
         return
 
     fs, fe = int(scene.frame_start), int(scene.frame_end)
     n = max(0, fe - fs + 1)
     if n <= 0:
+        print("[RepeatMap] bulk_merge skipped (invalid frame range)")
         return
 
-    series = list(scene.get("_kc_repeat_series") or [])
-    if len(series) != n:
+    # Serie initialisieren / sanieren
+    series = scene.get("_kc_repeat_series")
+    if not isinstance(series, list) or len(series) != n:
         series = [0.0] * n
 
-    # Bestehende Map holen (robust) und kopieren
-    existing = get_repeat_map(scene)
-    updated = dict(existing)
+    # Aktuelle Map holen
+    cur_map = get_repeat_map(scene)
 
     changed = 0
-    written = 0
-    min_f = None
-    max_f = None
+    unchanged = 0
+    written_frames: list[int] = []
+    vmax = 0
 
-    for f_abs, v_in in repeat_map.items():
+    for k, v in repeat_map.items():
         try:
-            f = int(f_abs)
-            v = int(v_in)
+            f = int(k)
+            nv = max(0, int(v))
         except Exception:
             continue
-        if v <= 0:
-            continue
         if f < fs or f > fe:
-            continue  # außerhalb der Szene ignorieren
-
+            continue
         idx = f - fs
-        cur_series = float(series[idx]) if 0 <= idx < n else 0.0
-        cur_map = int(existing.get(f, 0))
-        new_v = float(max(cur_series, v, cur_map))
-        if new_v > cur_series:
-            series[idx] = new_v
+        cv = int(series[idx]) if 0 <= idx < n else 0
+        mv = int(cur_map.get(f, 0))
+        merged = max(cv, nv)
+        if merged != cv:
+            series[idx] = float(merged)
             changed += 1
-        # Map immer auf MAX heben
-        if int(new_v) > cur_map:
-            updated[f] = int(new_v)
         else:
-            # auch wenn Serie unverändert blieb, sicherstellen, dass Key existiert
-            updated.setdefault(f, int(new_v))
-
-        written += 1
-        min_f = f if min_f is None else min(min_f, f)
-        max_f = f if max_f is None else max(max_f, f)
+            unchanged += 1
+        if merged > mv:
+            cur_map[f] = merged
+        vmax = max(vmax, merged)
+        written_frames.append(f)
 
     scene["_kc_repeat_series"] = series
-    scene["_kc_repeat_map"] = updated
+    scene["_kc_repeat_map"] = cur_map
+    if written_frames:
+        fmin, fmax = min(written_frames), max(written_frames)
+        print(f"[RepeatMap] bulk_merge write_frames={len(written_frames)} "
+              f"range={fmin}..{fmax} changed={changed} unchanged={unchanged} vmax={vmax}")
+    else:
+        print("[RepeatMap] bulk_merge had no in-range frames")
     _tag_redraw()
-
-    # Logging
-    print(
-        f"[RepeatScope][WRITE] bulk frames={written}, changed_series={changed}, "
-        f"range={min_f}..{max_f}, levels={getattr(scene, 'kc_repeat_scope_levels', 36)}"
-    )


### PR DESCRIPTION
## Summary
- Make fade-step scene property optional and documented
- Add merge-aware record_repeat_bulk_map with detailed stats
- Enhance jump logging and provide bulk write fallback

## Testing
- `python -m py_compile Helper/properties.py Helper/jump_to_frame.py`
- `pip install flake8` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c618329704832db2438295d3263913