### PR TITLE
Clamp solve frame range and skip zero solve errors

### DIFF
--- a/Helper/solve_camera.py
+++ b/Helper/solve_camera.py
@@ -24,7 +24,7 @@ def _clip_end_for_scene(clip: bpy.types.MovieClip, scn: bpy.types.Scene) -> int:
     return min(int(getattr(scn, "frame_end", 1)), int(c_end))
 
 def _clamp_view_to_range(context) -> None:
-    """Clamp Scene/Viewer frames auf Clip/Szenen-Ende (prä-Solve)."""
+    """Clamp Scene/Viewer auf Clip/Szenen-Ende (prä-Solve)."""
     scn  = context.scene
     clip = _resolve_clip(context)
     if not clip:
@@ -33,7 +33,6 @@ def _clamp_view_to_range(context) -> None:
     if int(scn.frame_current) > end:
         print(f"[SolveGuard] clamp scene.frame_current {int(scn.frame_current)} → {end}")
         scn.frame_current = end
-    # UI-Viewer (falls vorhanden) synchronisieren
     sp = getattr(context, "space_data", None)
     if sp and getattr(sp, "type", None) == 'CLIP_EDITOR':
         try:
@@ -43,7 +42,7 @@ def _clamp_view_to_range(context) -> None:
             pass
 
 def _clamp_to_solved_range_post(context) -> None:
-    """Nach dem Solve: auf max tatsächlich gelösten Kameraframe clampen (post-Solve)."""
+    """Nach Solve: auf max tatsächlich gelösten Kameraframe clampen."""
     scn  = context.scene
     clip = _resolve_clip(context)
     if not clip:
@@ -94,7 +93,7 @@ def solve_camera_only(context):
     """
     area, region, space = _find_clip_window(context)
     try:
-        # PRE: out-of-range Frames hart abfangen (verhindert "No camera for frame 301")
+        # PRE: out-of-range Frames hart abfangen (eliminiert "No camera for frame 301")
         _clamp_view_to_range(context)
         if area and region and space:
             with context.temp_override(area=area, region=region, space_data=space):

--- a/Operator/tracking_coordinator.py
+++ b/Operator/tracking_coordinator.py
@@ -428,8 +428,9 @@ def solve_camera_only(context, *args, **kwargs):
                 or _SOLVE_ERR_DEFAULT_THR
             )
             _thr_src = "scene.solve_error_threshold"
-        if ae is None:
-            print("[SolveCheck] Keine auswertbare Reconstruction – Check übersprungen.")
+        # 0.0 ist ebenfalls „invalid“ (Reconstruction noch nicht konsistent)
+        if ae is None or float(ae) <= 0.0:
+            print("[SolveCheck] Keine auswertbare Reconstruction (ae<=0) – Check übersprungen.")
             return res
 
         print(f"[SolveCheck] avg_error={ae:.6f} thr={thr:.6f} src={_thr_src}")


### PR DESCRIPTION
## Summary
- align the solve helper guard messaging with the new pre/post frame clamping flow
- skip solve quality evaluation when the reported average error is still zero to avoid racing on incomplete reconstructions

## Testing
- python -m compileall Helper/solve_camera.py Operator/tracking_coordinator.py

------
https://chatgpt.com/codex/tasks/task_e_68c94d314a50832db87e516899c13a32