### PR TITLE
Refactor repeat scope overlay management

### DIFF
--- a/Operator/tracking_coordinator.py
+++ b/Operator/tracking_coordinator.py
@@ -10,7 +10,12 @@ from dataclasses import dataclass
 from typing import Any, Callable, Dict, Iterable, Optional, Tuple
 
 import bpy
-from ..Helper.properties import get_repeat_map
+from ..Helper.properties import (
+    get_repeat_map,
+    enable_repeat_scope,
+    set_repeat_scope_sticky,
+    redraw_clip_editors,
+)
 from ..Helper.jump_to_frame import run_jump_to_frame
 
 # ---------------------------------------------------------------------------
@@ -65,8 +70,15 @@ def solve_eval_mode():
 def _coord_jump(context, target_frame: int) -> bool:
     """Zentraler Jump-Wrapper mit Telemetrie und Scope-Abgleich."""
     scn = context.scene
+    # Sticky einschalten – kein Nebenpfad darf Overlay deaktivieren
+    enable_repeat_scope(scn, True, source="coordinator", sticky=True)
+    set_repeat_scope_sticky(scn, True, source="coordinator")
     scn["goto_frame"] = int(target_frame)
     res = run_jump_to_frame(context)
+    try:
+        redraw_clip_editors()
+    except Exception:
+        pass
     try:
         fmap = get_repeat_map(scn)
         cur = int(fmap.get(int(target_frame), 0))


### PR DESCRIPTION
## Summary
- add register/unregister and stable handler helpers for repeat scope overlay
- expose repeat scope controls and sticky state management in Helper.properties
- keep coordinator overlay active and force redraws on frame jumps

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c724713558832da38f25bc2cb3a1e9