### PR TITLE
Add global default_min legacy guard

### DIFF
--- a/Operator/tracking_coordinator.py
+++ b/Operator/tracking_coordinator.py
@@ -14,6 +14,17 @@ from typing import Optional
 
 import bpy
 
+# --- Global Legacy Guard -----------------------------------------------------
+# In manchen lokalen Ständen referenzieren Altpfade noch die Variable `default_min`.
+# Wir registrieren sie einmalig in den Builtins, damit *jede* streunende Referenz
+# (auch in importierten Modulen) auf None (Auto-Logik) fällt.
+try:
+    import builtins as _bi
+    if not hasattr(_bi, "default_min"):
+        setattr(_bi, "default_min", None)
+except Exception:
+    pass
+
 # --- Legacy guard & version marker ------------------------------------------
 # (Verhindert NameError, falls im lokalen Stand noch `default_min` referenziert wird)
 default_min = None


### PR DESCRIPTION
## Summary
- register a default_min attribute in Python builtins so lingering legacy references resolve safely

## Testing
- python -m compileall Operator/tracking_coordinator.py

------
https://chatgpt.com/codex/tasks/task_e_68cbdc688b78832d98ab4135b0e4b7c4