### PR TITLE
Improve repeat scope diagnostics and viewport handling

### DIFF
--- a/Helper/jump_to_frame.py
+++ b/Helper/jump_to_frame.py
@@ -236,6 +236,16 @@ def run_jump_to_frame(
 
     _kc_record_repeat_bulk_map(scn, expanded)
 
+    # Diagnose: Serie/NZ-Anteil nach Merge
+    try:
+        series = scn.get("_kc_repeat_series") or []
+        nz = sum(1 for v in series if v)
+        fs, fe = int(scn.frame_start), int(scn.frame_end)
+        n = max(0, fe - fs + 1)
+        print(f"[JumpTo][Series] len={len(series)} expected={n} nonzero={nz}")
+    except Exception:
+        pass
+
     # Debugging & Transparenz
     try:
         scn["last_jump_frame"] = int(target)  # rein informativ


### PR DESCRIPTION
## Summary
- make repeat-scope overlay always draw a frame and log when data appears
- log series stats after bulk merging repeat counts

## Testing
- `python -m py_compile ui/repeat_scope.py Helper/jump_to_frame.py`
- `flake8 ui/repeat_scope.py Helper/jump_to_frame.py` *(fails: command not found and install attempts blocked by proxy)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c6b0cda904832dae211b2f2701bee9