### PR TITLE
Add post-solve safeguards and clamp jumps

### DIFF
--- a/Helper/reduce_error_tracks.py
+++ b/Helper/reduce_error_tracks.py
@@ -398,3 +398,22 @@ def get_avg_reprojection_error(context: bpy.types.Context) -> Optional[float]:
     except Exception:
         pass
     return None
+
+
+# ---------------------------------------------------------------------------
+# Backcompat-Shim: alte Call-Sites casten das Ergebnis zu int(...) und
+# erwarteten früher eine Integer-Anzahl gelöschter Tracks. Die neue API gibt
+# ein Dict zurück – diese Wrapper-Funktion behält die neue Logik bei, liefert
+# aber für "int(reduce_error_tracks(...))" wieder eine Zahl.
+# ---------------------------------------------------------------------------
+def reduce_error_tracks(context: bpy.types.Context, *args, **kwargs) -> int:
+    """
+    Rückgabewert: Anzahl gelöschter/entfernter Tracks (int).
+    Nutzt intern run_reduce_error_tracks(...) und extrahiert "deleted".
+    """
+    try:
+        res = run_reduce_error_tracks(context, *args, **kwargs)
+        return int(res.get("deleted", 0))
+    except Exception as ex:
+        print(f"[SolveCheck] reduce_error_tracks unexpected failure: {ex!r}")
+        return 0


### PR DESCRIPTION
## Summary
- add a backcompat int-returning wrapper for reduce_error_tracks
- expose trigger_post_solve_quality_check and connect the coordinator hook with a default policy
- clamp jump_to_frame targets against scene and clip bounds while reusing run_jump_to_frame

## Testing
- python -m compileall Helper/reduce_error_tracks.py Helper/solve_eval.py Helper/jump_to_frame.py Operator/tracking_coordinator.py

------
https://chatgpt.com/codex/tasks/task_e_68caad142a14832dbe4351b5dc3aeb6d