### PR TITLE
Centralize repeat counting and fade ring logic

### DIFF
--- a/Helper/properties.py
+++ b/Helper/properties.py
@@ -10,6 +10,7 @@ __all__ = (
     "unregister",
     "record_repeat_count",
     "record_repeat_bulk_map",
+    "get_repeat_value",
     "get_repeat_map",
     "enable_repeat_scope",
     "set_repeat_scope_sticky",
@@ -182,6 +183,25 @@ def get_repeat_map(scene=None) -> dict[int, int]:
         return {int(k): int(v) for k, v in m.items()}
     except Exception:
         return {}
+
+
+def get_repeat_value(scene, frame: int) -> int:
+    """Liest den Repeat-Wert (int) aus der Series-SSOT."""
+    if scene is None:
+        try:
+            scene = bpy.context.scene
+        except Exception:
+            return 0
+    fs = int(scene.frame_start)
+    fe = int(scene.frame_end)
+    n = max(0, fe - fs + 1)
+    series = scene.get("_kc_repeat_series")
+    if not isinstance(series, list) or len(series) != n:
+        return 0
+    idx = int(frame) - fs
+    if 0 <= idx < n:
+        return int(series[idx])
+    return 0
 
 
 def record_repeat_count(scene, frame, value) -> None:

--- a/Helper/repeat_core.py
+++ b/Helper/repeat_core.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+from typing import Dict
+import bpy
+
+# Zentrale Defaults
+FADE_STEP_DEFAULT = 5
+
+
+def get_fade_step(scene: bpy.types.Scene) -> int:
+    try:
+        val = int(getattr(scene, "kc_repeat_fade_step", FADE_STEP_DEFAULT))
+        return max(1, val)
+    except Exception:
+        return FADE_STEP_DEFAULT
+
+
+def get_series(scene: bpy.types.Scene) -> list[float]:
+    fs = int(scene.frame_start)
+    fe = int(scene.frame_end)
+    n = max(0, fe - fs + 1)
+    series = scene.get("_kc_repeat_series")
+    if not isinstance(series, list) or len(series) != n:
+        return [0.0] * n
+    return series
+
+
+def get_value(scene: bpy.types.Scene, frame: int) -> int:
+    fs = int(scene.frame_start)
+    ser = get_series(scene)
+    idx = int(frame) - fs
+    return int(ser[idx]) if 0 <= idx < len(ser) else 0
+
+
+def expand_rings(center_f: int, k: int, fs: int, fe: int, step: int) -> Dict[int, int]:
+    """
+    Exakte 5er-Ringlogik:
+      Ring 0 : [f-step .. f+step] → k
+      Ring m≥1:
+        L: [f-step*(m+1) .. f-(step*m+1)] → k-m
+        R: [f+(step*m+1) .. f+step*(m+1)] → k-m
+    Clamping auf [fs..fe], pro Frame MAX-Merge.
+    """
+    out: Dict[int, int] = {}
+    if k <= 0:
+        return out
+    # Ring 0
+    s0 = max(fs, center_f - step)
+    e0 = min(fe, center_f + step)
+    for i in range(s0, e0 + 1):
+        if k > out.get(i, 0):
+            out[i] = k
+    # Ringe 1..k-1
+    for m in range(1, k):
+        val = k - m
+        L1 = max(fs, center_f - step * (m + 1))
+        L2 = max(fs, center_f - (step * m + 1))
+        if L1 <= L2:
+            for i in range(L1, L2 + 1):
+                if val > out.get(i, 0):
+                    out[i] = val
+        R1 = min(fe, center_f + (step * m + 1))
+        R2 = min(fe, center_f + step * (m + 1))
+        if R1 <= R2:
+            for i in range(R1, R2 + 1):
+                if val > out.get(i, 0):
+                    out[i] = val
+    return out
+


### PR DESCRIPTION
## Summary
- Move ring expansion and fade step helpers to new `repeat_core` module
- Provide `get_repeat_value` and sync JSON state from SSOT
- Delegate jump handling to `orchestrate_on_jump` for consistent repeat counts

## Testing
- `python -m py_compile Helper/repeat_core.py Helper/properties.py Helper/tracking_state.py Helper/jump_to_frame.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c8283e7770832db9b7119ffd203d93