### PR TITLE
Refine repeat orchestration to use SSOT utilities

### DIFF
--- a/Helper/jump_to_frame.py
+++ b/Helper/jump_to_frame.py
@@ -184,7 +184,7 @@ def run_jump_to_frame(
     ensure_clip: bool = True,
     ensure_tracking_mode: bool = True,
     use_ui_override: bool = True,
-    repeat_map: Optional[Dict[int, int]] = None,  # (Kompat): wird nicht mehr genutzt
+    repeat_map: Optional[Dict[int, int]] = None,  # (Kompat) wird nicht mehr genutzt
 ) -> Dict[str, Any]:
     """
     Setzt den Playhead deterministisch auf 'frame' (oder scene['goto_frame']).
@@ -256,20 +256,20 @@ def run_jump_to_frame(
         from .tracking_state import orchestrate_on_jump
         orchestrate_on_jump(context, int(target))
     except Exception as e:  # noqa: BLE001
-        print(f"[JumpTo][WARN] orchestrate_on_jump failed: {e!r}")
+        _dbg(scn, f"[JumpTo][WARN] orchestrate_on_jump failed: {e!r}")
 
     # Logging NACH SSOT-Update: konsistenten Wert lesen
     repeat_count = 0
     try:
         from .properties import get_repeat_value
-        step = int(getattr(scn, "kc_repeat_fade_step", 5))
+        step = _fade_step_frames()
         k_used = int(get_repeat_value(scn, int(target)))
         repeat_count = k_used
-        print(f"[JumpTo][Count] frame={int(target)} repeat={k_used} (SSOT)")
+        _dbg(scn, f"[JumpTo][Count] frame={int(target)} repeat={k_used} (SSOT)")
         fs, fe = int(scn.frame_start), int(scn.frame_end)
         left = max(fs, int(target) - k_used * step)
         right = min(fe, int(target) + k_used * step)
-        print(f"[JumpTo][Spread] rings={k_used} step={step} outer_radius={k_used*step} bounds≈{left}..{right}")
+        _dbg(scn, f"[JumpTo][Spread] rings={k_used} step={step} outer_radius={k_used*step} bounds≈{left}..{right}")
     except Exception:  # noqa: BLE001
         pass
 

--- a/Helper/repeat_core.py
+++ b/Helper/repeat_core.py
@@ -7,28 +7,12 @@ FADE_STEP_DEFAULT = 5
 
 
 def get_fade_step(scene: bpy.types.Scene) -> int:
+    """Liest den Fade-Step (Ringbreite) aus der Scene-Property oder nutzt Default."""
     try:
         val = int(getattr(scene, "kc_repeat_fade_step", FADE_STEP_DEFAULT))
         return max(1, val)
     except Exception:
         return FADE_STEP_DEFAULT
-
-
-def get_series(scene: bpy.types.Scene) -> list[float]:
-    fs = int(scene.frame_start)
-    fe = int(scene.frame_end)
-    n = max(0, fe - fs + 1)
-    series = scene.get("_kc_repeat_series")
-    if not isinstance(series, list) or len(series) != n:
-        return [0.0] * n
-    return series
-
-
-def get_value(scene: bpy.types.Scene, frame: int) -> int:
-    fs = int(scene.frame_start)
-    ser = get_series(scene)
-    idx = int(frame) - fs
-    return int(ser[idx]) if 0 <= idx < len(ser) else 0
 
 
 def expand_rings(center_f: int, k: int, fs: int, fe: int, step: int) -> Dict[int, int]:

--- a/Helper/tracking_state.py
+++ b/Helper/tracking_state.py
@@ -217,12 +217,12 @@ def orchestrate_on_jump(context: bpy.types.Context, frame: int) -> None:
     scene = context.scene
     # 1) aktuellen Zähler aus SSOT lesen
     try:
-        from .repeat_core import get_value, get_fade_step, expand_rings
-        from .properties import record_repeat_bulk_map
+        from .repeat_core import get_fade_step, expand_rings
+        from .properties import get_repeat_value, record_repeat_bulk_map
     except Exception:
         # Fallback: sicherstellen, dass kein Crash entsteht
         return
-    current = int(get_value(scene, int(frame)))
+    current = int(get_repeat_value(scene, int(frame)))
     k = 1 if current <= 0 else current + 1
     # ABORT-Guard
     if k >= ABORT_AT:
@@ -237,7 +237,7 @@ def orchestrate_on_jump(context: bpy.types.Context, frame: int) -> None:
     fs, fe = int(scene.frame_start), int(scene.frame_end)
     step = get_fade_step(scene)
     mapping = expand_rings(int(frame), int(k), fs, fe, int(step))
-    record_repeat_bulk_map(scene, mapping)
+    record_repeat_bulk_map(scene, mapping, source="orchestrate")
     # 4) JSON-State spiegeln & Motion-Model setzen
     state = _get_state(context)
     _sync_json_count(state, int(frame), int(k))


### PR DESCRIPTION
## Summary
- centralize repeat-series handling via a reusable _ensure_series helper and expose get_repeat_value
- simplify repeat_core to provide fade-step accessor plus ring expansion utilities only
- ensure orchestrate_on_jump drives repeat updates and logging through the SSOT helpers
- adjust jump_to_frame logging to read SSOT state and avoid duplicate orchestration

## Testing
- python -m compileall Helper/repeat_core.py Helper/properties.py Helper/tracking_state.py Helper/jump_to_frame.py

------
https://chatgpt.com/codex/tasks/task_e_68c83aa7439c832da32f1536516a6e1e