### PR TITLE
Add coordinator version marker and default_min guard

### DIFF
--- a/Operator/tracking_coordinator.py
+++ b/Operator/tracking_coordinator.py
@@ -14,6 +14,12 @@ from typing import Optional
 
 import bpy
 
+# --- Legacy guard & version marker ------------------------------------------
+# Einige lokale ZIP-Builds referenzieren in Altpfaden noch `default_min`.
+# Der Guard neutralisiert das sicher (None == Auto-Logik in den Helpern).
+default_min: None | int = None
+COORD_VERSION = "no-solve-guard-2025-09-18"
+
 # --- Helper-Imports (robust) -------------------------------------------------
 try:
     from ..Helper.find_low_marker_frame import run_find_low_marker_frame
@@ -72,6 +78,7 @@ def _safe_count(context: bpy.types.Context) -> Optional[int]:
 # --- Orchestrierung ----------------------------------------------------------
 def _orchestrate_once(context: bpy.types.Context) -> None:
     """Tracking-&-Cleanup Sequenz ohne Solve."""
+    _log(f"[CoordinatorFile] {__file__} v={COORD_VERSION}")
     clip = getattr(context, "edit_movieclip", None) or getattr(getattr(context, "space_data", None), "clip", None)
     if clip is None:
         raise RuntimeError("Kein aktiver Clip im CLIP_EDITOR.")


### PR DESCRIPTION
## Summary
- add a default_min legacy guard for older ZIP builds and record a coordinator version marker
- log the coordinator file path and version during orchestration startup

## Testing
- python -m compileall Operator/tracking_coordinator.py

------
https://chatgpt.com/codex/tasks/task_e_68cbd9a5cee4832d865d290be1957271