### PR TITLE
Respect sticky flag when checking repeat scope

### DIFF
--- a/Helper/properties.py
+++ b/Helper/properties.py
@@ -51,7 +51,7 @@ def _kc_request_overlay_redraw(context):
 def _kc_update_repeat_scope(self, context):
     try:
         enable = bool(getattr(self, "kc_show_repeat_scope", False))
-        enable_repeat_scope(context.scene, enable)
+        enable_repeat_scope(context.scene, enable, source="prop_update")
     except Exception as e:  # noqa: BLE001
         # Beim Laden/Prefs nicht hart fehlschlagen.
         print("[RepeatScope] update skipped:", e)
@@ -132,7 +132,13 @@ def unregister():
 
 
 def is_repeat_scope_enabled(scn: bpy.types.Scene) -> bool:
-    return bool(getattr(scn, "kc_show_repeat_scope", False))
+    """Overlay gilt als aktiv, wenn UI-Flag ODER Sticky gesetzt ist."""
+    try:
+        ui_flag = bool(getattr(scn, "kc_show_repeat_scope", False))
+    except Exception:
+        ui_flag = False
+    sticky = bool(scn.get(_STICKY_KEY, False))
+    return ui_flag or sticky
 
 
 def set_repeat_scope_sticky(scn: bpy.types.Scene, sticky: bool, *, source: str = "api") -> None:


### PR DESCRIPTION
## Summary
- ensure update callback marks call source when toggling repeat scope
- treat repeat scope as enabled when sticky flag is set

## Testing
- `python -m py_compile Helper/properties.py`
- `flake8 Helper/properties.py` *(fails: command not found)*
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*

------
https://chatgpt.com/codex/tasks/task_e_68c809a88c34832d92f162be50f8e9ce