### PR TITLE
Make repeat scope sticky and expose settings in UI

### DIFF
--- a/Helper/properties.py
+++ b/Helper/properties.py
@@ -152,6 +152,12 @@ def enable_repeat_scope(
         return
     if sticky is not None:
         scn[_STICKY_KEY] = bool(sticky)
+    # Sticky-Guard: Overlay darf nur durch explizite UI-Aktionen ausgeschaltet werden
+    if (not enabled) and scn.get(_STICKY_KEY):
+        # UI/Property-Update/Unregister dürfen deaktivieren; alles andere wird geblockt
+        if source not in {"ui", "prop_update", "unregister"}:
+            print(f"[KC] enable_repeat_scope(False) ignored due to sticky=True (source={source})")
+            return
     print(f"[KC] enable_repeat_scope({bool(enabled)}) source={source} sticky={scn.get(_STICKY_KEY)}")
     try:
         from ..ui import repeat_scope as _rs

--- a/Operator/tracking_coordinator.py
+++ b/Operator/tracking_coordinator.py
@@ -70,15 +70,15 @@ def solve_eval_mode():
 def _coord_jump(context, target_frame: int) -> bool:
     """Zentraler Jump-Wrapper mit Telemetrie und Scope-Abgleich."""
     scn = context.scene
-    # Sticky einschalten – kein Nebenpfad darf Overlay deaktivieren
-    enable_repeat_scope(scn, True, source="coordinator", sticky=True)
-    set_repeat_scope_sticky(scn, True, source="coordinator")
+    # Repeat-Scope sticky aktivieren – kein Nebenpfad darf das Overlay beim Zyklus abschalten
+    try:
+        enable_repeat_scope(scn, True, source="coordinator", sticky=True)
+        set_repeat_scope_sticky(scn, True, source="coordinator")
+        redraw_clip_editors()
+    except Exception as _e:
+        print(f"[COORD][Jump] sticky enable failed: {_e!r}")
     scn["goto_frame"] = int(target_frame)
     res = run_jump_to_frame(context)
-    try:
-        redraw_clip_editors()
-    except Exception:
-        pass
     try:
         fmap = get_repeat_map(scn)
         cur = int(fmap.get(int(target_frame), 0))

--- a/__init__.py
+++ b/__init__.py
@@ -168,6 +168,18 @@ class CLIP_PT_kaiserlich_panel(Panel):
             scene, "kaiserlich_solve_err_idx",
             rows=rows
         )
+        # Repeat Scope – direkt im Hauptpanel integriert
+        layout.separator()
+        scope = layout.box()
+        r = scope.row(align=True)
+        r.label(text="Repeat Scope")
+        r.prop(scene, "kc_show_repeat_scope", text="Overlay aktiv")
+        c = scope.column(align=True)
+        c.prop(scene, "kc_repeat_scope_height")
+        c.prop(scene, "kc_repeat_scope_bottom")
+        c.prop(scene, "kc_repeat_scope_margin_x")
+        c.prop(scene, "kc_repeat_scope_show_cursor")
+        c.prop(scene, "kc_repeat_scope_levels", slider=True)
         layout.separator()
         layout.operator("clip.kaiserlich_coordinator_launcher", text="Coordinator starten")
 # --- UIList für Solve-Log ---


### PR DESCRIPTION
## Summary
- Prevent repeat scope overlay from being disabled unless via explicit UI actions
- Ensure coordinator enables sticky repeat scope safely
- Integrate repeat scope options directly into the main Kaiserlich panel

## Testing
- `python -m py_compile Helper/properties.py Operator/tracking_coordinator.py __init__.py`
- `flake8 Helper/properties.py Operator/tracking_coordinator.py __init__.py` *(fails: command not found)*
- `python -m pycodestyle Helper/properties.py Operator/tracking_coordinator.py __init__.py` *(fails: No module named pycodestyle)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c7e31b1614832db9e79db3c4f47285