### PR TITLE
Adjust reduce error tracks batch sizing

### DIFF
--- a/Operator/tracking_coordinator.py
+++ b/Operator/tracking_coordinator.py
@@ -471,8 +471,14 @@ def solve_camera_only(context, *args, **kwargs):
         attempts = int(scene.get("kc_solve_attempts", 0) or 0)
         if ae > thr and attempts < 5:
             scene["kc_solve_attempts"] = attempts + 1
-            print(f"[SolveCheck] Über Schwellwert → reduce_error_tracks() Pass #{attempts+1}")
-            run_reduce_error_tracks(context)
+            # --- Empfohlener Ablauf: n_delete = max(10, avg_projection_error / error_track)
+            err_track = float(getattr(scene, "error_track", 2.0) or 2.0)
+            n_delete = max(10, int(ae / max(1e-6, err_track)))
+            print(
+                f"[SolveCheck] Über Schwellwert → reduce_error_tracks(max_to_delete={n_delete}) "
+                f"(Formel: max(10, {ae:.3f}/{err_track:.3f})) Pass #{attempts+1}"
+            )
+            run_reduce_error_tracks(context, max_to_delete=int(n_delete))
             try:
                 reset_for_new_cycle(context, clear_solve_log=False)
             except Exception:


### PR DESCRIPTION
## Summary
- compute a recommended max_to_delete value for auto reduce passes based on the current average reprojection error and the scene error_track setting
- call run_reduce_error_tracks with the computed limit and extend the diagnostic log message to include the formula

## Testing
- python -m py_compile Operator/tracking_coordinator.py

------
https://chatgpt.com/codex/tasks/task_e_68c9e3e5a7c4832daf69975d0822be57