### PR TITLE
Add repeat scope overlay and refine jump logging

### DIFF
--- a/Helper/properties.py
+++ b/Helper/properties.py
@@ -260,6 +260,7 @@ def record_repeat_bulk_map(scene, repeat_map: dict[int, int]) -> None:
     scene["_kc_repeat_map"] = cur_map
     if written_frames:
         fmin, fmax = min(written_frames), max(written_frames)
+        # Log-Ausgabe: Anzahl, Range, Änderungen, Max-Wert der Merge-Session
         print(f"[RepeatMap] bulk_merge write_frames={len(written_frames)} "
               f"range={fmin}..{fmax} changed={changed} unchanged={unchanged} vmax={vmax}")
     else:


### PR DESCRIPTION
## Summary
- Introduce repeat scope overlay for visualizing repeat counts with quantized fade-out
- Improve jump-to-frame logging and radius handling for repeat diffusion
- Enhance repeat map merge logging

## Testing
- `python -m py_compile Helper/jump_to_frame.py Helper/properties.py ui/repeat_scope.py`
- `flake8 Helper/jump_to_frame.py Helper/properties.py ui/repeat_scope.py` *(fails: command not found)*
- `blender --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c61c79dec0832d8ec06eac74f8cc04