### PR TITLE
Refactor repeat state handling to use central orchestration

### DIFF
--- a/Helper/jump_to_frame.py
+++ b/Helper/jump_to_frame.py
@@ -251,26 +251,26 @@ def run_jump_to_frame(
     else:
         scn.frame_current = target
 
-    # Einheitlicher Zähler & Ringe per Orchestrator aktualisieren (SSOT).
+    # Einheitlicher Zähler & Ringe zentral aktualisieren (SSOT)
     try:
         from .tracking_state import orchestrate_on_jump
         orchestrate_on_jump(context, int(target))
-    except Exception as e:
-        _dbg(scn, f"[JumpTo][WARN] orchestrate_on_jump failed: {e!r}")
-    # Logging aus SSOT lesen (konsistent zu Motion-Model)
+    except Exception as e:  # noqa: BLE001
+        print(f"[JumpTo][WARN] orchestrate_on_jump failed: {e!r}")
+
+    # Logging NACH SSOT-Update: konsistenten Wert lesen
     repeat_count = 0
     try:
         from .properties import get_repeat_value
+        step = int(getattr(scn, "kc_repeat_fade_step", 5))
         k_used = int(get_repeat_value(scn, int(target)))
         repeat_count = k_used
-        step = _fade_step_frames()
-        _dbg(scn, f"[JumpTo][Count] frame={int(target)} repeat={k_used} (SSOT)")
-        # Optional: Bounds grob loggen (clamped außen ±k*step)
+        print(f"[JumpTo][Count] frame={int(target)} repeat={k_used} (SSOT)")
         fs, fe = int(scn.frame_start), int(scn.frame_end)
         left = max(fs, int(target) - k_used * step)
         right = min(fe, int(target) + k_used * step)
-        _dbg(scn, f"[JumpTo][Spread] rings={k_used} step={step} outer_radius={k_used*step} bounds≈{left}..{right}")
-    except Exception:
+        print(f"[JumpTo][Spread] rings={k_used} step={step} outer_radius={k_used*step} bounds≈{left}..{right}")
+    except Exception:  # noqa: BLE001
         pass
 
     # Debugging & Transparenz

--- a/Helper/properties.py
+++ b/Helper/properties.py
@@ -238,7 +238,7 @@ def record_repeat_count(scene, frame, value) -> None:
         _kc_request_overlay_redraw(bpy.context)
 
 
-def record_repeat_bulk_map(scene, repeat_map: Dict[int, int]) -> None:
+def record_repeat_bulk_map(scene, repeat_map: Dict[int, int], *, source: str = "bulk") -> None:
     """Schreibt eine Menge Frame→Wert in einem Rutsch (MAX-Merge) mit Diagnose-Logs."""
     if scene is None:
         try:
@@ -274,7 +274,7 @@ def record_repeat_bulk_map(scene, repeat_map: Dict[int, int]) -> None:
             min_f = f if min_f is None else min(min_f, f)
             max_f = f if max_f is None else max(max_f, f)
             if _dbg_enabled(scene):
-                print(f"[RepeatMap][merge] frame={f} {int(cur)}→{int(v)}")
+                print(f"[RepeatMap][merge] frame={f} {int(cur)}→{int(v)} source={source}")
 
     scene["_kc_repeat_series"] = series
     # Map parallel pflegen (nur non-zero)
@@ -286,6 +286,6 @@ def record_repeat_bulk_map(scene, repeat_map: Dict[int, int]) -> None:
     scene["_kc_repeat_map"] = out_map
     if changed:
         nz = sum(1 for v in series if v)
-        _dbg(scene, f"[RepeatMap][bulk] changed={changed} range={min_f}..{max_f} nonzero={nz} series_len={len(series)}")
+        _dbg(scene, f"[RepeatMap][bulk] changed={changed} range={min_f}..{max_f} nonzero={nz} series_len={len(series)} source={source}")
         _kc_request_overlay_redraw(bpy.context)
 


### PR DESCRIPTION
## Summary
- let jump_to_frame delegate repeat counting to tracking_state and log SSOT values
- avoid redundant orchestration in tracking coordinator
- log repeat bulk updates only when values increase and include source

## Testing
- `python -m py_compile Helper/jump_to_frame.py Operator/tracking_coordinator.py Helper/properties.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c8330e0d04832dbf7dbec66aa8335e