### PR TITLE
Reset detect parameters between cycles

### DIFF
--- a/Helper/marker_helper_main.py
+++ b/Helper/marker_helper_main.py
@@ -1,4 +1,5 @@
 # Helper/marker_helper_main.py
+from __future__ import annotations
 import bpy
 from typing import Tuple, Dict, Any
 
@@ -68,6 +69,16 @@ def marker_helper_main(context) -> Tuple[bool, int, Dict[str, Any]]:
     scn["min_distance_base"] = int(min_dist)
     scn["clip_width"]     = int(width)
     scn["clip_height"]    = int(height)
+
+    # NEU: Detect-Startwerte deterministisch initialisieren.
+    # Damit wird jeder Cycle garantiert mit den Baselines (aus Clipgröße) gefahren –
+    # und NICHT mit ggf. veralteten tco_* Werten aus einer früheren Session.
+    try:
+        scn["tco_detect_min_distance"] = float(min_dist)
+        scn["kc_min_distance_effective"] = int(min_dist)
+        scn["tco_detect_margin"] = int(margin)
+    except Exception:
+        pass
     # Telemetrie (Konsole): Baselines ausgeben
     try:
         clip_name = getattr(clip, "name", "None")

--- a/Helper/reset_state.py
+++ b/Helper/reset_state.py
@@ -220,6 +220,32 @@ def reset_for_new_cycle(context: bpy.types.Context, *, clear_solve_log: bool = F
         except Exception:
             pass
 
+    # 2d) WICHTIG: Detect-/Stufungs-IDs purgen (keine kc_* → wurden bisher NICHT entfernt)
+    # Dadurch starten wir jeden Zyklus ohne Altlasten (z. B. tco_detect_min_distance=120).
+    try:
+        stale_keys = (
+            "tco_detect_min_distance",
+            "tco_detect_thr",
+            "tco_last_count_for_formulas",
+            "tco_last_detect_new_count",
+            "tco_detect_margin",
+            "tco_count_for_formulas",
+        )
+        for k in stale_keys:
+            if k in scene.keys():
+                try:
+                    del scene[k]
+                except Exception:
+                    pass
+        # Falls vorhanden, ebenfalls zurücksetzen/entfernen:
+        if "kc_min_distance_effective" in scene.keys():
+            try:
+                del scene["kc_min_distance_effective"]
+            except Exception:
+                pass
+    except Exception:
+        pass
+
     # Optional: UI-Refresh, damit Panels frische Werte anzeigen
     try:
         for area in context.window.screen.areas:

--- a/Operator/tracking_coordinator.py
+++ b/Operator/tracking_coordinator.py
@@ -1220,7 +1220,17 @@ class CLIP_OT_tracking_coordinator(bpy.types.Operator):
                 clip = _resolve_clip(context)
                 post_ptrs = {int(t.as_pointer()) for t in getattr(clip.tracking, "tracks", [])}
                 base = self.pre_ptrs or set()
-                print(f"[COORD] Post Distanze: new_after={len(post_ptrs - base)}")
+                # Korrektur: Das hier passiert direkt NACH dem Detect-Call.
+                print(f"[COORD] Post Detect: new_after={len(post_ptrs - base)}")
+            except Exception:
+                pass
+            try:
+                src = "rd"
+                if int(rd.get("min_distance_px", 0) or 0) <= 0:
+                    src = "tco|base"
+                print(f"[COORD] Detect result: frame={self.target_frame} "
+                      f"new={new_cnt} thr->{float(self.detection_threshold):.6f} "
+                      f"min_distance->{int(self.last_detect_min_distance)} src={src}")
             except Exception:
                 pass
             self.report({'INFO'}, f"DETECT @f{self.target_frame}: new={new_cnt}, thr={self.detection_threshold}")


### PR DESCRIPTION
## Summary
- purge detect-related ID properties during runtime reset to avoid stale configuration
- seed detect baseline margin and min distance when marker helper initializes the scene
- reuse the last detect margin/min-distance in multi-pass runs and extend coordinator logging

## Testing
- python -m compileall Helper/reset_state.py Helper/marker_helper_main.py Helper/multi.py Operator/tracking_coordinator.py

------
https://chatgpt.com/codex/tasks/task_e_68c8946753f8832db7bcac5873e9d8d1